### PR TITLE
fix(app): make fresh sessions usable from the app

### DIFF
--- a/internal/adapter/claudecode/hook.go
+++ b/internal/adapter/claudecode/hook.go
@@ -242,6 +242,10 @@ func ProcessHook(reg *registry.Registry, ev HookEvent) (session.Session, bool) {
 	// dock needs an interaction); replace forces it over anything still pending.
 	// resume (--resume/--continue//resume) reopens an existing conversation waiting
 	// on the user, so it surfaces the same compose prompt.
+	//
+	// A plain startup surfaces the idle interaction so clients can start the
+	// conversation, but keeps the status idle — awaiting-input would fire a push
+	// on every launch.
 	switch {
 	case event == "SessionEnd" && p.Reason == "clear":
 		status = session.StatusIdle
@@ -249,6 +253,8 @@ func ProcessHook(reg *registry.Registry, ev HookEvent) (session.Session, bool) {
 		status = session.StatusAwaitingInput
 		ix = &session.Interaction{Kind: session.InteractionIdle}
 		replace = true
+	case event == "SessionStart" && p.Source == "startup":
+		ix = &session.Interaction{Kind: session.InteractionIdle}
 	}
 
 	// Refresh the transcript digest only on summary-relevant events.

--- a/internal/adapter/claudecode/hook_test.go
+++ b/internal/adapter/claudecode/hook_test.go
@@ -132,12 +132,13 @@ func TestProcessHookSessionStartStartupIsIdle(t *testing.T) {
 	if !alive {
 		t.Fatal("SessionStart(source=startup) must keep the session")
 	}
-	// A genuinely fresh session is idle with no pending prompt — only /clear surfaces one.
+	// Startup surfaces the idle compose prompt but keeps the status idle (not
+	// awaiting-input) so it doesn't fire a push on every launch.
 	if got.Status != session.StatusIdle {
 		t.Fatalf("want idle after startup, got %q", got.Status)
 	}
-	if got.Interaction != nil {
-		t.Fatalf("startup must not synthesize a respond prompt, got %+v", got.Interaction)
+	if got.Interaction == nil || got.Interaction.Kind != session.InteractionIdle {
+		t.Fatalf("startup must surface the compose prompt, got %+v", got.Interaction)
 	}
 }
 

--- a/internal/adapter/claudecode/parser/classify_noise.go
+++ b/internal/adapter/claudecode/parser/classify_noise.go
@@ -14,6 +14,10 @@ var noiseEntryTypes = map[string]bool{
 	"file-history-snapshot": true,
 	"queue-operation":       true,
 	"progress":              true,
+	// Session metadata sidecars with no visible content; without dropping them
+	// they render as an empty "(no output)" chunk.
+	"last-prompt": true,
+	"mode":        true,
 }
 
 // hardNoiseTags are XML tags whose sole presence means the entire message is noise.

--- a/internal/adapter/claudecode/parser/classify_test.go
+++ b/internal/adapter/claudecode/parser/classify_test.go
@@ -163,6 +163,17 @@ func TestClassify_OtherSystemStillNoise(t *testing.T) {
 	}
 }
 
+func TestClassify_MetaSidecarsDropped(t *testing.T) {
+	// Startup/resume metadata sidecars carry no visible content and must not fold
+	// into an empty "(no output)" chunk.
+	for _, typ := range []string{"last-prompt", "mode"} {
+		e := parser.Entry{Type: typ, UUID: "m1", Timestamp: "2025-01-15T10:00:00Z"}
+		if _, ok := parser.Classify(e); ok {
+			t.Fatalf("%q entry should be dropped as noise", typ)
+		}
+	}
+}
+
 func TestClassify_SidechainFiltered(t *testing.T) {
 	e := makeEntry("assistant", "sc1", "2025-01-15T10:00:00Z",
 		json.RawMessage(`[{"type":"text","text":"sidechain"}]`),

--- a/internal/adapter/claudecode/parser/session.go
+++ b/internal/adapter/claudecode/parser/session.go
@@ -74,6 +74,12 @@ func ReadSubagentSession(path string) ([]Chunk, error) {
 func ReadSessionIncremental(path string, offset int64, clearSidechain bool) ([]ClassifiedMsg, map[string]string, int64, error) {
 	f, err := os.Open(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// A not-yet-created transcript (freshly launched session, subscribed
+			// before Claude writes its first line) reads as empty, not an error, so
+			// the subscription's poller can pick up content once the file appears.
+			return nil, nil, offset, nil
+		}
 		return nil, nil, offset, err
 	}
 	defer f.Close()

--- a/internal/adapter/claudecode/parser/session_test.go
+++ b/internal/adapter/claudecode/parser/session_test.go
@@ -39,6 +39,20 @@ func TestProjectDirForPath(t *testing.T) {
 	}
 }
 
+func TestReadSessionIncremental_MissingFileIsEmpty(t *testing.T) {
+	// A freshly launched session may be subscribed before Claude writes its first
+	// line. A missing file must read as empty (no error) so the subscription's
+	// poller can start and pick up content once the file appears.
+	path := filepath.Join(t.TempDir(), "not-created-yet.jsonl")
+	msgs, links, off, err := parser.ReadSessionIncremental(path, 0, false)
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if len(msgs) != 0 || len(links) != 0 || off != 0 {
+		t.Fatalf("missing file should read empty at offset 0, got msgs=%d links=%d off=%d", len(msgs), len(links), off)
+	}
+}
+
 func TestReadSession_ValidFile(t *testing.T) {
 	path := filepath.Join("testdata", "minimal.jsonl")
 	chunks, err := parser.ReadSession(path)

--- a/internal/registry/reconcile_sessions_test.go
+++ b/internal/registry/reconcile_sessions_test.go
@@ -40,6 +40,38 @@ func TestReconcileSessionsAddsTmuxAndPrunes(t *testing.T) {
 	}
 }
 
+// A freshly opened pane-bearing session has no transcript yet, so discovery
+// carries no StatusHint. It must still land as idle with an idle Interaction so
+// clients show the compose to send the first prompt; a paneless one (can't be
+// typed into) stays discovered.
+func TestReconcileSessionsFreshPaneDefaultsIdle(t *testing.T) {
+	r := New()
+	r.ReconcileSessions("claude", []DiscoveredSession{
+		tmuxDisc("c0", "%0", "a", session.TmuxServerDefault), // no StatusHint
+		{AgentSessionID: "vs-1", Frontend: session.FrontendVSCode},
+	})
+
+	s, ok := r.Get("default:%0")
+	if !ok {
+		t.Fatal("pane session missing")
+	}
+	if s.Status != session.StatusIdle {
+		t.Fatalf("fresh pane session status: want idle, got %q", s.Status)
+	}
+	if s.Interaction == nil || s.Interaction.Kind != session.InteractionIdle {
+		t.Fatalf("fresh pane session must synthesize idle interaction, got %+v", s.Interaction)
+	}
+
+	// Paneless: nothing to type into, stays discovered with no interaction.
+	vs, ok := r.Get("claude:vs-1")
+	if !ok {
+		t.Fatal("vscode session missing")
+	}
+	if vs.Status != session.StatusDiscovered || vs.Interaction != nil {
+		t.Fatalf("paneless session should stay discovered/no-interaction, got %q %+v", vs.Status, vs.Interaction)
+	}
+}
+
 func TestReconcileSessionsAddsVSCodeAndPrunes(t *testing.T) {
 	r := New()
 	r.ReconcileSessions("claude", []DiscoveredSession{

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -259,10 +259,18 @@ func setTranscriptPath(s *session.Session, path string) {
 
 // applyStatusHint seeds a transcript-derived status onto a still-StatusDiscovered
 // session (no authoritative hook status yet). An idle hint also synthesizes an idle
-// Interaction so clients show the compose. Caller holds r.mu.
+// Interaction so clients show the compose. A missing hint on a pane-bearing session
+// (freshly opened, no transcript yet) defaults to idle so clients can send the first
+// prompt. Caller holds r.mu.
 func applyStatusHint(s *session.Session, hint session.Status) {
-	if hint == "" || s.Status != session.StatusDiscovered {
+	if s.Status != session.StatusDiscovered {
 		return
+	}
+	if hint == "" {
+		if s.Tmux.PaneID == "" {
+			return // no pane = can't type into it, leave discovered
+		}
+		hint = session.StatusIdle
 	}
 	s.Status = hint
 	if hint == session.StatusIdle && s.Interaction == nil {


### PR DESCRIPTION
## The problem

If you open a brand-new Claude session and haven't typed anything yet, the mobile app is basically stuck on it:

1. **You can't start the conversation.** The session shows "No transcript yet." and there's no box to type your first message. You have to go to your terminal to get it going.
2. **Replies don't show up live.** Once you do send a first message, Claude's reply doesn't appear — the screen just sits there. You have to leave the session and open it again to see the response.
3. **A blank "(no output)" line at the top.** When you reopen it, there's an empty entry above your first message that shouldn't be there.

## Why it happened

1. The app only shows the "type a message" box when a session is waiting on you for something. A fresh session wasn't marked as waiting, so no box appeared.
2. The app started listening for new messages before Claude had created the session's transcript file. That made the "listen for updates" request fail, so nothing streamed in. Reopening worked only because the file existed by then.
3. New Claude sessions begin with a couple of internal bookkeeping lines. The app didn't recognize them and drew them as an empty entry.

## The fix

1. A freshly opened session is now marked as waiting for your first message, so the compose box shows up. It's kept as a quiet "idle" state — no push notification on every launch.
2. A transcript file that doesn't exist yet is treated as empty instead of an error, so the app starts streaming right away and picks up replies as they arrive.
3. Those internal bookkeeping lines are now ignored, so no more blank entry.

Problems 2 and 3 were already there — they just couldn't be seen until fresh sessions became openable (problem 1).

## Tests
Added coverage for each fix. Full suite passes (`go test ./...`).