### PR TITLE
fix: encode modified cursor & nav keys in virtual terminal

### DIFF
--- a/app/lib/state/pty_keys.dart
+++ b/app/lib/state/pty_keys.dart
@@ -36,16 +36,57 @@ const _appCursorSeqs = <String, String>{
   'end': '\x1bOF',
 };
 
+// Modified-key encoding: cursor keys use CSI 1;<param><final>; the ~-style nav
+// keys use CSI <num>;<param>~. param = 1 + shift(1) + alt(2) + ctrl(4).
+const _cursorFinals = <String, String>{
+  'up': 'A',
+  'down': 'B',
+  'right': 'C',
+  'left': 'D',
+  'home': 'H',
+  'end': 'F',
+};
+
+const _tildeNums = <String, int>{
+  'insert': 2,
+  'delete': 3,
+  'pgup': 5,
+  'pgdown': 6,
+};
+
+// The xterm sequence for a cursor/nav key held with a modifier ([mod] a nonzero
+// bitmask), or null if [name] isn't such a key. Programs expect this form for
+// Ctrl+Home/End etc., and it applies regardless of DECCKM (app-cursor mode).
+String? _modifiedNavSeq(String name, int mod) {
+  final param = mod + 1;
+  final fin = _cursorFinals[name];
+  if (fin != null) return '\x1b[1;$param$fin';
+  final tildeNum = _tildeNums[name];
+  if (tildeNum != null) return '\x1b[$tildeNum;$param~';
+  return null;
+}
+
 /// Raw PTY bytes for a named key. [shift] affects Tab (back-tab) and Enter;
-/// [alt] affects Enter. [appCursor] emits the SS3 form of the cursor keys
-/// (DECCKM), which full-screen TUIs enable — pass the remote terminal's
-/// `cursorKeysMode`.
+/// [alt] affects Enter. [ctrl]/[shift]/[alt] on a cursor or ~-style nav key emit
+/// the xterm modified form (e.g. Ctrl+Home → CSI 1;5H). [appCursor] emits the SS3
+/// form of the cursor keys (DECCKM), which full-screen TUIs enable — pass the
+/// remote terminal's `cursorKeysMode`.
 List<int> ptyKeyBytes(String name,
-    {bool shift = false, bool alt = false, bool appCursor = false}) {
+    {bool shift = false,
+    bool alt = false,
+    bool ctrl = false,
+    bool appCursor = false}) {
   if (name == 'tab' && shift) return utf8.encode('\x1b[Z');
   // Alt+Enter / Shift+Enter → ESC+CR (meta-Enter): the sequence agent TUIs
   // (Claude Code and other Ink/readline apps) treat as "insert newline".
   if (name == 'enter' && (alt || shift)) return utf8.encode('\x1b\r');
+  // Modified cursor/nav keys take precedence over DECCKM: xterm emits the CSI
+  // form whenever a modifier is held, regardless of cursor-keys mode.
+  final mod = (shift ? 1 : 0) | (alt ? 2 : 0) | (ctrl ? 4 : 0);
+  if (mod != 0) {
+    final seq = _modifiedNavSeq(name, mod);
+    if (seq != null) return utf8.encode(seq);
+  }
   if (appCursor) {
     final app = _appCursorSeqs[name];
     if (app != null) return utf8.encode(app);

--- a/app/lib/ui/live_screen_screen.dart
+++ b/app/lib/ui/live_screen_screen.dart
@@ -249,7 +249,7 @@ class _InputBarState extends State<_InputBar> {
 
   void _pressKey(String name) {
     widget.onInput(ptyKeyBytes(name,
-        shift: _shift, alt: _alt, appCursor: widget.appCursorMode()));
+        shift: _shift, alt: _alt, ctrl: _ctrl, appCursor: widget.appCursorMode()));
     _clearMods();
   }
 

--- a/app/test/state/pty_keys_test.dart
+++ b/app/test/state/pty_keys_test.dart
@@ -41,6 +41,28 @@ void main() {
     test('appCursor leaves delete as CSI', () => expect(ptyKeyBytes('delete', appCursor: true), [27, 91, 51, 126]));
     // Default (no DECCKM) keeps CSI arrows.
     test('default up stays CSI', () => expect(ptyKeyBytes('up'), [27, 91, 65]));
+
+    // Modified cursor/nav keys: xterm CSI encoding. Cursor keys use CSI 1;<mod><final>;
+    // the ~-style nav keys use CSI <num>;<mod>~. mod = 1 + shift(1) + alt(2) + ctrl(4).
+    test('ctrl+home → CSI 1;5H', () => expect(ptyKeyBytes('home', ctrl: true), [27, 91, 49, 59, 53, 72]));
+    test('ctrl+end → CSI 1;5F', () => expect(ptyKeyBytes('end', ctrl: true), [27, 91, 49, 59, 53, 70]));
+    test('ctrl+up → CSI 1;5A', () => expect(ptyKeyBytes('up', ctrl: true), [27, 91, 49, 59, 53, 65]));
+    test('shift+up → CSI 1;2A', () => expect(ptyKeyBytes('up', shift: true), [27, 91, 49, 59, 50, 65]));
+    test('alt+left → CSI 1;3D', () => expect(ptyKeyBytes('left', alt: true), [27, 91, 49, 59, 51, 68]));
+    test('ctrl+shift+end → CSI 1;6F',
+        () => expect(ptyKeyBytes('end', ctrl: true, shift: true), [27, 91, 49, 59, 54, 70]));
+    test('ctrl+delete → CSI 3;5~', () => expect(ptyKeyBytes('delete', ctrl: true), [27, 91, 51, 59, 53, 126]));
+    test('ctrl+insert → CSI 2;5~', () => expect(ptyKeyBytes('insert', ctrl: true), [27, 91, 50, 59, 53, 126]));
+    test('ctrl+pgup → CSI 5;5~', () => expect(ptyKeyBytes('pgup', ctrl: true), [27, 91, 53, 59, 53, 126]));
+    test('ctrl+pgdown → CSI 6;5~', () => expect(ptyKeyBytes('pgdown', ctrl: true), [27, 91, 54, 59, 53, 126]));
+    // All three modifiers together → param 8 (1 + shift(1) + alt(2) + ctrl(4)).
+    test('ctrl+shift+alt+end → CSI 1;8F',
+        () => expect(ptyKeyBytes('end', ctrl: true, shift: true, alt: true), [27, 91, 49, 59, 56, 70]));
+    // The modifier form wins over DECCKM app-cursor mode.
+    test('ctrl+home ignores appCursor',
+        () => expect(ptyKeyBytes('home', ctrl: true, appCursor: true), [27, 91, 49, 59, 53, 72]));
+    // A modifier on a non-nav key is dropped (unchanged behavior).
+    test('ctrl+space stays SP', () => expect(ptyKeyBytes('space', ctrl: true), [32]));
   });
 
   group('ptyTextBytes', () {

--- a/app/test/ui/live_screen_screen_test.dart
+++ b/app/test/ui/live_screen_screen_test.dart
@@ -261,6 +261,17 @@ void main() {
     await tester.pumpWidget(const SizedBox());
   });
 
+  testWidgets('arming Ctrl then tapping Home sends CSI 1;5H', (tester) async {
+    final repo = _FakeTerminalRepo();
+    await _pump(tester, repo);
+    await tester.tap(find.byTooltip('Ctrl')); // arm the one-shot Ctrl modifier
+    await tester.pump();
+    await tester.tap(find.byTooltip('Home'));
+    await tester.pump();
+    expect(repo.sends.last, [27, 91, 49, 59, 53, 72]);
+    await tester.pumpWidget(const SizedBox());
+  });
+
   testWidgets('tapping PageUp sends the pgup escape sequence', (tester) async {
     final repo = _FakeTerminalRepo();
     await _pump(tester, repo);

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -19,6 +19,11 @@ func ptyBytesFor(msg tea.KeyPressMsg) []byte {
 	if msg.Code == tea.KeyEnter && msg.Mod&(tea.ModAlt|tea.ModShift) != 0 {
 		return []byte("\x1b\r")
 	}
+	// Modified cursor/nav keys (Ctrl/Shift/Alt+Home/End/arrows/PgUp…). Matched on
+	// Code+Mod before the string switch, which only sees the bare keys.
+	if b := modifiedNavSeq(msg); b != nil {
+		return b
+	}
 	s := msg.String()
 	switch s {
 	case "enter":
@@ -82,6 +87,45 @@ var fnKeySeqs = map[int]string{
 	1: "\x1bOP", 2: "\x1bOQ", 3: "\x1bOR", 4: "\x1bOS",
 	5: "\x1b[15~", 6: "\x1b[17~", 7: "\x1b[18~", 8: "\x1b[19~",
 	9: "\x1b[20~", 10: "\x1b[21~", 11: "\x1b[23~", 12: "\x1b[24~",
+}
+
+// Cursor keys encode a held modifier as CSI 1;<param><final>; the ~-style nav
+// keys as CSI <num>;<param>~ (xterm). param = 1 + shift(1) + alt(2) + ctrl(4).
+var cursorFinals = map[rune]byte{
+	tea.KeyUp: 'A', tea.KeyDown: 'B', tea.KeyRight: 'C', tea.KeyLeft: 'D',
+	tea.KeyHome: 'H', tea.KeyEnd: 'F',
+}
+
+var tildeNums = map[rune]int{
+	tea.KeyInsert: 2, tea.KeyDelete: 3, tea.KeyPgUp: 5, tea.KeyPgDown: 6,
+}
+
+// modifiedNavSeq returns the xterm sequence for a cursor/nav key pressed with a
+// Ctrl/Shift/Alt modifier, or nil if msg isn't such a key or holds no relevant
+// modifier (bare keys fall through to the plain-key encoding). This form is what
+// programs expect for Ctrl+Home/End etc.; it applies regardless of DECCKM.
+func modifiedNavSeq(msg tea.KeyPressMsg) []byte {
+	mod := 0
+	if msg.Mod&tea.ModShift != 0 {
+		mod |= 1
+	}
+	if msg.Mod&tea.ModAlt != 0 {
+		mod |= 2
+	}
+	if msg.Mod&tea.ModCtrl != 0 {
+		mod |= 4
+	}
+	if mod == 0 {
+		return nil
+	}
+	param := strconv.Itoa(mod + 1)
+	if final, ok := cursorFinals[msg.Code]; ok {
+		return []byte("\x1b[1;" + param + string(final))
+	}
+	if num, ok := tildeNums[msg.Code]; ok {
+		return []byte("\x1b[" + strconv.Itoa(num) + ";" + param + "~")
+	}
+	return nil
 }
 
 // termOpenedMsg reports the result of a terminal.open request.

--- a/internal/tui/terminal_test.go
+++ b/internal/tui/terminal_test.go
@@ -87,16 +87,33 @@ func TestPtyBytesFor(t *testing.T) {
 		{"alt+enter", tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt}, []byte("\x1b\r")},
 		{"shift+enter", tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}, []byte("\x1b\r")},
 		{"plain enter stays CR", tea.KeyPressMsg{Code: tea.KeyEnter}, []byte{'\r'}},
+		// Modified cursor/nav keys: xterm CSI encoding. Cursor keys use CSI 1;<mod><final>;
+		// the ~-style nav keys use CSI <num>;<mod>~. mod = 1 + shift(1) + alt(2) + ctrl(4).
+		{"ctrl+home", tea.KeyPressMsg{Code: tea.KeyHome, Mod: tea.ModCtrl}, []byte("\x1b[1;5H")},
+		{"ctrl+end", tea.KeyPressMsg{Code: tea.KeyEnd, Mod: tea.ModCtrl}, []byte("\x1b[1;5F")},
+		{"ctrl+up", tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModCtrl}, []byte("\x1b[1;5A")},
+		{"shift+home", tea.KeyPressMsg{Code: tea.KeyHome, Mod: tea.ModShift}, []byte("\x1b[1;2H")},
+		{"alt+left", tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModAlt}, []byte("\x1b[1;3D")},
+		{"ctrl+shift+end", tea.KeyPressMsg{Code: tea.KeyEnd, Mod: tea.ModCtrl | tea.ModShift}, []byte("\x1b[1;6F")},
+		{"ctrl+delete", tea.KeyPressMsg{Code: tea.KeyDelete, Mod: tea.ModCtrl}, []byte("\x1b[3;5~")},
+		{"ctrl+insert", tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModCtrl}, []byte("\x1b[2;5~")},
+		{"ctrl+pgup", tea.KeyPressMsg{Code: tea.KeyPgUp, Mod: tea.ModCtrl}, []byte("\x1b[5;5~")},
+		{"ctrl+pgdown", tea.KeyPressMsg{Code: tea.KeyPgDown, Mod: tea.ModCtrl}, []byte("\x1b[6;5~")},
+		// All three modifiers together → param 8 (1 + shift(1) + alt(2) + ctrl(4)).
+		{"ctrl+shift+alt+end", tea.KeyPressMsg{Code: tea.KeyEnd, Mod: tea.ModCtrl | tea.ModShift | tea.ModAlt}, []byte("\x1b[1;8F")},
+		{"bare home stays CSI H", tea.KeyPressMsg{Code: tea.KeyHome}, []byte("\x1b[H")},
+		{"bare end stays CSI F", tea.KeyPressMsg{Code: tea.KeyEnd}, []byte("\x1b[F")},
+		// shift+up is a modified cursor key now, not an unencoded key.
+		{"shift+up", tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift}, []byte("\x1b[1;2A")},
+		// A modifier on a non-nav key isn't caught by modifiedNavSeq; ctrl+a still
+		// falls through to the ctrl-chord branch.
+		{"ctrl+a falls through to chord", tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl}, []byte{0x01}},
 	}
 	for _, tc := range cases {
 		got := ptyBytesFor(tc.msg)
 		if string(got) != string(tc.want) {
 			t.Errorf("%s: got %q want %q", tc.name, got, tc.want)
 		}
-	}
-	// A key with no PTY encoding yields nil.
-	if got := ptyBytesFor(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift}); got != nil {
-		t.Errorf("shift+up: got %q want nil", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Ctrl/Shift/Alt with Home, End, arrows, and the ~-style nav keys did nothing on the live-screen terminal in both the TUI and the app — the encoders emitted only the bare sequences and dropped the modifier.

## Fix

Emit the xterm modified encoding, taking precedence over DECCKM app-cursor mode:

- Cursor keys (↑↓←→, Home, End) → `CSI 1;<param><final>`
- ~-style nav keys (Insert, Delete, PgUp, PgDown) → `CSI <num>;<param>~`

where `param = 1 + shift(1) + alt(2) + ctrl(4)`. E.g. Ctrl+Home → `\x1b[1;5H`.

- **TUI** (`ptyBytesFor`): match on `Code`+`Mod` before the bare-key switch.
- **App** (`ptyKeyBytes`): add a `ctrl` param and thread the armed `_ctrl` modifier through `_pressKey`.

## Tests

Unit + widget coverage on both sides for Ctrl/Shift/Alt combinations, modifier-wins-over-appCursor, and modifier-on-non-nav-key fall-through. `go test ./internal/tui/...` and `flutter test` green.