### PR TITLE
feat(app): make transcript text selectable and links tappable

### DIFF
--- a/app/lib/ui/code_block.dart
+++ b/app/lib/ui/code_block.dart
@@ -6,6 +6,7 @@ import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:re_highlight/languages/all.dart';
 import 'package:re_highlight/re_highlight.dart';
 import 'package:re_highlight/styles/all.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'theme.dart';
 
@@ -27,10 +28,18 @@ String safeFence(String body) {
 
 /// Renders markdown with app-consistent code blocks: fenced code goes through the
 /// same [codeView] renderer standalone blocks use, so it gets syntax highlighting
-/// and is copyable.
-Widget appMarkdown(String data) => GptMarkdown(
-      data,
-      codeBuilder: (context, name, code, closed) => codeView(code, lang: name),
+/// and is copyable. Wrapped in a [SelectionArea] so prose (and fenced code, which
+/// renders with `selectable: false` to avoid a forbidden nested SelectionArea) is
+/// selectable via the native long-press → Copy toolbar.
+Widget appMarkdown(String data) => SelectionArea(
+      child: Builder(
+        builder: (context) => GptMarkdown(
+          data,
+          onLinkTap: (url, title) => showLinkActions(context, url),
+          codeBuilder: (context, name, code, closed) =>
+              codeView(code, lang: name, selectable: false),
+        ),
+      ),
     );
 
 /// Renders [body] as a standalone code block (see [codeView]).
@@ -47,17 +56,27 @@ Widget codeBlock(String body,
 ///
 /// Set [lineNumberToggle] false for content that already carries its own line
 /// numbers (e.g. the Read tool's `cat -n` output). [wrap] sets the initial line
-/// wrap state (still user-toggleable).
+/// wrap state (still user-toggleable). [selectable] controls whether the content
+/// region is wrapped in a [SelectionArea]; set to `false` when an ancestor
+/// [SelectionArea] already covers this block (e.g. inside [appMarkdown]).
 Widget codeView(String body,
-    {String? lang, bool lineNumberToggle = true, bool wrap = false}) {
+    {String? lang,
+    bool lineNumberToggle = true,
+    bool wrap = false,
+    bool selectable = true}) {
   // Show the box with a dim marker so an empty block still reads as "a block that
   // was empty" rather than a missing render.
   if (body.trim().isEmpty) {
     return _container(
-        Text('(empty)', style: _codeMono.copyWith(color: AppColors.dim)));
+        Text('(empty)', style: _codeMono.copyWith(color: AppColors.dim)),
+        selectable: selectable);
   }
   return _CodeBlock(
-      body: body, lang: lang, lineNumberToggle: lineNumberToggle, wrap: wrap);
+      body: body,
+      lang: lang,
+      lineNumberToggle: lineNumberToggle,
+      wrap: wrap,
+      selectable: selectable);
 }
 
 class _CodeBlock extends StatefulWidget {
@@ -65,12 +84,14 @@ class _CodeBlock extends StatefulWidget {
       {required this.body,
       this.lang,
       this.lineNumberToggle = true,
-      this.wrap = false});
+      this.wrap = false,
+      this.selectable = true});
 
   final String body;
   final String? lang;
   final bool lineNumberToggle;
   final bool wrap;
+  final bool selectable;
 
   @override
   State<_CodeBlock> createState() => _CodeBlockState();
@@ -125,15 +146,19 @@ class _CodeBlockState extends State<_CodeBlock> {
           _header(label),
           Padding(
             padding: const EdgeInsets.all(10),
-            child: _wrap
-                ? content
-                : SingleChildScrollView(
-                    scrollDirection: Axis.horizontal, child: content),
+            child: widget.selectable
+                ? SelectionArea(child: _scrollable(content))
+                : _scrollable(content),
           ),
         ],
       ),
     );
   }
+
+  Widget _scrollable(Widget content) => _wrap
+      ? content
+      : SingleChildScrollView(
+          scrollDirection: Axis.horizontal, child: content);
 
   Widget _numbered(List<List<_Run>> lines) {
     final gutterWidth = lines.length.toString().length * 9.0;
@@ -262,6 +287,55 @@ Widget codeBarButton({
       onPressed: onTap,
     );
 
+/// Presents a bottom sheet offering to open [url] externally or copy it, so a
+/// tapped link isn't launched without confirmation.
+void showLinkActions(BuildContext context, String url) {
+  showModalBottomSheet<void>(
+    context: context,
+    builder: (sheetCtx) {
+      ListTile action(IconData icon, String label, VoidCallback onTap) =>
+          ListTile(
+            leading: Icon(icon),
+            title: Text(label),
+            onTap: () {
+              Navigator.pop(sheetCtx);
+              onTap();
+            },
+          );
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+              child: Text(url,
+                  style: const TextStyle(color: AppColors.dim, fontSize: 13),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis),
+            ),
+            action(Icons.open_in_new, 'Open link', () => openExternalUrl(url)),
+            action(Icons.copy, 'Copy link', () => copyToClipboard(context, url)),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+/// Opens [url] in the external browser. Overridable in tests. Malformed or
+/// unlaunchable URLs are ignored so a bad link can never crash the render.
+Future<void> Function(String url) openExternalUrl = _openExternalUrl;
+
+Future<void> _openExternalUrl(String url) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return;
+  try {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  } catch (_) {
+    // Unlaunchable URL (no handler, platform error): ignore.
+  }
+}
+
 /// Copies [text] to the clipboard and shows a brief confirmation snackbar when a
 /// messenger is available.
 void copyToClipboard(BuildContext context, String text) {
@@ -272,18 +346,21 @@ void copyToClipboard(BuildContext context, String text) {
   ));
 }
 
-Widget _container(Widget child) => Container(
-      width: double.infinity,
-      margin: const EdgeInsets.symmetric(vertical: 4),
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: AppColors.canvas,
-        borderRadius: BorderRadius.circular(6),
-        border: Border.all(color: AppColors.border),
-      ),
-      child:
-          SingleChildScrollView(scrollDirection: Axis.horizontal, child: child),
-    );
+Widget _container(Widget child, {bool selectable = true}) {
+  final inner =
+      SingleChildScrollView(scrollDirection: Axis.horizontal, child: child);
+  return Container(
+    width: double.infinity,
+    margin: const EdgeInsets.symmetric(vertical: 4),
+    padding: const EdgeInsets.all(10),
+    decoration: BoxDecoration(
+      color: AppColors.canvas,
+      borderRadius: BorderRadius.circular(6),
+      border: Border.all(color: AppColors.border),
+    ),
+    child: selectable ? SelectionArea(child: inner) : inner,
+  );
+}
 
 // Shared highlighter with all highlight.js grammars registered.
 final Highlight _highlight = Highlight()

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -957,6 +957,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:
@@ -1119,4 +1183,4 @@ packages:
     version: "0.0.6"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   basic_utils: ^5.8.2
   # Terminal emulator for the live tmux screen; fed capture-pane snapshots.
   xterm: ^4.0.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:

--- a/app/test/ui/code_block_test.dart
+++ b/app/test/ui/code_block_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:argus/ui/code_block.dart';
 
@@ -100,5 +101,81 @@ void main() {
     await tester.tap(find.text('tap'));
     await tester.pump();
     expect(find.text('Copied'), findsOneWidget);
+  });
+
+  testWidgets('standalone codeBlock is wrapped in a SelectionArea',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: codeBlock('selectable code', lang: 'bash'))));
+    expect(find.byType(SelectionArea), findsOneWidget);
+  });
+
+  testWidgets('appMarkdown wraps prose in a SelectionArea', (tester) async {
+    await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: appMarkdown('some **prose** here'))));
+    expect(find.byType(SelectionArea), findsOneWidget);
+  });
+
+  testWidgets('fenced code inside markdown does not nest a SelectionArea',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: appMarkdown('intro text\n\n```bash\necho hi\n```\n'))));
+    // Exactly one: the outer appMarkdown area. The nested code block must use
+    // selectable:false, so it adds no SelectionArea of its own.
+    expect(find.byType(SelectionArea), findsOneWidget);
+  });
+
+  testWidgets('tapping a markdown link opens the actions sheet', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: appMarkdown('see [docs](https://argus.muniftanjim.dev)'))));
+    await tester.tap(find.text('docs'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('https://argus.muniftanjim.dev'), findsOneWidget);
+    expect(find.text('Open link'), findsOneWidget);
+    expect(find.text('Copy link'), findsOneWidget);
+  });
+
+  testWidgets('Open link in the sheet calls openExternalUrl', (tester) async {
+    final tapped = <String>[];
+    final original = openExternalUrl;
+    openExternalUrl = (url) async => tapped.add(url);
+    addTearDown(() => openExternalUrl = original);
+
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: appMarkdown('see [docs](https://argus.muniftanjim.dev)'))));
+    await tester.tap(find.text('docs'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open link'));
+    await tester.pumpAndSettle();
+
+    expect(tapped, ['https://argus.muniftanjim.dev']);
+  });
+
+  testWidgets('Copy link in the sheet copies the url to the clipboard',
+      (tester) async {
+    final copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        copied.add((call.arguments as Map)['text'] as String);
+      }
+      return null;
+    });
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: appMarkdown('see [docs](https://argus.muniftanjim.dev)'))));
+    await tester.tap(find.text('docs'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Copy link'));
+    await tester.pumpAndSettle();
+
+    expect(copied, ['https://argus.muniftanjim.dev']);
   });
 }


### PR DESCRIPTION
Rendered transcript text in the mobile app couldn't be selected/copied and links weren't tappable.

- Markdown prose and code blocks are now selectable (per-block, native long-press → Copy), alongside the existing whole-block copy button.
- Tapping a markdown link opens an action sheet to open it in the external browser or copy the URL.

All changes are in `app/lib/ui/code_block.dart` (the shared render path for every transcript surface) plus the `url_launcher` dependency. 17/17 code-block tests pass.