### PR TITLE
feat(app): show claude session name in ui and notifications

### DIFF
--- a/app/lib/models/session.dart
+++ b/app/lib/models/session.dart
@@ -214,6 +214,12 @@ class Session {
           ? name!
           : id;
 
+  /// The Claude session name, shown as a secondary label beside [displayTitle].
+  /// Null when it would duplicate the primary title (e.g. repo is empty, so the
+  /// name is already the title).
+  String? get displayName =>
+      (name?.isNotEmpty ?? false) && name != displayTitle ? name : null;
+
   /// Whether argus can drive this session's terminal. Derived from frontend:
   /// only tmux sessions are controllable; vscode/external are decision-only.
   bool get controllable => frontend == FrontendKind.tmux;

--- a/app/lib/ui/session_card.dart
+++ b/app/lib/ui/session_card.dart
@@ -24,8 +24,6 @@ class SessionCard extends StatelessWidget {
 
   final bool showAgent;
 
-  static const _mono = TextStyle(fontFamily: 'monospace', fontSize: 12);
-
   @override
   Widget build(BuildContext context) {
     final s = session;
@@ -73,10 +71,17 @@ class SessionCard extends StatelessWidget {
                 const Icon(Icons.dns_outlined, size: 13, color: AppColors.dim),
                 const SizedBox(width: 4),
                 Text(nodeLabel,
-                    style: _mono.copyWith(color: AppColors.dim, fontSize: 11)),
+                    style: mono.copyWith(color: AppColors.dim, fontSize: 11)),
               ],
             ],
           ),
+          if (s.displayName != null) ...[
+            const SizedBox(height: 2),
+            Text(s.displayName!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: mono.copyWith(color: AppColors.dim)),
+          ],
           if ((s.summary?.task ?? s.interaction?.message) != null) ...[
             const SizedBox(height: 4),
             Text(s.summary?.task ?? s.interaction!.message!,
@@ -86,7 +91,7 @@ class SessionCard extends StatelessWidget {
           ],
           if (meta.isNotEmpty) ...[
             const SizedBox(height: 6),
-            Text(meta, style: _mono.copyWith(color: AppColors.dim)),
+            Text(meta, style: mono.copyWith(color: AppColors.dim)),
           ],
         ],
       ),

--- a/app/lib/ui/session_detail_screen.dart
+++ b/app/lib/ui/session_detail_screen.dart
@@ -142,27 +142,40 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen>
 
     return Scaffold(
       appBar: AppBar(
-        title: Row(
+        titleSpacing: 0,
+        title: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(statusGlyph(live.status),
-                style: TextStyle(
-                    fontFamily: 'monospace', color: statusColor(live.status))),
-            const SizedBox(width: 8),
-            Expanded(
-                child:
-                    Text(title, maxLines: 1, overflow: TextOverflow.ellipsis)),
-            if (live.frontend != FrontendKind.tmux)
-              Padding(
-                padding: const EdgeInsets.only(left: 8),
-                child: Chip(
-                  label: Text(live.frontend.name),
-                  padding: EdgeInsets.zero,
-                  labelPadding:
-                      const EdgeInsets.symmetric(horizontal: 6),
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  visualDensity: VisualDensity.compact,
-                ),
-              ),
+            Row(
+              children: [
+                Text(statusGlyph(live.status),
+                    style: TextStyle(
+                        fontFamily: 'monospace',
+                        color: statusColor(live.status))),
+                const SizedBox(width: 8),
+                Expanded(
+                    child: Text(title,
+                        maxLines: 1, overflow: TextOverflow.ellipsis)),
+                if (live.frontend != FrontendKind.tmux)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 8),
+                    child: Chip(
+                      label: Text(live.frontend.name),
+                      padding: EdgeInsets.zero,
+                      labelPadding:
+                          const EdgeInsets.symmetric(horizontal: 6),
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ),
+              ],
+            ),
+            if (live.displayName != null)
+              Text(live.displayName!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: mono.copyWith(color: AppColors.dim)),
           ],
         ),
         actions: [

--- a/app/lib/ui/theme.dart
+++ b/app/lib/ui/theme.dart
@@ -17,6 +17,8 @@ class AppColors {
   static const errorSurface = Color(0xFF3c1f1d);
 }
 
+const mono = TextStyle(fontFamily: 'monospace', fontSize: 12);
+
 Color teamColor(String? name) {
   switch (name) {
     case 'blue':

--- a/app/test/models/session_test.dart
+++ b/app/test/models/session_test.dart
@@ -78,6 +78,29 @@ void main() {
     expect(s.controllable, isFalse);
   });
 
+  Session withRepoName({String? repo, String? name}) => Session.fromJson({
+        'id': 's1',
+        'agent': 'claude',
+        'status': 'idle',
+        'source': 'discovered',
+        'tmux': {'server': 'default', 'pane_id': '%1'},
+        if (repo != null) 'repo': repo,
+        if (name != null) 'name': name,
+      });
+
+  test('displayName surfaces the session name beside a repo title', () {
+    expect(withRepoName(repo: 'argus', name: 'auth').displayName, 'auth');
+  });
+
+  test('displayName is null when it would duplicate the title', () {
+    // No repo: the name is already displayTitle.
+    expect(withRepoName(name: 'auth').displayName, isNull);
+    // Name equals repo: nothing to add.
+    expect(withRepoName(repo: 'argus', name: 'argus').displayName, isNull);
+    // No name at all.
+    expect(withRepoName(repo: 'argus').displayName, isNull);
+  });
+
   test('tmux session is controllable', () {
     final s = Session.fromJson({
       'id': 's1',

--- a/app/test/ui/session_card_test.dart
+++ b/app/test/ui/session_card_test.dart
@@ -44,6 +44,22 @@ void main() {
     expect(find.text('CODEX'), findsNothing);
   });
 
+  testWidgets('shows the session name beside the repo', (tester) async {
+    final s = _session(
+        '{"id":"mac:%1","agent":"claude","status":"idle","source":"hooked","tmux":{"server":"argus","pane_id":"%1","session_name":"s","window_index":0,"current_path":"/p"},"repo":"argus","name":"auth-refactor"}');
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: SessionCard(session: s))));
+    expect(find.text('argus'), findsOneWidget);
+    expect(find.text('auth-refactor'), findsOneWidget);
+  });
+
+  testWidgets('omits the name line when it duplicates the title', (tester) async {
+    final s = _session(
+        '{"id":"mac:%1","agent":"claude","status":"idle","source":"hooked","tmux":{"server":"argus","pane_id":"%1","session_name":"s","window_index":0,"current_path":"/p"},"name":"auth-refactor"}');
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: SessionCard(session: s))));
+    // No repo, so name is the title — it appears exactly once (not twice).
+    expect(find.text('auth-refactor'), findsOneWidget);
+  });
+
   testWidgets('falls back to id when no repo/name', (tester) async {
     final s = _session(
         '{"id":"mac:%9","agent":"t","status":"idle","source":"hooked","tmux":{"server":"argus","pane_id":"%9","session_name":"s","window_index":0,"current_path":"/p"}}');

--- a/app/test/ui/session_detail_screen_test.dart
+++ b/app/test/ui/session_detail_screen_test.dart
@@ -14,7 +14,7 @@ import 'package:argus/state/transcript_controller.dart';
 import 'package:argus/ui/session_detail_screen.dart';
 import '../support/fake_session_repository.dart';
 
-Session _s({String? agentSessionId}) => Session.fromJson({
+Session _s({String? agentSessionId, String? name}) => Session.fromJson({
       'id': 'mac:%1',
       'agent': 't',
       'status': 'working',
@@ -30,6 +30,7 @@ Session _s({String? agentSessionId}) => Session.fromJson({
       'repo': 'argus',
       'node_label': 'mac',
       'agent_session_id': ?agentSessionId,
+      'name': ?name,
     });
 
 class _SeededTranscript extends TranscriptNotifier {
@@ -101,6 +102,17 @@ void main() {
     ]));
     await tester.pump();
     expect(find.textContaining('No transcript'), findsOneWidget);
+  });
+
+  testWidgets('shows the session name as an AppBar subtitle', (tester) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: _baseOverrides(),
+      child:
+          MaterialApp(home: SessionDetailScreen(session: _s(name: 'auth-refactor'))),
+    ));
+    await tester.pump();
+    expect(find.text('argus'), findsOneWidget);
+    expect(find.text('auth-refactor'), findsOneWidget);
   });
 
   testWidgets('shows terminal icon button in AppBar', (tester) async {

--- a/internal/push/trigger.go
+++ b/internal/push/trigger.go
@@ -147,6 +147,11 @@ func notificationFor(s session.Session) Notification {
 	if title == "" {
 		title = "argus session"
 	}
+	// Append the session name only when it adds info beyond the repo title. Skip
+	// when repo is empty: the name is already the title, so appending duplicates.
+	if s.Repo != "" && s.Name != "" && s.Name != s.Repo {
+		title += " · " + s.Name
+	}
 	if s.NodeLabel != "" {
 		title = s.NodeLabel + " · " + title
 	}

--- a/internal/push/trigger_test.go
+++ b/internal/push/trigger_test.go
@@ -167,6 +167,67 @@ func TestNotificationForRendersInteraction(t *testing.T) {
 	}
 }
 
+func TestNotificationForSurfacesSessionName(t *testing.T) {
+	cases := []struct {
+		name      string
+		sess      session.Session
+		wantTitle string
+		wantBody  string
+	}{
+		{
+			name: "named session in repo appends name to title",
+			sess: session.Session{
+				Repo: "argus", Name: "auth-refactor",
+				Interaction: &session.Interaction{Kind: session.InteractionPermission, ToolName: "Bash"},
+			},
+			wantTitle: "argus · auth-refactor",
+			wantBody:  "Permission: Bash",
+		},
+		{
+			name:      "unnamed session leaves body unchanged",
+			sess:      session.Session{Repo: "argus", Interaction: &session.Interaction{Kind: session.InteractionPlan}},
+			wantTitle: "argus",
+			wantBody:  "Plan ready to review",
+		},
+		{
+			name:      "name equal to repo is not duplicated",
+			sess:      session.Session{Repo: "argus", Name: "argus"},
+			wantTitle: "argus",
+			wantBody:  "Needs your attention",
+		},
+		{
+			name:      "no repo: name is the title, not the body",
+			sess:      session.Session{Name: "auth-refactor"},
+			wantTitle: "auth-refactor",
+			wantBody:  "Needs your attention",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := notificationFor(tc.sess)
+			if n.Title != tc.wantTitle {
+				t.Errorf("Title = %q, want %q", n.Title, tc.wantTitle)
+			}
+			if n.Body != tc.wantBody {
+				t.Errorf("Body = %q, want %q", n.Body, tc.wantBody)
+			}
+		})
+	}
+}
+
+func TestNotificationForNodeLabelPrefixWithName(t *testing.T) {
+	n := notificationFor(session.Session{
+		Repo: "argus", Name: "auth-refactor", NodeLabel: "MacBook",
+		Interaction: &session.Interaction{Kind: session.InteractionPermission, ToolName: "Bash"},
+	})
+	if want := "MacBook · argus · auth-refactor"; n.Title != want {
+		t.Errorf("Title = %q, want %q", n.Title, want)
+	}
+	if want := "Permission: Bash"; n.Body != want {
+		t.Errorf("Body = %q, want %q", n.Body, want)
+	}
+}
+
 func TestNotificationForCarriesSessionID(t *testing.T) {
 	n := notificationFor(session.Session{ID: "node1:abc", NodeID: "node1"})
 	if n.Data["session_id"] != "node1:abc" {


### PR DESCRIPTION
A Claude session's own name (from `/rename`, `claude -n`, or the auto/plan default) only showed in the TUI. In the app and push notifications the repo name always won, so a renamed session inside a git repo never surfaced its name.

Now the name appears alongside the repo — on session cards, the detail header, and appended to the notification title (`repo · name`, or `node · repo · name` across hosts) — shown only when it adds information beyond the repo title.