### PR TITLE
feat: resume sessions from history

### DIFF
--- a/app/lib/data/session_repository.dart
+++ b/app/lib/data/session_repository.dart
@@ -25,6 +25,13 @@ abstract class SessionRepository {
 
   /// Lists every agent [nodeId] knows (empty [nodeId] = sole node).
   Future<Result<List<AgentInfo>>> listAgents(String? nodeId);
+
+  Future<Result<ResumeOutcome>> resume({
+    String? nodeId,
+    required String agent,
+    required String agentSessionId,
+    required String cwd,
+  });
 }
 
 /// [SessionRepository] backed by the gateway over JSON-RPC via [SessionService].
@@ -70,6 +77,20 @@ class SessionRepositoryRemote implements SessionRepository {
   @override
   Future<Result<List<AgentInfo>>> listAgents(String? nodeId) =>
       _service.listAgents(nodeId);
+
+  @override
+  Future<Result<ResumeOutcome>> resume({
+    String? nodeId,
+    required String agent,
+    required String agentSessionId,
+    required String cwd,
+  }) =>
+      _service.resume(
+        nodeId: nodeId,
+        agent: agent,
+        agentSessionId: agentSessionId,
+        cwd: cwd,
+      );
 }
 
 final sessionRepositoryProvider = Provider<SessionRepository>(

--- a/app/lib/models/history.dart
+++ b/app/lib/models/history.dart
@@ -45,6 +45,7 @@ class HistorySession {
   final String? nodeId;
   final String? nodeLabel;
   final String agent;
+  final bool resumable;
 
   const HistorySession({
     required this.sessionId,
@@ -60,6 +61,7 @@ class HistorySession {
     this.nodeId,
     this.nodeLabel,
     this.agent = '',
+    this.resumable = false,
   });
 
   factory HistorySession.fromJson(Map<String, dynamic> j) => HistorySession(
@@ -76,6 +78,7 @@ class HistorySession {
         nodeId: j['node_id'] as String?,
         nodeLabel: j['node_label'] as String?,
         agent: j['agent'] as String? ?? '',
+        resumable: j['resumable'] as bool? ?? false,
       );
 
   /// The label shown wherever a history session needs a title: title, else the

--- a/app/lib/state/control.dart
+++ b/app/lib/state/control.dart
@@ -71,6 +71,22 @@ class SessionService {
             if (agent != null && agent.isNotEmpty) 'agent': agent,
           }));
 
+  Future<Result<ResumeOutcome>> resume({
+    String? nodeId,
+    required String agent,
+    required String agentSessionId,
+    required String cwd,
+  }) =>
+      _guard((c) async {
+        final r = await c.call('sessions.resume', {
+          'agent': agent,
+          'agent_session_id': agentSessionId,
+          'cwd': cwd,
+          if (nodeId != null && nodeId.isNotEmpty) 'node_id': nodeId,
+        }) as Map?;
+        return ResumeOutcome(sessionId: r?['session_id'] as String? ?? '');
+      });
+
   /// An empty [nodeId] targets the sole node.
   Future<Result<List<AgentInfo>>> listAgents(String? nodeId) =>
       _guard((c) async {

--- a/app/lib/state/grouping.dart
+++ b/app/lib/state/grouping.dart
@@ -35,6 +35,11 @@ class AgentInfo {
   });
 }
 
+class ResumeOutcome {
+  final String sessionId;
+  const ResumeOutcome({required this.sessionId});
+}
+
 List<NodeRef> nodesFromSessions(Iterable<Session> sessions) {
   final seen = <String, NodeRef>{};
   for (final s in sessions) {

--- a/app/lib/state/navigation.dart
+++ b/app/lib/state/navigation.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/legacy.dart';
+
+/// Selected tab in HomeShell: 0 = Sessions, 1 = History, 2 = Settings.
+final homeTabProvider = StateProvider<int>((ref) => 0);
+
+const homeTabSessions = 0;

--- a/app/lib/ui/history_sessions_screen.dart
+++ b/app/lib/ui/history_sessions_screen.dart
@@ -111,7 +111,8 @@ class _HistorySessionsScreenState extends ConsumerState<HistorySessionsScreen> {
             onTap: () => Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (_) => HistoryTranscriptScreen(session: s),
+                builder: (_) =>
+                    HistoryTranscriptScreen(session: s, project: widget.project),
               ),
             ),
           );
@@ -148,10 +149,9 @@ class _SessionCard extends StatelessWidget {
       subtitle: subtitleParts.isNotEmpty
           ? Text(subtitleParts.join(' · '))
           : null,
-      trailing:
-          showAgent && session.agent.isNotEmpty
-              ? AgentBadge(agent: session.agent)
-              : null,
+      trailing: showAgent && session.agent.isNotEmpty
+          ? AgentBadge(agent: session.agent)
+          : null,
       onTap: onTap,
     );
   }

--- a/app/lib/ui/history_transcript_screen.dart
+++ b/app/lib/ui/history_transcript_screen.dart
@@ -6,12 +6,18 @@ import '../data/history_repository.dart';
 import '../models/chunk.dart';
 import '../models/history.dart';
 import '../state/tool_detail.dart';
+import 'resume_action.dart';
 import 'transcript_feed.dart';
 
 class HistoryTranscriptScreen extends ConsumerStatefulWidget {
-  const HistoryTranscriptScreen({super.key, required this.session});
+  const HistoryTranscriptScreen({
+    super.key,
+    required this.session,
+    this.project,
+  });
 
   final HistorySession session;
+  final HistoryProject? project;
 
   @override
   ConsumerState<HistoryTranscriptScreen> createState() =>
@@ -46,10 +52,38 @@ class _HistoryTranscriptScreenState
     });
   }
 
+  Future<void> _resumeSession() async {
+    final project = widget.project;
+    if (project == null) return;
+    final s = widget.session;
+    await resumeSession(
+      context,
+      ref,
+      nodeId: s.nodeId,
+      agent: s.agent,
+      agentSessionId: s.sessionId,
+      cwd: project.cwd,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    // A resume needs the original working directory; some sessions (e.g.
+    // antigravity) have an unknown cwd and can't be reopened in place.
+    final canResume = widget.session.resumable &&
+        (widget.project?.cwd.isNotEmpty ?? false);
     return Scaffold(
-      appBar: AppBar(title: Text(widget.session.displayTitle)),
+      appBar: AppBar(
+        title: Text(widget.session.displayTitle),
+        actions: [
+          if (canResume)
+            IconButton(
+              icon: const Icon(Icons.play_arrow),
+              onPressed: _resumeSession,
+              tooltip: 'Resume',
+            ),
+        ],
+      ),
       // top:false — AppBar insets the top; bottom safe-area keeps the feed
       // clear of the system navigation bar (e.g. Android 3-button nav).
       body: SafeArea(top: false, child: _buildBody()),

--- a/app/lib/ui/home_shell.dart
+++ b/app/lib/ui/home_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/session.dart';
+import '../state/navigation.dart';
 import '../state/push.dart';
 import '../state/sessions.dart';
 import 'history_screen.dart';
@@ -17,8 +18,6 @@ class HomeShell extends ConsumerStatefulWidget {
 }
 
 class _HomeShellState extends ConsumerState<HomeShell> {
-  int _index = 0;
-
   @override
   void initState() {
     super.initState();
@@ -54,18 +53,22 @@ class _HomeShellState extends ConsumerState<HomeShell> {
       const HistoryScreen(),
       const SettingsScreen(),
     ];
+    final index = ref.watch(homeTabProvider);
     // The tabs share one route, so back on a non-first tab would otherwise exit
     // the app. Intercept it to return to Sessions first; only exit from Sessions.
     return PopScope(
-      canPop: _index == 0,
+      canPop: index == homeTabSessions,
       onPopInvokedWithResult: (didPop, _) {
-        if (!didPop && _index != 0) setState(() => _index = 0);
+        if (!didPop && index != homeTabSessions) {
+          ref.read(homeTabProvider.notifier).state = homeTabSessions;
+        }
       },
       child: Scaffold(
-        body: IndexedStack(index: _index, children: tabs),
+        body: IndexedStack(index: index, children: tabs),
         bottomNavigationBar: NavigationBar(
-          selectedIndex: _index,
-          onDestinationSelected: (i) => setState(() => _index = i),
+          selectedIndex: index,
+          onDestinationSelected: (i) =>
+              ref.read(homeTabProvider.notifier).state = i,
           destinations: const [
             NavigationDestination(
                 icon: Icon(Icons.dashboard_outlined), label: 'Sessions'),

--- a/app/lib/ui/resume_action.dart
+++ b/app/lib/ui/resume_action.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/result.dart';
+import '../data/session_repository.dart';
+import '../state/navigation.dart';
+
+/// On success, returns to the live Sessions list, where the resumed session
+/// appears (live-jumped or freshly launched) once discovery catches up.
+Future<void> resumeSession(
+  BuildContext context,
+  WidgetRef ref, {
+  String? nodeId,
+  required String agent,
+  required String agentSessionId,
+  required String cwd,
+}) async {
+  final result = await ref.read(sessionRepositoryProvider).resume(
+        nodeId: nodeId,
+        agent: agent,
+        agentSessionId: agentSessionId,
+        cwd: cwd,
+      );
+  if (!context.mounted) return;
+  switch (result) {
+    case Ok():
+      ref.read(homeTabProvider.notifier).state = homeTabSessions;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Resuming session…')),
+      );
+      Navigator.of(context).popUntil((r) => r.isFirst);
+    case Error(:final error):
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to resume: $error')),
+      );
+  }
+}

--- a/app/test/models/history_test.dart
+++ b/app/test/models/history_test.dart
@@ -137,6 +137,16 @@ void main() {
       expect(s.nodeId, isNull);
       expect(s.nodeLabel, isNull);
     });
+
+    test('parses resumable true', () {
+      final s = HistorySession.fromJson({'resumable': true});
+      expect(s.resumable, isTrue);
+    });
+
+    test('defaults resumable to false when absent', () {
+      final s = HistorySession.fromJson(jsonDecode(_minimalSessionJson));
+      expect(s.resumable, isFalse);
+    });
   });
 
   group('HistorySessionPage.fromJson', () {

--- a/app/test/support/fake_session_repository.dart
+++ b/app/test/support/fake_session_repository.dart
@@ -6,6 +6,13 @@ import 'package:argus/state/grouping.dart';
 /// Base fake for [SessionRepository] where every method succeeds with a no-op
 /// result. Tests subclass this and override only the methods they exercise.
 class FakeSessionRepository implements SessionRepository {
+  FakeSessionRepository({
+    this.resumeResult = const Result.ok(ResumeOutcome(sessionId: '')),
+  });
+
+  final Result<ResumeOutcome> resumeResult;
+  Map<String, dynamic>? lastResumeArgs;
+
   @override
   Future<Result<void>> respond(Map<String, dynamic> params) async =>
       const Result.ok(null);
@@ -43,4 +50,20 @@ class FakeSessionRepository implements SessionRepository {
   @override
   Future<Result<List<AgentInfo>>> listAgents(String? nodeId) async =>
       const Result.ok(<AgentInfo>[]);
+
+  @override
+  Future<Result<ResumeOutcome>> resume({
+    String? nodeId,
+    required String agent,
+    required String agentSessionId,
+    required String cwd,
+  }) async {
+    lastResumeArgs = {
+      'nodeId': nodeId,
+      'agent': agent,
+      'agentSessionId': agentSessionId,
+      'cwd': cwd,
+    };
+    return resumeResult;
+  }
 }

--- a/app/test/ui/history_transcript_screen_test.dart
+++ b/app/test/ui/history_transcript_screen_test.dart
@@ -36,7 +36,12 @@ class _FakeHistoryRepository implements HistoryRepository {
       const Result.ok(HistorySessionPage(items: [], hasMore: false));
 }
 
-HistorySession _session({String? title, String? firstMessage}) => HistorySession(
+HistorySession _session({
+  String? title,
+  String? firstMessage,
+  bool resumable = false,
+}) =>
+    HistorySession(
       sessionId: 'sess-1',
       title: title,
       firstMessage: firstMessage,
@@ -45,11 +50,27 @@ HistorySession _session({String? title, String? firstMessage}) => HistorySession
       tokens: 0,
       turnCount: 0,
       durationMs: 0,
+      resumable: resumable,
     );
 
-Widget _app(HistoryRepository repo, HistorySession session) => ProviderScope(
+HistoryProject _project({required String cwd}) => HistoryProject(
+      projectDir: '/home/user/project',
+      cwd: cwd,
+      label: 'Project',
+      sessionCount: 1,
+      lastActivity: '',
+    );
+
+Widget _app(
+  HistoryRepository repo,
+  HistorySession session, {
+  HistoryProject? project,
+}) =>
+    ProviderScope(
       overrides: [historyRepositoryProvider.overrideWithValue(repo)],
-      child: MaterialApp(home: HistoryTranscriptScreen(session: session)),
+      child: MaterialApp(
+        home: HistoryTranscriptScreen(session: session, project: project),
+      ),
     );
 
 void main() {
@@ -96,5 +117,24 @@ void main() {
     await tester.pump();
     await tester.pump();
     expect(find.text('sess-1'), findsOneWidget);
+  });
+
+  testWidgets('shows resume button when resumable and cwd is known',
+      (tester) async {
+    final repo = _FakeHistoryRepository(const <Chunk>[]);
+    await tester.pumpWidget(_app(repo, _session(resumable: true),
+        project: _project(cwd: '/home/user/project')));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byTooltip('Resume'), findsOneWidget);
+  });
+
+  testWidgets('hides resume button when cwd is unknown', (tester) async {
+    final repo = _FakeHistoryRepository(const <Chunk>[]);
+    await tester.pumpWidget(_app(repo, _session(resumable: true),
+        project: _project(cwd: '')));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byTooltip('Resume'), findsNothing);
   });
 }

--- a/app/test/ui/resume_action_test.dart
+++ b/app/test/ui/resume_action_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:argus/core/result.dart';
+import 'package:argus/data/session_repository.dart';
+import 'package:argus/state/grouping.dart';
+import 'package:argus/state/navigation.dart';
+import 'package:argus/ui/resume_action.dart';
+
+import '../support/fake_session_repository.dart';
+
+class _ResumePage extends ConsumerWidget {
+  const _ResumePage();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: ElevatedButton(
+        onPressed: () => resumeSession(
+          context,
+          ref,
+          nodeId: 'home',
+          agent: 'claude',
+          agentSessionId: 'sess-1',
+          cwd: '/home/user/project',
+        ),
+        child: const Text('resume'),
+      ),
+    );
+  }
+}
+
+Widget _harness(SessionRepository repo) => ProviderScope(
+      overrides: [sessionRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const _ResumePage()),
+              ),
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+/// Pushes the resume page so popUntil-first has something to unwind.
+Future<void> _openResumePage(
+    WidgetTester tester, SessionRepository repo) async {
+  await tester.pumpWidget(_harness(repo));
+  await tester.tap(find.text('go'));
+  await tester.pumpAndSettle();
+  expect(find.text('resume'), findsOneWidget);
+}
+
+void main() {
+  testWidgets('success pops to the session list and notifies', (tester) async {
+    final repo = FakeSessionRepository(
+      resumeResult: const Result.ok(ResumeOutcome(sessionId: 'default:%9')),
+    );
+    await _openResumePage(tester, repo);
+
+    await tester.tap(find.text('resume'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('resume'), findsNothing);
+    expect(find.text('go'), findsOneWidget);
+    expect(find.text('Resuming session…'), findsOneWidget);
+  });
+
+  testWidgets('forwards the resume arguments to the repository',
+      (tester) async {
+    final repo = FakeSessionRepository(
+      resumeResult: const Result.ok(ResumeOutcome(sessionId: 'default:%9')),
+    );
+    await _openResumePage(tester, repo);
+
+    await tester.tap(find.text('resume'));
+    await tester.pumpAndSettle();
+
+    expect(repo.lastResumeArgs, {
+      'nodeId': 'home',
+      'agent': 'claude',
+      'agentSessionId': 'sess-1',
+      'cwd': '/home/user/project',
+    });
+  });
+
+  testWidgets('success switches to the Sessions tab', (tester) async {
+    final container = ProviderContainer(overrides: [
+      sessionRepositoryProvider.overrideWithValue(
+        FakeSessionRepository(
+          resumeResult: const Result.ok(ResumeOutcome(sessionId: 'default:%9')),
+        ),
+      ),
+    ]);
+    addTearDown(container.dispose);
+    container.read(homeTabProvider.notifier).state = 1; // start on History
+
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const _ResumePage()),
+              ),
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('resume'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(homeTabProvider), homeTabSessions);
+  });
+
+  testWidgets('failure stays on the page and shows the error', (tester) async {
+    final repo = FakeSessionRepository(
+      resumeResult: Result.error(Exception('boom')),
+    );
+    await _openResumePage(tester, repo);
+
+    await tester.tap(find.text('resume'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('resume'), findsOneWidget);
+    expect(find.textContaining('Failed to resume'), findsOneWidget);
+  });
+}

--- a/docs/guide/tui.md
+++ b/docs/guide/tui.md
@@ -19,4 +19,4 @@ See [Single Machine](/guide/single-machine) for the node it connects to,
 - **Sessions** — the session list, with live status at a glance.
 - **Transcript** — the full conversation, foldable, with tool-call detail.
 - **Live screen** — watch a session's terminal and type into it.
-- **History** — browse past projects and sessions.
+- **History** — browse past projects and sessions, and resume one to pick it back up.

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -58,6 +58,11 @@ type Adapter interface {
 	// An empty name means the agent cannot be spawned.
 	SpawnCommand(prompt string) (name string, args []string)
 
+	// ResumeCommand returns the CLI invocation to resume a past session by its
+	// agent session id. ok=false means this agent cannot resume by id; probe with
+	// an empty id to test resume capability.
+	ResumeCommand(agentSessionID string) (name string, args []string, ok bool)
+
 	ProcessHook(reg *registry.Registry, ev HookEvent) (session.Session, bool)
 	EventName(ev HookEvent) string
 	RescanOnHook(ev HookEvent) bool

--- a/internal/adapter/antigravity/adapter.go
+++ b/internal/adapter/antigravity/adapter.go
@@ -35,6 +35,10 @@ func (agAdapter) SpawnCommand(prompt string) (string, []string) {
 	return "agy", []string{"--prompt-interactive", prompt}
 }
 
+func (agAdapter) ResumeCommand(agentSessionID string) (string, []string, bool) {
+	return "agy", []string{"--conversation", agentSessionID}, true
+}
+
 func (agAdapter) ProcessHook(reg *registry.Registry, ev adapter.HookEvent) (session.Session, bool) {
 	return ProcessHook(reg, ev)
 }

--- a/internal/adapter/antigravity/adapter_resume_test.go
+++ b/internal/adapter/antigravity/adapter_resume_test.go
@@ -1,0 +1,11 @@
+package antigravity
+
+import "testing"
+
+func TestResumeCommand(t *testing.T) {
+	a := New()
+	name, args, ok := a.ResumeCommand("sess-123")
+	if !ok || name != "agy" || len(args) != 2 || args[0] != "--conversation" || args[1] != "sess-123" {
+		t.Fatalf("got name=%q args=%#v ok=%v", name, args, ok)
+	}
+}

--- a/internal/adapter/claudecode/adapter.go
+++ b/internal/adapter/claudecode/adapter.go
@@ -35,6 +35,10 @@ func (ccAdapter) SpawnCommand(prompt string) (string, []string) {
 	return "claude", []string{prompt}
 }
 
+func (ccAdapter) ResumeCommand(agentSessionID string) (string, []string, bool) {
+	return "claude", []string{"--resume", agentSessionID}, true
+}
+
 func (ccAdapter) ProcessHook(reg *registry.Registry, ev adapter.HookEvent) (session.Session, bool) {
 	return ProcessHook(reg, ev)
 }

--- a/internal/adapter/claudecode/adapter_resume_test.go
+++ b/internal/adapter/claudecode/adapter_resume_test.go
@@ -1,0 +1,11 @@
+package claudecode
+
+import "testing"
+
+func TestResumeCommand(t *testing.T) {
+	a := New()
+	name, args, ok := a.ResumeCommand("sess-123")
+	if !ok || name != "claude" || len(args) != 2 || args[0] != "--resume" || args[1] != "sess-123" {
+		t.Fatalf("got name=%q args=%#v ok=%v", name, args, ok)
+	}
+}

--- a/internal/adapter/codex/adapter.go
+++ b/internal/adapter/codex/adapter.go
@@ -34,6 +34,10 @@ func (cxAdapter) SpawnCommand(prompt string) (string, []string) {
 	return "codex", []string{prompt}
 }
 
+func (cxAdapter) ResumeCommand(agentSessionID string) (string, []string, bool) {
+	return "codex", []string{"resume", agentSessionID}, true
+}
+
 func (cxAdapter) ProcessHook(reg *registry.Registry, ev adapter.HookEvent) (session.Session, bool) {
 	return ProcessHook(reg, ev)
 }

--- a/internal/adapter/codex/adapter_resume_test.go
+++ b/internal/adapter/codex/adapter_resume_test.go
@@ -1,0 +1,11 @@
+package codex
+
+import "testing"
+
+func TestResumeCommand(t *testing.T) {
+	a := New()
+	name, args, ok := a.ResumeCommand("sess-123")
+	if !ok || name != "codex" || len(args) != 2 || args[0] != "resume" || args[1] != "sess-123" {
+		t.Fatalf("got name=%q args=%#v ok=%v", name, args, ok)
+	}
+}

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -29,6 +29,7 @@ const (
 	MethodSessionKey            = "sessions.key"            // request: KeyParams; result: nil
 	MethodSessionRespond        = "sessions.respond"        // request: RespondParams; result: nil
 	MethodSessionSpawn          = "sessions.spawn"          // request: SpawnParams; result: SpawnResult
+	MethodSessionResume         = "sessions.resume"         // request: ResumeParams; result: ResumeResult
 	// Probed live per call.
 	MethodAgentsList   = "agents.list"    // request: AgentsListParams; result: AgentsListResult
 	MethodSessionKill  = "sessions.kill"  // request: SessionRef; result: nil
@@ -167,6 +168,21 @@ type SpawnParams struct {
 type SpawnResult struct {
 	SessionID string `json:"session_id"`
 	PaneID    string `json:"pane_id"`
+}
+
+// ResumeParams asks a node to resume a past session by its agent session id, in
+// the session's original working directory.
+type ResumeParams struct {
+	NodeID         string `json:"node_id,omitempty"` // gateway routing key; ignored node-side
+	Agent          string `json:"agent"`             // owning agent id
+	AgentSessionID string `json:"agent_session_id"`  // the tool's own session id to resume
+	Cwd            string `json:"cwd"`               // original working directory
+}
+
+// ResumeResult identifies the session to open, whether newly spawned or an
+// already-live session the resume jumped to.
+type ResumeResult struct {
+	SessionID string `json:"session_id"`
 }
 
 type AgentsListParams struct {

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -344,6 +344,7 @@ func (s *Server) buildClientServer() *api.Server {
 	})
 
 	srv.Handle(api.MethodSessionSpawn, s.routeByNodeIDOrSole(api.MethodSessionSpawn))
+	srv.Handle(api.MethodSessionResume, s.routeByNodeIDOrSole(api.MethodSessionResume))
 	srv.Handle(api.MethodAgentsList, s.routeByNodeIDOrSole(api.MethodAgentsList))
 
 	// History projects aggregate across machines: fan out, stamp origin node, order

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -13,6 +13,27 @@ import (
 	"github.com/MunifTanjim/argus/internal/session"
 )
 
+func TestResumeRoutesByNodeID(t *testing.T) {
+	a := New(time.Second)
+	home := newFakeSource("home", "home-box", sess("default:%1"))
+	home.callResp = json.RawMessage(`{"session_id":"default:%9"}`)
+	a.AddSource(home)
+	eventually(t, func() bool { return len(a.Snapshot()) == 1 })
+
+	srv := NewServer(a, nil, nil)
+	dispatch := srv.clientSrv.DispatchFunc()
+	res, err := dispatch(context.Background(), api.MethodSessionResume,
+		json.RawMessage(`{"node_id":"home","agent":"claude","agent_session_id":"x","cwd":"/tmp"}`))
+	if err != nil {
+		t.Fatalf("resume dispatch: %v", err)
+	}
+	raw, _ := json.Marshal(res)
+	got, _ := sessionIDFromParams(raw)
+	if got != "home:default:%9" {
+		t.Fatalf("want composite session id, got %q (%s)", got, raw)
+	}
+}
+
 func TestClientServerSpawnRoutesByNodeID(t *testing.T) {
 	a := New(time.Second)
 	home := newFakeSource("home", "home-box", sess("default:%1"))

--- a/internal/node/handlers.go
+++ b/internal/node/handlers.go
@@ -23,6 +23,7 @@ func (d *Node) registerHandlers(srv *api.Server) {
 	srv.Handle(api.MethodSessionKey, d.handleSessionKey)
 	srv.Handle(api.MethodSessionRespond, d.handleSessionRespond)
 	srv.Handle(api.MethodSessionSpawn, d.handleSessionSpawn)
+	srv.Handle(api.MethodSessionResume, d.handleSessionResume)
 	srv.Handle(api.MethodAgentsList, d.handleAgentsList)
 	srv.Handle(api.MethodSessionKill, d.handleSessionKill)
 	srv.Handle(api.MethodSessionFocus, d.handleSessionFocus)

--- a/internal/node/handlers_history.go
+++ b/internal/node/handlers_history.go
@@ -39,8 +39,10 @@ func (d *Node) handleHistorySessions(_ context.Context, params json.RawMessage) 
 			d.log.Warn("history sessions", "agent", a.Agent(), "err", err)
 			continue
 		}
+		_, _, resumable := a.ResumeCommand("")
 		for i := range page.Items {
 			page.Items[i].Agent = a.Agent()
+			page.Items[i].Resumable = resumable
 		}
 		all = append(all, page.Items...)
 	}

--- a/internal/node/handlers_history_test.go
+++ b/internal/node/handlers_history_test.go
@@ -106,3 +106,51 @@ func TestHandleHistoryTranscript_UnknownAgentID(t *testing.T) {
 		t.Fatal("expected error for unknown agent_id")
 	}
 }
+
+func TestHistorySessionsStampResumable(t *testing.T) {
+	// Seed a real Claude session under a temp HOME so the handler returns a
+	// non-empty page; every real adapter is resumable today, so each returned
+	// session must be stamped resumable. This asserts the stamping happens.
+	writeHistoryNestedFixture(t)
+	d := &Node{adapterList: []adapter.Adapter{claudecode.New()}}
+
+	pres, err := d.handleHistoryProjects(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleHistoryProjects: %v", err)
+	}
+	projects, ok := pres.([]session.HistoryProject)
+	if !ok {
+		t.Fatalf("expected []session.HistoryProject, got %T", pres)
+	}
+	var projectDir string
+	for _, p := range projects {
+		if p.SessionCount > 0 {
+			projectDir = p.ProjectDir
+			break
+		}
+	}
+	if projectDir == "" {
+		t.Fatal("fixture produced no project with sessions")
+	}
+
+	raw, err := json.Marshal(api.HistorySessionsParams{ProjectDir: projectDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := d.handleHistorySessions(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("handleHistorySessions: %v", err)
+	}
+	page, ok := res.(session.HistorySessionPage)
+	if !ok {
+		t.Fatalf("expected session.HistorySessionPage, got %T", res)
+	}
+	if len(page.Items) == 0 {
+		t.Fatal("expected at least one seeded session to exercise stamping")
+	}
+	for _, s := range page.Items {
+		if !s.Resumable {
+			t.Fatalf("session %q not stamped resumable", s.SessionID)
+		}
+	}
+}

--- a/internal/node/handlers_session.go
+++ b/internal/node/handlers_session.go
@@ -233,10 +233,6 @@ func (d *Node) handleSessionSpawn(ctx context.Context, params json.RawMessage) (
 			Message: "spawn unavailable: tmux not found on node " + d.label,
 		}
 	}
-	c := d.clients[session.TmuxServerArgus]
-	if p.Name == "" {
-		p.Name = spawn.SessionName(ctx, c, p.Cwd)
-	}
 	command, args := d.resolveSpawnCommand(p)
 	// Fail loudly rather than opening a tmux pane that dies "command not found".
 	if _, err := exec.LookPath(command); err != nil {
@@ -245,13 +241,115 @@ func (d *Node) handleSessionSpawn(ctx context.Context, params json.RawMessage) (
 			Message: fmt.Sprintf("cannot spawn: %q is not installed on node %s", command, d.label),
 		}
 	}
-	paneID, err := c.NewSession(ctx, tmux.NewSessionOpts{Name: p.Name, Cwd: p.Cwd, Command: command, Args: args})
+	paneID, err := d.launchPane(ctx, p.Name, command, args, p.Cwd)
 	if err != nil {
 		return nil, err
 	}
-	// Discovery will register it shortly; trigger a scan for immediacy.
-	go d.scan(context.Background())
 	return api.SpawnResult{SessionID: string(session.TmuxServerArgus) + ":" + paneID, PaneID: paneID}, nil
+}
+
+// launchPane opens a new tmux pane running command in cwd. A blank sessionName
+// gets a node-generated default. Discovery registers the pane shortly; a scan is
+// triggered for immediacy.
+func (d *Node) launchPane(ctx context.Context, sessionName, command string, args []string, cwd string) (string, error) {
+	c := d.clients[session.TmuxServerArgus]
+	if sessionName == "" {
+		sessionName = spawn.SessionName(ctx, c, cwd)
+	}
+	paneID, err := c.NewSession(ctx, tmux.NewSessionOpts{Name: sessionName, Cwd: cwd, Command: command, Args: args})
+	if err != nil {
+		return "", err
+	}
+	go d.scan(context.Background())
+	return paneID, nil
+}
+
+// resumeGraceWindow must outlast the discovery + agent-hook latency that
+// re-registers a resumed session under its own id, after which the registry check
+// takes over from the in-flight guard.
+var resumeGraceWindow = 30 * time.Second
+
+// handleSessionResume resumes a past session by its agent session id. If that
+// session is already running live (or a concurrent resume is launching it), it
+// returns that session rather than spawning a duplicate; otherwise it launches the
+// agent's resume command in the session's original cwd.
+func (d *Node) handleSessionResume(ctx context.Context, params json.RawMessage) (any, error) {
+	p, err := api.Decode[api.ResumeParams](params)
+	if err != nil {
+		return nil, err
+	}
+	if p.Agent == "" || p.AgentSessionID == "" {
+		return nil, &api.RPCError{
+			Code:    api.CodeInvalidRequest,
+			Message: "resume requires agent and agent_session_id",
+		}
+	}
+	// Resume must reopen in the session's original directory; an unknown cwd (e.g.
+	// some antigravity sessions) would launch the agent somewhere arbitrary.
+	if p.Cwd == "" {
+		return nil, &api.RPCError{
+			Code:    api.CodeInvalidRequest,
+			Message: "cannot resume: session working directory is unknown",
+		}
+	}
+	if !d.caps.SpawnSession {
+		return nil, &api.RPCError{
+			Code:    api.CodeInvalidRequest,
+			Message: "resume unavailable: tmux not found on node " + d.label,
+		}
+	}
+
+	key := p.Agent + "\x00" + p.AgentSessionID
+	d.resumeMu.Lock()
+	defer d.resumeMu.Unlock()
+
+	snap := d.reg.Snapshot()
+	// Jump to an already-live, controllable session with this agent session id.
+	for _, s := range snap {
+		if s.Agent == p.Agent && s.AgentSessionID == p.AgentSessionID && s.Controllable() {
+			return api.ResumeResult{SessionID: s.ID}, nil
+		}
+	}
+	// Don't relaunch while a prior resume of this session is in flight — a duplicate
+	// would race discovery. Jump to that pane if it's already live, else tell the
+	// caller to retry (a kill clears this guard immediately; see clearResuming).
+	if id, ok := d.resuming[key]; ok {
+		for _, s := range snap {
+			if s.ID == id && s.Controllable() {
+				return api.ResumeResult{SessionID: id}, nil
+			}
+		}
+		return nil, &api.RPCError{
+			Code:    api.CodeInvalidRequest,
+			Message: "session was resumed moments ago; wait a few seconds and try again",
+		}
+	}
+
+	name, args, ok := d.adapterFor(p.Agent).ResumeCommand(p.AgentSessionID)
+	if !ok {
+		return nil, &api.RPCError{
+			Code:    api.CodeInvalidRequest,
+			Message: "resume not supported for agent " + p.Agent,
+		}
+	}
+	if _, err := exec.LookPath(name); err != nil {
+		return nil, &api.RPCError{
+			Code:    api.CodeInvalidRequest,
+			Message: fmt.Sprintf("cannot resume: %q is not installed on node %s", name, d.label),
+		}
+	}
+	paneID, err := d.launchPane(ctx, "", name, args, p.Cwd)
+	if err != nil {
+		return nil, err
+	}
+	sid := string(session.TmuxServerArgus) + ":" + paneID
+	d.resuming[key] = sid
+	time.AfterFunc(resumeGraceWindow, func() {
+		d.resumeMu.Lock()
+		delete(d.resuming, key)
+		d.resumeMu.Unlock()
+	})
+	return api.ResumeResult{SessionID: sid}, nil
 }
 
 // handleSessionKill kills a session's pane.
@@ -267,6 +365,19 @@ func (d *Node) handleSessionKill(ctx context.Context, params json.RawMessage) (a
 	if err := c.KillPane(ctx, s.Tmux.PaneID); err != nil {
 		return nil, err
 	}
+	d.clearResuming(s.ID)
 	go d.scan(context.Background())
 	return nil, nil
+}
+
+// clearResuming drops sid's in-flight guard so a session killed inside the grace
+// window can be resumed again immediately.
+func (d *Node) clearResuming(sid string) {
+	d.resumeMu.Lock()
+	defer d.resumeMu.Unlock()
+	for k, v := range d.resuming {
+		if v == sid {
+			delete(d.resuming, k)
+		}
+	}
 }

--- a/internal/node/handlers_session_test.go
+++ b/internal/node/handlers_session_test.go
@@ -2,12 +2,14 @@ package node
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/registry"
 	"github.com/MunifTanjim/argus/internal/session"
 	"github.com/MunifTanjim/argus/internal/tmux"
 )
@@ -141,5 +143,119 @@ func TestHandleSessionSpawnRejectsMissingBinary(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "claude") {
 		t.Fatalf("error should name the missing binary, got %v", err)
+	}
+}
+
+func TestHandleSessionResumeRejectsNoTmux(t *testing.T) {
+	d := New()
+	d.caps.SpawnSession = false
+	d.label = "boxy"
+	raw, _ := json.Marshal(api.ResumeParams{Agent: "claude", AgentSessionID: "x", Cwd: t.TempDir()})
+	if _, err := d.handleSessionResume(context.Background(), raw); err == nil {
+		t.Fatal("expected error when tmux unavailable")
+	}
+}
+
+func TestHandleSessionResumeRejectsMissingBinary(t *testing.T) {
+	d := New()
+	d.caps.SpawnSession = true
+	d.label = "boxy"
+	t.Setenv("PATH", t.TempDir()) // no agent CLI installed
+	raw, _ := json.Marshal(api.ResumeParams{Agent: "claude", AgentSessionID: "x", Cwd: t.TempDir()})
+	if _, err := d.handleSessionResume(context.Background(), raw); err == nil {
+		t.Fatal("expected error when binary missing")
+	}
+}
+
+func TestHandleSessionResumeRejectsEmptyParams(t *testing.T) {
+	d := New()
+	d.caps.SpawnSession = true
+	for _, p := range []api.ResumeParams{
+		{Agent: "", AgentSessionID: "x", Cwd: t.TempDir()},
+		{Agent: "claude", AgentSessionID: "", Cwd: t.TempDir()},
+		{Agent: "claude", AgentSessionID: "x", Cwd: ""}, // unknown cwd
+	} {
+		raw, _ := json.Marshal(p)
+		if _, err := d.handleSessionResume(context.Background(), raw); err == nil {
+			t.Fatalf("expected error for empty params %+v", p)
+		}
+	}
+}
+
+func TestHandleSessionResumeJumpsToInflightLivePane(t *testing.T) {
+	d := New()
+	d.caps.SpawnSession = true
+	// A live pane exists under id "argus:%7" but its agent session id hasn't been
+	// reported yet, so the by-agent-session check misses and the guard is consulted.
+	d.reg.ReconcileSessions("claude", []registry.DiscoveredSession{{
+		HasPane:     true,
+		Server:      session.TmuxServerArgus,
+		PaneID:      "%7",
+		SessionName: "proj",
+		CurrentPath: t.TempDir(),
+	}})
+	d.resuming["claude\x00sess-1"] = "argus:%7"
+	raw, _ := json.Marshal(api.ResumeParams{Agent: "claude", AgentSessionID: "sess-1", Cwd: t.TempDir()})
+	res, err := d.handleSessionResume(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if r := res.(api.ResumeResult); r.SessionID != "argus:%7" {
+		t.Fatalf("got %#v, want in-flight session id argus:%%7", r)
+	}
+}
+
+func TestHandleSessionResumeErrorsWhenInflightPaneGone(t *testing.T) {
+	d := New()
+	d.caps.SpawnSession = true
+	d.resuming["claude\x00sess-1"] = "argus:%dead"
+	raw, _ := json.Marshal(api.ResumeParams{Agent: "claude", AgentSessionID: "sess-1", Cwd: t.TempDir()})
+	if _, err := d.handleSessionResume(context.Background(), raw); err == nil {
+		t.Fatal("expected error when the in-flight pane is gone")
+	}
+}
+
+func TestClearResumingOnKill(t *testing.T) {
+	d := New()
+	d.resuming["claude\x00sess-1"] = "argus:%7"
+	d.resuming["claude\x00sess-2"] = "argus:%8"
+	d.clearResuming("argus:%7")
+	if _, ok := d.resuming["claude\x00sess-1"]; ok {
+		t.Fatal("guard for the killed pane should be cleared")
+	}
+	if _, ok := d.resuming["claude\x00sess-2"]; !ok {
+		t.Fatal("guard for an unrelated pane must survive")
+	}
+}
+
+func TestHandleSessionResumeJumpsToLiveSession(t *testing.T) {
+	d := New()
+	d.caps.SpawnSession = true
+	// Seed a live, controllable session with a matching agent session id.
+	d.reg.ReconcileSessions("claude", []registry.DiscoveredSession{{
+		AgentSessionID: "live-1",
+		HasPane:        true,
+		Server:         session.TmuxServerArgus,
+		PaneID:         "%9",
+		SessionName:    "proj",
+		CurrentPath:    t.TempDir(),
+	}})
+	var live string
+	for _, s := range d.reg.Snapshot() {
+		if s.AgentSessionID == "live-1" {
+			live = s.ID
+		}
+	}
+	if live == "" {
+		t.Fatal("seed failed: no live session")
+	}
+	raw, _ := json.Marshal(api.ResumeParams{Agent: "claude", AgentSessionID: "live-1", Cwd: t.TempDir()})
+	res, err := d.handleSessionResume(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	r := res.(api.ResumeResult)
+	if r.SessionID != live {
+		t.Fatalf("got %#v, want SessionID=%q", r, live)
 	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -67,6 +67,12 @@ type Node struct {
 	// openMu serializes terminal.open so evict→setup→register is atomic; without it
 	// two concurrent opens of one session both register, defeating single-viewer.
 	openMu sync.Mutex
+
+	// Discovery registers a launched pane asynchronously, so a rapid second resume
+	// can't see the first pane yet; the guard returns the launching session rather
+	// than spawning a duplicate.
+	resumeMu sync.Mutex
+	resuming map[string]string // agent+session key -> launched session id
 }
 
 // SetLogger routes operational logging to l. Off by default so an embedded node
@@ -244,6 +250,7 @@ func newNode(clients map[session.TmuxServer]*tmux.Client) *Node {
 		conns:        map[api.Notifier]*connSubs{},
 		terms:        map[api.Notifier]*connTerms{},
 		sessionTerms: map[string]*term{},
+		resuming:     map[string]string{},
 	}
 	d.notifier = push.NewOSNotifier(nil, nil)
 	d.revealFn = func(ctx context.Context, c *tmux.Client, paneID string) error {

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -19,6 +19,7 @@ type HistoryProject struct {
 type HistorySession struct {
 	SessionID      string `json:"session_id"`
 	Agent          string `json:"agent,omitempty"`         // owning agent, stamped by the node
+	Resumable      bool   `json:"resumable,omitempty"`     // agent can resume this session by id
 	Title          string `json:"title,omitempty"`         // custom/AI title, when present
 	FirstMessage   string `json:"first_message,omitempty"` // first user message (title fallback)
 	TranscriptPath string `json:"transcript_path"`         // node-local path; routing key for the view

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -146,6 +146,7 @@ func (m model) actHistProjOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleHistorySessionsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	m.flash = "" // any key dismisses a transient flash; the action may re-set it
 	if mm, cmd, ok := m.dispatch(msg, historySessionsTable); ok {
 		return mm, cmd
 	}
@@ -160,6 +161,7 @@ var historySessionsTable = []keyTableEntry{
 	{historySessionsKeys.HalfUp, model.actHistSessHalfUp},
 	{historySessionsKeys.HalfDown, model.actHistSessHalfDown},
 	{historySessionsKeys.Open, model.actHistSessOpen},
+	{historySessionsKeys.Resume, model.actHistSessResume},
 	{historySessionsKeys.More, model.actHistSessMore},
 	{historySessionsKeys.Back, model.actHistSessBack},
 }
@@ -207,6 +209,22 @@ func (m model) actHistSessMore(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) actHistSessResume(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.history.sessCursor >= len(m.history.sessions) {
+		return m, nil
+	}
+	s := m.history.sessions[m.history.sessCursor]
+	if !s.Resumable {
+		m.flash = "resume not supported for this session"
+		return m, nil
+	}
+	if m.history.project.Cwd == "" {
+		m.flash = "resume unavailable: unknown working directory"
+		return m, nil
+	}
+	return m, m.resumeCmd(m.history.project.NodeID, s.Agent, s.SessionID, m.history.project.Cwd)
+}
+
 func (m model) actHistSessOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.history.sessCursor >= len(m.history.sessions) {
 		return m, nil
@@ -215,6 +233,7 @@ func (m model) actHistSessOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.history.title = historySessionTitle(s)
 	// Address for follow-up per-tool detail fetches on this transcript.
 	m.history.openNodeID, m.history.openPath, m.history.openAgent = m.history.project.NodeID, s.TranscriptPath, s.Agent
+	m.history.openSessionID, m.history.openResumable = s.SessionID, s.Resumable
 	m.transcript.chunks, m.transcript.err = nil, nil
 	m.transcript.cursor, m.transcript.scroll = 0, 0
 	m.transcript.detailStack = nil
@@ -227,6 +246,7 @@ func (m model) actHistSessOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleHistoryTranscriptKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	m.flash = "" // any key dismisses a transient flash; the action may re-set it
 	if key.Matches(msg, transcriptKeys.Back) {
 		if m.historyView == histDetail {
 			if m.popDetail() { // root frame → back to transcript
@@ -236,6 +256,17 @@ func (m model) handleHistoryTranscriptKey(msg tea.KeyPressMsg) (tea.Model, tea.C
 		}
 		m.mode = modeHistorySessions
 		return m, nil
+	}
+	if key.Matches(msg, transcriptKeys.Resume) && m.historyView == histTranscript {
+		if !m.history.openResumable {
+			m.flash = "resume not supported for this session"
+			return m, nil
+		}
+		if m.history.project.Cwd == "" {
+			m.flash = "resume unavailable: unknown working directory"
+			return m, nil
+		}
+		return m, m.resumeCmd(m.history.openNodeID, m.history.openAgent, m.history.openSessionID, m.history.project.Cwd)
 	}
 	if m.historyView == histDetail {
 		return m.handleDetailKey(msg)
@@ -292,12 +323,16 @@ func (m model) historySessionsView() string {
 		cards[i] = historySessionRow(s, i == m.history.sessCursor, cardW, showAgent)
 	}
 	body := renderCardList(cards, m.history.sessCursor, max(1, m.height-4))
-	binds := []key.Binding{historySessionsKeys.Up, historySessionsKeys.Bottom, historySessionsKeys.Open}
+	binds := []key.Binding{historySessionsKeys.Up, historySessionsKeys.Bottom, historySessionsKeys.Open, historySessionsKeys.Resume}
 	if m.history.hasMore {
 		binds = append(binds, historySessionsKeys.More)
 	}
 	binds = append(binds, historySessionsKeys.Back)
-	return pinFooter(centerBlock(title+"\n\n"+body, cardW, m.width), m.footer(binds...), m.width, m.height)
+	footer := m.footer(binds...)
+	if m.flash != "" {
+		footer = asstStyle.Render(m.flash)
+	}
+	return pinFooter(centerBlock(title+"\n\n"+body, cardW, m.width), footer, m.width, m.height)
 }
 
 // renderCardList lays out blank-line-separated cards, windowed to avail height
@@ -330,7 +365,10 @@ func (m model) historyTranscriptView() string {
 	header = centerBlock(indentBlock(header, strings.Repeat(" ", contentPadX)), m.containerWidth(), m.width)
 	body := m.historyBody() // reuses live transcript/detail renderers (read-only)
 	footer := m.footer(transcriptKeys.ScrollUp, transcriptKeys.TurnNext, transcriptKeys.Fold,
-		transcriptKeys.Detail, transcriptKeys.Bottom, transcriptKeys.Back)
+		transcriptKeys.Detail, transcriptKeys.Bottom, transcriptKeys.Resume, transcriptKeys.Back)
+	if m.flash != "" {
+		footer = asstStyle.Render(m.flash)
+	}
 	return pinFooter(header+"\n\n"+body, footer, m.width, m.height)
 }
 

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -4,10 +4,53 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/MunifTanjim/argus/internal/session"
 )
+
+func TestHistResumeGating(t *testing.T) {
+	m := model{}
+	m.history.project = session.HistoryProject{NodeID: "n1", Cwd: "/tmp/proj"}
+	m.history.sessions = []session.HistorySession{{SessionID: "s1", Agent: "claude", Resumable: false}}
+	m.history.sessCursor = 0
+	_, cmd := m.actHistSessResume(tea.KeyPressMsg{})
+	if cmd != nil {
+		t.Fatal("non-resumable session must not issue a resume command")
+	}
+	m.history.sessions[0].Resumable = true
+	if _, cmd := m.actHistSessResume(tea.KeyPressMsg{}); cmd == nil {
+		t.Fatal("resumable session must issue a resume command")
+	}
+}
+
+func TestHistResumeGatingUnknownCwd(t *testing.T) {
+	m := model{}
+	m.history.project = session.HistoryProject{NodeID: "n1", Cwd: ""} // unknown cwd
+	m.history.sessions = []session.HistorySession{{SessionID: "s1", Agent: "claude", Resumable: true}}
+	m.history.sessCursor = 0
+	mm, cmd := m.actHistSessResume(tea.KeyPressMsg{})
+	if cmd != nil {
+		t.Fatal("unknown-cwd session must not issue a resume command")
+	}
+	if !strings.Contains(mm.(model).flash, "working directory") {
+		t.Fatalf("expected unknown-cwd flash, got %q", mm.(model).flash)
+	}
+}
+
+func TestHistorySessionsViewShowsFlash(t *testing.T) {
+	m := model{width: 80, height: 24}
+	m.history.project = session.HistoryProject{Label: "proj", Cwd: "/tmp"}
+	m.history.sessions = []session.HistorySession{
+		{SessionID: "s1", Agent: "claude", LastActivity: "2026-01-01T00:00:00Z"},
+	}
+	m.flash = "resume unavailable: unknown working directory"
+	out := ansi.Strip(m.historySessionsView())
+	if !strings.Contains(out, "unknown working directory") {
+		t.Fatalf("flash not rendered in history sessions view:\n%s", out)
+	}
+}
 
 func TestHistorySessionRowShowsAgentWhenMixed(t *testing.T) {
 	s := session.HistorySession{SessionID: "s1", Agent: "codex", LastActivity: "2026-01-01T00:00:00Z"}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -67,7 +67,7 @@ var listKeys = struct {
 var transcriptKeys = struct {
 	ScrollUp, ScrollDown, TurnNext, TurnPrev, CardNext, CardPrev, HalfUp, HalfDown key.Binding
 	Top, Bottom, Fold, Detail, ExpandAll, CollapseAll                              key.Binding
-	Raw, Answer, Back                                                              key.Binding
+	Raw, Answer, Back, Resume                                                      key.Binding
 }{
 	ScrollUp:    nb([]string{"up"}, "↑/↓", "scroll"),
 	ScrollDown:  nb([]string{"down"}, "", ""),
@@ -86,6 +86,7 @@ var transcriptKeys = struct {
 	Raw:         nb([]string{"ctrl+s"}, "ctrl+s", "raw"),
 	Answer:      nb([]string{"tab"}, "tab", "answer"),
 	Back:        nb([]string{"esc", "escape", "q"}, "esc", "back"),
+	Resume:      nb([]string{"R"}, "R", "resume"),
 }
 
 var detailKeys = struct {
@@ -143,7 +144,7 @@ var historyProjectsKeys = struct {
 }
 
 var historySessionsKeys = struct {
-	Up, Down, Top, Bottom, HalfUp, HalfDown, Open, More, Back key.Binding
+	Up, Down, Top, Bottom, HalfUp, HalfDown, Open, More, Back, Resume key.Binding
 }{
 	Up:       nb([]string{"up", "k"}, "↑/↓", "move"),
 	Down:     nb([]string{"down", "j"}, "", ""),
@@ -154,6 +155,7 @@ var historySessionsKeys = struct {
 	Open:     nb([]string{"enter"}, "enter", "open"),
 	More:     nb([]string{"m"}, "m", "more"),
 	Back:     nb([]string{"esc", "escape", "q"}, "esc", "back"),
+	Resume:   nb([]string{"R"}, "R", "resume"),
 }
 
 var logsKeys = struct {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -52,6 +52,15 @@ type spawnAgentsMsg struct {
 
 // Successful spawns surface via registry events; only the error is acted on.
 type spawnResultMsg struct{ err error }
+
+type resumeResultMsg struct {
+	sessionID string
+	err       error
+}
+
+// clearPendingResumeMsg drops a still-pending resume selection so a stale id can't
+// later match a reused tmux pane id.
+type clearPendingResumeMsg struct{ id string }
 type logTickMsg struct{}    // embedded-node logs changed; wake the render loop
 type spinResumeMsg struct{} // periodic kick that re-arms the list spinner
 type spinTickMsg struct{}   // list spinner animation frame

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -104,8 +104,9 @@ type model struct {
 
 	prompt promptState // compose-then-submit draft for the prompt dock
 
-	pendingKill bool   // awaiting kill confirmation in list view
-	flash       string // transient list-view status (e.g. why a jump was refused)
+	pendingKill     bool   // awaiting kill confirmation in list view
+	pendingResumeID string // resumed session id to select once it appears in the list
+	flash           string // transient list-view status (e.g. why a jump was refused)
 
 	spawn spawnState // staged "new session" flow (node → dir → name → command)
 
@@ -150,9 +151,11 @@ type historyState struct {
 	loading    bool
 	title      string // header for the open historical transcript
 	// openNodeID/openPath/openAgent route per-tool detail fetches to the right adapter.
-	openNodeID string
-	openPath   string
-	openAgent  string // owning agent of the open transcript, for read routing
+	openNodeID    string
+	openPath      string
+	openAgent     string // owning agent of the open transcript, for read routing
+	openSessionID string // agent session id of the open transcript, for resume
+	openResumable bool   // whether the open session can be resumed
 }
 
 func newModel(client Client, hasDark bool, logs *logbuf.Buffer) model {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -18,6 +18,10 @@ import (
 	"github.com/MunifTanjim/argus/internal/tmux"
 )
 
+// resumeSelectTimeout bounds how long the list waits for a just-resumed session to
+// appear before dropping the pending auto-select (see clearPendingResumeMsg).
+const resumeSelectTimeout = 30 * time.Second
+
 func (m model) Init() tea.Cmd { return tea.Batch(m.refreshCmd(), spinResumeCmd()) }
 
 // spinResumeCmd re-arms the list spinner on a timer, so it resumes even when no
@@ -183,6 +187,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.flash = "spawn failed: " + msg.err.Error()
 		}
 		return m, nil
+	case resumeResultMsg:
+		if msg.err != nil {
+			m.flash = "resume failed: " + msg.err.Error()
+			return m, nil
+		}
+		m.mode = modeList
+		m.pendingResumeID = msg.sessionID
+		m.selectPendingResume()
+		if m.pendingResumeID == "" {
+			return m, nil
+		}
+		// Not in the list yet; time out the pending selection (see clearPendingResumeMsg).
+		id := m.pendingResumeID
+		return m, tea.Tick(resumeSelectTimeout, func(time.Time) tea.Msg {
+			return clearPendingResumeMsg{id: id}
+		})
+	case clearPendingResumeMsg:
+		if m.pendingResumeID == msg.id {
+			m.pendingResumeID = ""
+		}
+		return m, nil
 	case termOpenedMsg:
 		if msg.termID == m.termID && msg.err != nil {
 			m.termErr = msg.err
@@ -256,6 +281,17 @@ func (m model) spawnCmd(cwd, nodeID, agent, prompt string) tea.Cmd {
 			NodeID: nodeID, Cwd: cwd, Agent: agent, Prompt: prompt,
 		}, nil)
 		return spawnResultMsg{err: err} // a successful spawn surfaces via registry events
+	}
+}
+
+func (m model) resumeCmd(nodeID, agent, agentSessionID, cwd string) tea.Cmd {
+	client := m.client
+	return func() tea.Msg {
+		var res api.ResumeResult
+		err := client.Call(api.MethodSessionResume, api.ResumeParams{
+			NodeID: nodeID, Agent: agent, AgentSessionID: agentSessionID, Cwd: cwd,
+		}, &res)
+		return resumeResultMsg{sessionID: res.SessionID, err: err}
 	}
 }
 
@@ -397,6 +433,23 @@ func (m *model) reorder() {
 	})
 	if m.cursor >= len(m.order) {
 		m.cursor = max(0, len(m.order)-1)
+	}
+	m.selectPendingResume()
+}
+
+// selectPendingResume moves the list cursor onto a just-resumed session once it
+// is present in the ordered list, clearing the pending id. Freshly spawned
+// sessions arrive via registry events, which re-invoke this through reorder.
+func (m *model) selectPendingResume() {
+	if m.pendingResumeID == "" {
+		return
+	}
+	for i, id := range m.order {
+		if id == m.pendingResumeID {
+			m.cursor = i
+			m.pendingResumeID = ""
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
Adds the ability to resume a past session from the History tab, on both the TUI and the app.

- Resume relaunches the owning agent against the session's id in its original cwd. If that session is already running live, it jumps to it instead of spawning a duplicate.
- Per-adapter resume capability: claude (`--resume`), codex (`resume`), antigravity (`--conversation`). History sessions carry a `resumable` flag so the UI only offers it where supported.
- New `sessions.resume` RPC, routed by node like `sessions.spawn`. No prompt is sent — the resumed session comes up idle for the user to drive.
- TUI: `R` from the history session list and transcript view. App: a resume action on both history screens.

Tests cover the node handler (jump-to-live, missing tmux/binary), gateway routing, per-adapter commands, resumable stamping, and TUI gating.