### PR TITLE
feat: export, view offline, and redact shareable session files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.out
 coverage.*
 
+# Exported session bundles
+*.argus
+
 # Editor / OS
 .DS_Store
 

--- a/cmd/argus/config_guard_test.go
+++ b/cmd/argus/config_guard_test.go
@@ -26,6 +26,7 @@ func TestFlagsAreMappedToConfigKeys(t *testing.T) {
 		"timeout":       true, // `pair` only: device-connect wait
 		"agent":         true, // `hook` only: selects the adapter, not a config key
 		"argus-managed": true, // `hook` only: install marker, parsed and ignored
+		"redact":        true, // `view` only: offline viewer flag, not a node/client setting
 	}
 
 	seen := map[string]bool{}

--- a/cmd/argus/root.go
+++ b/cmd/argus/root.go
@@ -103,7 +103,7 @@ func newRootCmd(version string) *cobra.Command {
 
 	addClientFlags(cmd.Flags())
 
-	cmd.AddCommand(newStartCmd(version), newSpawnCmd(), newHooksCmd(), newHookCmd(), newPingCmd(), newPairCmd(), newUnpairCmd(), newFocusCmd(), newUpgradeCmd(), newConfigCmd())
+	cmd.AddCommand(newStartCmd(version), newSpawnCmd(), newHooksCmd(), newHookCmd(), newPingCmd(), newPairCmd(), newUnpairCmd(), newFocusCmd(), newUpgradeCmd(), newConfigCmd(), newViewCmd())
 
 	cmd.InitDefaultCompletionCmd()
 	if subcmd, _, _ := cmd.Find([]string{"completion"}); subcmd != nil && subcmd.Name() == "completion" {

--- a/cmd/argus/view.go
+++ b/cmd/argus/view.go
@@ -10,11 +10,15 @@ import (
 
 // newViewCmd builds the `argus view <file.argus>` offline bundle-viewer command.
 func newViewCmd() *cobra.Command {
+	var redact bool
 	cmd := &cobra.Command{
 		Use:   "view <file.argus>",
 		Short: "View an exported session bundle offline",
 		Long: `Opens an exported .argus session bundle in an offline viewer.
 No running argus node, gateway, or config file is required.
+
+With --redact, queue secrets in the viewer (press d) and write a scrubbed
+<name>-redacted.argus copy; the original bundle is left untouched.
 
 Note: .argus files contain the session's raw transcript data, including full
 tool input and output. Share them only with people you trust.`,
@@ -26,11 +30,12 @@ tool input and output. Share them only with people you trust.`,
 			if _, err := os.Stat(path); err != nil {
 				return fail(cmd, err)
 			}
-			if err := tui.RunBundle(path); err != nil {
+			if err := tui.RunBundle(path, redact); err != nil {
 				return fail(cmd, err)
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&redact, "redact", false, "enable interactive redaction, writing a scrubbed copy")
 	return cmd
 }

--- a/cmd/argus/view.go
+++ b/cmd/argus/view.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MunifTanjim/argus/internal/tui"
+)
+
+// newViewCmd builds the `argus view <file.argus>` offline bundle-viewer command.
+func newViewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view <file.argus>",
+		Short: "View an exported session bundle offline",
+		Long: `Opens an exported .argus session bundle in an offline viewer.
+No running argus node, gateway, or config file is required.
+
+Note: .argus files contain the session's raw transcript data, including full
+tool input and output. Share them only with people you trust.`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			if _, err := os.Stat(path); err != nil {
+				return fail(cmd, err)
+			}
+			if err := tui.RunBundle(path); err != nil {
+				return fail(cmd, err)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/argus/view_test.go
+++ b/cmd/argus/view_test.go
@@ -25,3 +25,14 @@ func TestViewCmdRejectsGarbage(t *testing.T) {
 		t.Fatal("expected error for non-gzip file")
 	}
 }
+
+func TestViewCmdRedactFlag(t *testing.T) {
+	cmd := newViewCmd()
+	f := cmd.Flags().Lookup("redact")
+	if f == nil {
+		t.Fatal("view command should define a --redact flag")
+	}
+	if f.Value.Type() != "bool" {
+		t.Fatalf("--redact should be a bool, got %s", f.Value.Type())
+	}
+}

--- a/cmd/argus/view_test.go
+++ b/cmd/argus/view_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestViewCmdRejectsMissingFile(t *testing.T) {
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{filepath.Join(t.TempDir(), "nope.argus")})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestViewCmdRejectsGarbage(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "bad.argus")
+	if err := os.WriteFile(f, []byte("not a gzip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{f})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for non-gzip file")
+	}
+}

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -5,6 +5,8 @@ package adapter
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
+	"strings"
 
 	"github.com/MunifTanjim/argus/internal/api"
 	"github.com/MunifTanjim/argus/internal/registry"
@@ -12,6 +14,38 @@ import (
 	"github.com/MunifTanjim/argus/internal/tmux"
 	"github.com/MunifTanjim/argus/internal/transcript"
 )
+
+// BundleRoot is the archive subtree every bundled file is rooted under.
+const BundleRoot = "root"
+
+// BundledFile pairs a source file on disk with its path inside an export bundle.
+type BundledFile struct {
+	AbsPath string // source path on disk
+	RelPath string // path within the bundle (slash-separated, rooted at BundleRoot)
+}
+
+// RootedFile pairs p with its path inside an export bundle, rooted under
+// BundleRoot relative to home. ok is false when p escapes home.
+func RootedFile(home, p string) (BundledFile, bool) {
+	rel, err := filepath.Rel(home, p)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return BundledFile{}, false
+	}
+	return BundledFile{
+		AbsPath: p,
+		RelPath: filepath.ToSlash(filepath.Join(BundleRoot, rel)),
+	}, true
+}
+
+// WithinDir reports whether p lies inside dir (cleaned paths only, no symlink
+// resolution), confining an export entry to its session subtree.
+func WithinDir(dir, p string) bool {
+	rel, err := filepath.Rel(dir, p)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
 
 // HookMethod is the JSON-RPC method every argus hook invocation calls.
 const HookMethod = "hook.event"
@@ -73,6 +107,10 @@ type Adapter interface {
 	FormatDecision(toolName string, toolInput json.RawMessage, p api.RespondParams) string
 	// HookOutput returns stdout for an unblocked hook. "" means print nothing.
 	HookOutput(ev HookEvent) string
+
+	// CollectSessionFiles returns every on-disk file the session consists of
+	// (transcript, subagents, team members, tasks, config). Vanished optionals are skipped.
+	CollectSessionFiles(transcriptPath string) ([]BundledFile, error)
 
 	ReadTranscriptView(path string) (transcript.TranscriptView, error)
 	ReadSubagentView(rootPath, agentID string) (transcript.TranscriptView, bool, error)

--- a/internal/adapter/antigravity/adapter.go
+++ b/internal/adapter/antigravity/adapter.go
@@ -59,6 +59,10 @@ func (agAdapter) FormatDecision(toolName string, toolInput json.RawMessage, p ap
 
 func (agAdapter) HookOutput(ev adapter.HookEvent) string { return HookOutput(EventName(ev)) }
 
+func (agAdapter) CollectSessionFiles(transcriptPath string) ([]adapter.BundledFile, error) {
+	return collectSessionFiles(transcriptPath)
+}
+
 func (agAdapter) ReadTranscriptView(path string) (transcript.TranscriptView, error) {
 	return ReadTranscriptView(path)
 }

--- a/internal/adapter/antigravity/collect.go
+++ b/internal/adapter/antigravity/collect.go
@@ -1,0 +1,75 @@
+package antigravity
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/MunifTanjim/argus/internal/adapter"
+)
+
+// collectSessionFiles gathers the main transcript plus every transitively invoked
+// subagent's transcript and conversation db, rooted under the antigravity home so
+// subagents resolve offline.
+func collectSessionFiles(transcriptPath string) ([]adapter.BundledFile, error) {
+	abs, err := filepath.Abs(transcriptPath)
+	if err != nil {
+		return nil, err
+	}
+	home, err := homeDir()
+	if err != nil {
+		return nil, err
+	}
+	home, _ = filepath.Abs(home)
+
+	// The entry must be a real conversation transcript under <home>/brain, not any
+	// other readable file; everything else is derived from it.
+	if !adapter.WithinDir(filepath.Join(home, "brain"), abs) || filepath.Base(abs) != "transcript_full.jsonl" {
+		return nil, fmt.Errorf("collect: %s is not a session transcript", abs)
+	}
+	if info, err := os.Lstat(abs); err != nil {
+		return nil, err
+	} else if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("collect: %s is not a regular file", abs)
+	}
+
+	var out []adapter.BundledFile
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		// Lstat, not Stat: skip symlinks whose target could sit outside home.
+		if info, err := os.Lstat(p); err != nil || !info.Mode().IsRegular() {
+			return
+		}
+		if bf, ok := adapter.RootedFile(home, p); ok {
+			out = append(out, bf)
+		}
+	}
+
+	seen := make(map[string]bool)
+	var walk func(convID, tpath string)
+	walk = func(convID, tpath string) {
+		if convID == "" || seen[convID] {
+			return
+		}
+		seen[convID] = true
+		add(tpath)
+		add(conversationDBPath(convID))
+		chunks, err := parseTranscript(tpath)
+		if err != nil {
+			return
+		}
+		for _, c := range chunks {
+			for _, it := range c.Items {
+				for _, sub := range it.Subagents {
+					if sub.ID != "" {
+						walk(sub.ID, transcriptPathFor(sub.ID))
+					}
+				}
+			}
+		}
+	}
+	walk(convIDFromPath(abs), abs)
+	return out, nil
+}

--- a/internal/adapter/antigravity/collect_test.go
+++ b/internal/adapter/antigravity/collect_test.go
@@ -1,0 +1,74 @@
+package antigravity
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeBrainTranscriptAt(t *testing.T, home, convID, body string) string {
+	t.Helper()
+	dir := filepath.Join(home, "brain", convID, ".system_generated", "logs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "transcript_full.jsonl")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCollectSessionFilesIncludesSubagents(t *testing.T) {
+	home := t.TempDir()
+	homeDirOverride = home
+	t.Cleanup(func() { homeDirOverride = "" })
+
+	const childID = "acec302c-335c-46b5-b75a-4d7695c26a3c"
+	parentBody := `{"type":"PLANNER_RESPONSE","source":"MODEL","tool_calls":[{"name":"invoke_subagent","args":{"toolSummary":"Run subagent","Subagents":[{"name":"test_subagent","TypeName":"General"}]}}],"step_index":0}` + "\n" +
+		`{"type":"INVOKE_SUBAGENT","source":"MODEL","content":` + jsonQuote(invokeResult) + `,"step_index":1}` + "\n"
+	parent := writeBrainTranscriptAt(t, home, "parent-conv", parentBody)
+	writeBrainTranscriptAt(t, home, childID, `{"type":"USER_INPUT","content":"<USER_REQUEST>\nGo\n</USER_REQUEST>","step_index":0}`+"\n")
+
+	files, err := collectSessionFiles(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("want 2 transcripts (parent + child), got %d: %+v", len(files), files)
+	}
+	var haveChild bool
+	for _, f := range files {
+		if !strings.HasPrefix(f.RelPath, "root/brain/") {
+			t.Fatalf("RelPath %q not rooted under root/brain/", f.RelPath)
+		}
+		if strings.Contains(f.RelPath, childID) {
+			haveChild = true
+		}
+	}
+	if !haveChild {
+		t.Fatalf("child transcript not collected: %+v", files)
+	}
+}
+
+// TestSubagentFilePathRootRelative verifies resolution follows the passed rootPath
+// (an extracted bundle), not the live antigravity home.
+func TestSubagentFilePathRootRelative(t *testing.T) {
+	liveHome := t.TempDir() // live home has no matching child
+	homeDirOverride = liveHome
+	t.Cleanup(func() { homeDirOverride = "" })
+
+	const childID = "acec302c-335c-46b5-b75a-4d7695c26a3c"
+	bundleHome := t.TempDir()
+	child := writeBrainTranscriptAt(t, bundleHome, childID, `{"type":"USER_INPUT","content":"hi","step_index":0}`+"\n")
+	entry := writeBrainTranscriptAt(t, bundleHome, "main-conv", `{"type":"USER_INPUT","content":"hi","step_index":0}`+"\n")
+
+	p, ok := SubagentFilePath(entry, childID)
+	if !ok || p != child {
+		t.Fatalf("SubagentFilePath = (%q, %v), want (%q, true) from bundle root", p, ok, child)
+	}
+	if _, ok := SubagentFilePath("", childID); ok {
+		t.Fatal("empty root must not resolve against the (childless) live home")
+	}
+}

--- a/internal/adapter/antigravity/convdb.go
+++ b/internal/adapter/antigravity/convdb.go
@@ -18,7 +18,16 @@ var modelSlugRe = regexp.MustCompile(`(?i)(?:gpt-oss|gpt|gemini|claude|grok|llam
 // on-disk source (transcript_full.jsonl carries none). Uses executor_metadata
 // (gen_metadata holds a placeholder enum for some families).
 func conversationModel(convID string) (name, color string) {
-	path := conversationDBPath(convID)
+	return conversationModelAt(conversationDBPath(convID))
+}
+
+// conversationModelIn reads the model from a conversation db under an explicit
+// home (an extracted bundle), instead of the live home.
+func conversationModelIn(home, convID string) (name, color string) {
+	return conversationModelAt(conversationDBPathIn(home, convID))
+}
+
+func conversationModelAt(path string) (name, color string) {
 	if path == "" {
 		return "", ""
 	}

--- a/internal/adapter/antigravity/paths.go
+++ b/internal/adapter/antigravity/paths.go
@@ -51,20 +51,60 @@ func sub(name string) (string, error) {
 // transcriptPathFor returns a conversation's transcript_full.jsonl path. Empty when
 // convID is blank/unsafe. The file need not exist.
 func transcriptPathFor(convID string) string {
-	dir, err := brainDir()
-	if err != nil || !safeConvID(convID) {
+	dir, err := homeDir()
+	if err != nil {
 		return ""
 	}
-	return filepath.Join(dir, convID, ".system_generated", "logs", "transcript_full.jsonl")
+	return transcriptPathForIn(dir, convID)
+}
+
+// transcriptPathForIn resolves a conversation's transcript under an explicit home
+// (e.g. an extracted bundle root), instead of the live ~/.gemini/antigravity-cli.
+func transcriptPathForIn(home, convID string) string {
+	if home == "" || !safeConvID(convID) {
+		return ""
+	}
+	return filepath.Join(home, "brain", convID, ".system_generated", "logs", "transcript_full.jsonl")
 }
 
 // conversationDBPath returns a conversation's sqlite db path. Empty when convID is blank/unsafe.
 func conversationDBPath(convID string) string {
 	dir, err := homeDir()
-	if err != nil || !safeConvID(convID) {
+	if err != nil {
 		return ""
 	}
-	return filepath.Join(dir, "conversations", convID+".db")
+	return conversationDBPathIn(dir, convID)
+}
+
+func conversationDBPathIn(home, convID string) string {
+	if home == "" || !safeConvID(convID) {
+		return ""
+	}
+	return filepath.Join(home, "conversations", convID+".db")
+}
+
+// homeFromBrainPath derives the antigravity home from a transcript path laid out
+// as <home>/brain/<convID>/...; empty when the path has no brain segment.
+func homeFromBrainPath(p string) string {
+	parts := strings.Split(filepath.ToSlash(p), "/")
+	for i, seg := range parts {
+		if seg == "brain" {
+			return filepath.FromSlash(strings.Join(parts[:i], "/"))
+		}
+	}
+	return ""
+}
+
+// resolveHome picks the antigravity home for resolution: derived from rootPath
+// (an extracted bundle) when possible, else the live home.
+func resolveHome(rootPath string) string {
+	if h := homeFromBrainPath(rootPath); h != "" {
+		return h
+	}
+	if dir, err := homeDir(); err == nil {
+		return dir
+	}
+	return ""
 }
 
 func safeConvID(convID string) bool {

--- a/internal/adapter/antigravity/subagent.go
+++ b/internal/adapter/antigravity/subagent.go
@@ -30,7 +30,16 @@ func subagentChildID(resultContent string) string {
 
 // childTranscriptPath resolves a subagent's transcript_full.jsonl. ok is false when missing.
 func childTranscriptPath(convID string) (string, bool) {
-	p := transcriptPathFor(convID)
+	dir, err := homeDir()
+	if err != nil {
+		return "", false
+	}
+	return childTranscriptPathIn(dir, convID)
+}
+
+// childTranscriptPathIn resolves a subagent's transcript under an explicit home.
+func childTranscriptPathIn(home, convID string) (string, bool) {
+	p := transcriptPathForIn(home, convID)
 	if p == "" {
 		return "", false
 	}

--- a/internal/adapter/antigravity/transcript.go
+++ b/internal/adapter/antigravity/transcript.go
@@ -13,13 +13,27 @@ func ReadTranscriptView(path string) (transcript.TranscriptView, error) {
 	if err != nil {
 		return transcript.TranscriptView{}, err
 	}
-	stampChunkModel(chunks, convIDFromPath(path))
+	home := resolveHome(path)
+	name, color := conversationModelIn(home, convIDFromPath(path))
+	stampChunkModelWith(chunks, name, color)
+	stampSubagentTrace(chunks, home)
 	return transcript.TranscriptView{Chunks: chunks}, nil
 }
 
-func stampChunkModel(chunks []transcript.Chunk, convID string) {
-	name, color := conversationModel(convID)
-	stampChunkModelWith(chunks, name, color)
+// stampSubagentTrace recomputes each subagent's HasTrace against home, correcting
+// linkSubagent's live-home resolution for a bundle extracted under a temp dir.
+func stampSubagentTrace(chunks []transcript.Chunk, home string) {
+	for i := range chunks {
+		for j := range chunks[i].Items {
+			for k := range chunks[i].Items[j].Subagents {
+				sub := &chunks[i].Items[j].Subagents[k]
+				if sub.ID == "" {
+					continue
+				}
+				_, sub.HasTrace = childTranscriptPathIn(home, sub.ID)
+			}
+		}
+	}
 }
 
 func stampChunkModelWith(chunks []transcript.Chunk, name, color string) {
@@ -35,11 +49,12 @@ func stampChunkModelWith(chunks []transcript.Chunk, name, color string) {
 }
 
 func SubagentFilePath(rootPath, agentID string) (string, bool) {
-	return childTranscriptPath(agentID)
+	return childTranscriptPathIn(resolveHome(rootPath), agentID)
 }
 
 func ReadSubagentView(rootPath, agentID string) (transcript.TranscriptView, bool, error) {
-	path, ok := childTranscriptPath(agentID)
+	home := resolveHome(rootPath)
+	path, ok := childTranscriptPathIn(home, agentID)
 	if !ok {
 		return transcript.TranscriptView{}, false, nil
 	}
@@ -47,7 +62,9 @@ func ReadSubagentView(rootPath, agentID string) (transcript.TranscriptView, bool
 	if err != nil {
 		return transcript.TranscriptView{}, false, err
 	}
-	stampChunkModel(chunks, agentID)
+	name, color := conversationModelIn(home, agentID)
+	stampChunkModelWith(chunks, name, color)
+	stampSubagentTrace(chunks, home)
 	return transcript.TranscriptView{Chunks: chunks}, true, nil
 }
 
@@ -55,7 +72,7 @@ func ReadSubagentView(rootPath, agentID string) (transcript.TranscriptView, bool
 // Empty agentID searches path itself.
 func FindToolDetail(path, agentID, toolID string) (transcript.ToolDetail, bool, error) {
 	if agentID != "" {
-		p, ok := childTranscriptPath(agentID)
+		p, ok := childTranscriptPathIn(resolveHome(path), agentID)
 		if !ok {
 			return transcript.ToolDetail{}, false, nil
 		}
@@ -80,6 +97,7 @@ func FindToolDetail(path, agentID, toolID string) (transcript.ToolDetail, bool, 
 type streamingTranscript struct {
 	path       string
 	convID     string
+	home       string
 	offset     int64
 	loaded     bool
 	lines      []line
@@ -109,16 +127,21 @@ func (s *streamingTranscript) Refresh() ([]transcript.Chunk, error) {
 
 	// Re-query while empty: the model may land in the DB mid-session.
 	if s.modelName == "" {
-		s.modelName, s.modelColor = conversationModel(s.convID)
+		s.modelName, s.modelColor = conversationModelIn(s.home, s.convID)
 	}
 	chunks := foldTranscript(s.lines)
 	stampChunkModelWith(chunks, s.modelName, s.modelColor)
+	stampSubagentTrace(chunks, s.home)
 	s.chunks = chunks
 	return s.chunks, nil
 }
 
 func NewStreamingTranscript(path, rootPath string, isSubagent bool) adapter.StreamingTranscript {
-	return &streamingTranscript{path: path, convID: convIDFromPath(path)}
+	home := resolveHome(rootPath)
+	if home == "" {
+		home = resolveHome(path)
+	}
+	return &streamingTranscript{path: path, convID: convIDFromPath(path), home: home}
 }
 
 func ListHistoryProjects() ([]session.HistoryProject, error) { return listHistoryProjects() }

--- a/internal/adapter/claudecode/adapter.go
+++ b/internal/adapter/claudecode/adapter.go
@@ -62,6 +62,10 @@ func (ccAdapter) FormatDecision(toolName string, toolInput json.RawMessage, p ap
 
 func (ccAdapter) HookOutput(adapter.HookEvent) string { return "" }
 
+func (ccAdapter) CollectSessionFiles(transcriptPath string) ([]adapter.BundledFile, error) {
+	return collectSessionFiles(transcriptPath, claudeHome())
+}
+
 func (ccAdapter) ReadTranscriptView(path string) (transcript.TranscriptView, error) {
 	return ReadTranscriptView(path)
 }

--- a/internal/adapter/claudecode/collect.go
+++ b/internal/adapter/claudecode/collect.go
@@ -1,0 +1,94 @@
+package claudecode
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MunifTanjim/argus/internal/adapter"
+	"github.com/MunifTanjim/argus/internal/adapter/claudecode/parser"
+)
+
+// claudeHome returns the ~/.claude root that a project transcript path lives
+// under (…/.claude/projects/<proj>/<uuid>.jsonl → …/.claude).
+func claudeHome() string {
+	if h, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(h, ".claude")
+	}
+	return ""
+}
+
+// collectSessionFiles gathers the session's files rooted under home (the
+// ~/.claude dir), returning bundle-relative paths under "root/".
+func collectSessionFiles(transcriptPath, home string) ([]adapter.BundledFile, error) {
+	if home == "" {
+		return nil, fmt.Errorf("collect: cannot determine ~/.claude home")
+	}
+
+	abs, err := filepath.Abs(transcriptPath)
+	if err != nil {
+		return nil, err
+	}
+	home, _ = filepath.Abs(home)
+
+	// The entry must be a real session transcript under <home>/projects, not any
+	// other readable file (e.g. credentials); everything else is derived from it.
+	if !adapter.WithinDir(filepath.Join(home, "projects"), abs) || !strings.HasSuffix(abs, ".jsonl") {
+		return nil, fmt.Errorf("collect: %s is not a session transcript", abs)
+	}
+
+	var out []adapter.BundledFile
+	addRel := func(p string) {
+		if bf, ok := adapter.RootedFile(home, p); ok {
+			out = append(out, bf)
+		}
+	}
+	add := func(p string) {
+		// Lstat, not Stat: skip symlinks, whose target could sit outside home.
+		if info, err := os.Lstat(p); err == nil && info.Mode().IsRegular() {
+			addRel(p)
+		}
+	}
+	addTree := func(dir string) {
+		filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error { //nolint:errcheck
+			if err == nil && d.Type().IsRegular() { // skip dirs and symlinks
+				addRel(p)
+			}
+			return nil
+		})
+	}
+
+	// Main transcript (required); must be a regular file (see add).
+	if info, err := os.Lstat(abs); err != nil {
+		return nil, err
+	} else if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("collect: %s is not a regular file", abs)
+	}
+	addRel(abs)
+
+	// Subagents dir: <projects>/<proj>/<uuid>/subagents/*
+	base := strings.TrimSuffix(filepath.Base(abs), ".jsonl")
+	addTree(filepath.Join(filepath.Dir(abs), base, "subagents"))
+
+	// Team member sessions: sibling top-level .jsonl created by team Task calls.
+	if chunks, err := parser.ReadSession(abs); err == nil {
+		if procs, err := parser.DiscoverTeamSessions(abs, chunks); err == nil {
+			for _, p := range procs {
+				if p.FilePath != "" {
+					add(p.FilePath)
+				}
+			}
+		}
+	}
+
+	// tasks/ and teams/ dirs, keyed by session-<shortid> (first UUID segment).
+	short := base
+	if i := strings.IndexByte(short, '-'); i > 0 {
+		short = short[:i]
+	}
+	addTree(filepath.Join(home, "tasks", "session-"+short))
+	addTree(filepath.Join(home, "teams", "session-"+short))
+
+	return out, nil
+}

--- a/internal/adapter/claudecode/collect_test.go
+++ b/internal/adapter/claudecode/collect_test.go
@@ -1,0 +1,215 @@
+package claudecode
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// parentJSONL is a minimal assistant entry that spawns one team member via Task.
+const parentJSONL = `{"uuid":"a1","type":"assistant","timestamp":"2025-06-15T10:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Task","input":{"subagent_type":"general-purpose","description":"Do work","team_name":"myteam","name":"worker"}}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":100,"output_tokens":10,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}
+`
+
+// memberJSONL has teamName+agentName in first line (required by ReadTeamSessionMeta)
+// and an assistant entry so readSubagentSession returns a non-empty chunk slice.
+const memberJSONL = `{"uuid":"m1","type":"user","teamName":"myteam","agentName":"worker","timestamp":"2025-06-15T10:00:01Z","message":{"role":"user","content":"Do work"}}
+{"uuid":"m2","type":"assistant","timestamp":"2025-06-15T10:00:05Z","message":{"role":"assistant","content":[{"type":"text","text":"Done."}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":50,"output_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}
+`
+
+func TestCollectSessionFiles(t *testing.T) {
+	home := t.TempDir()
+	projects := filepath.Join(home, "projects", "-proj")
+	uuid := "bd9d953d-3545-4c85-91c2-049ea8c71743"
+	short := "bd9d953d"
+
+	mkfile := func(p string) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	main := filepath.Join(projects, uuid+".jsonl")
+	mkfile(main)
+	mkfile(filepath.Join(projects, uuid, "subagents", "agent-a.jsonl"))
+	mkfile(filepath.Join(projects, uuid, "subagents", "agent-a.meta.json"))
+	mkfile(filepath.Join(home, "tasks", "session-"+short, "1.json"))
+	mkfile(filepath.Join(home, "teams", "session-"+short, "config.json"))
+
+	files, err := collectSessionFiles(main, home)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range files {
+		got[filepath.ToSlash(f.RelPath)] = true
+	}
+	want := []string{
+		"root/projects/-proj/" + uuid + ".jsonl",
+		"root/projects/-proj/" + uuid + "/subagents/agent-a.jsonl",
+		"root/projects/-proj/" + uuid + "/subagents/agent-a.meta.json",
+		"root/tasks/session-" + short + "/1.json",
+		"root/teams/session-" + short + "/config.json",
+	}
+	sort.Strings(want)
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("missing %s (got %v)", w, got)
+		}
+	}
+	// The entry (main transcript) must be present with its expected RelPath.
+	entry := "root/projects/-proj/" + uuid + ".jsonl"
+	if !got[entry] {
+		t.Errorf("entry %s not collected", entry)
+	}
+}
+
+func TestCollectSessionFilesSkipsMissingOptional(t *testing.T) {
+	home := t.TempDir()
+	projects := filepath.Join(home, "projects", "-proj")
+	uuid := "abc12345-0000-0000-0000-000000000000"
+	main := filepath.Join(projects, uuid+".jsonl")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(main, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files, err := collectSessionFiles(main, home)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("want only main transcript, got %d: %v", len(files), files)
+	}
+}
+
+func TestCollectSessionFilesEmptyHome(t *testing.T) {
+	_, err := collectSessionFiles("/some/path.jsonl", "")
+	if err == nil {
+		t.Fatal("expected error for empty home, got nil")
+	}
+}
+
+// A path readable under ~/.claude but outside projects/ (e.g. a credentials file)
+// must be rejected: export is for sessions, not arbitrary home files.
+func TestCollectSessionFilesRejectsNonSessionPath(t *testing.T) {
+	home := t.TempDir()
+	secret := filepath.Join(home, ".credentials.json")
+	if err := os.WriteFile(secret, []byte(`{"token":"s3cret"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := collectSessionFiles(secret, home); err == nil {
+		t.Fatal("expected rejection of a non-session path, got nil")
+	}
+
+	// A .jsonl directly under home (not under projects/) is also not a session.
+	stray := filepath.Join(home, "stray.jsonl")
+	if err := os.WriteFile(stray, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := collectSessionFiles(stray, home); err == nil {
+		t.Fatal("expected rejection of a .jsonl outside projects/, got nil")
+	}
+}
+
+// A symlink planted in the session tree must not be followed to its target's
+// bytes, which could live outside home.
+func TestCollectSessionFilesSkipsSymlinks(t *testing.T) {
+	home := t.TempDir()
+	projects := filepath.Join(home, "projects", "-proj")
+	uuid := "sym12345-0000-0000-0000-000000000000"
+	if err := os.MkdirAll(filepath.Join(projects, uuid, "subagents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	main := filepath.Join(projects, uuid+".jsonl")
+	if err := os.WriteFile(main, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A subagent-dir entry symlinked to a file outside home.
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("s3cret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(projects, uuid, "subagents", "evil.jsonl")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	files, err := collectSessionFiles(main, home)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	for _, f := range files {
+		if strings.Contains(f.RelPath, "evil.jsonl") {
+			t.Fatalf("symlink was collected: %+v", files)
+		}
+	}
+}
+
+// The entry itself being a symlink is rejected outright (fail closed).
+func TestCollectSessionFilesRejectsSymlinkEntry(t *testing.T) {
+	home := t.TempDir()
+	projects := filepath.Join(home, "projects", "-proj")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("s3cret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entry := filepath.Join(projects, "link.jsonl")
+	if err := os.Symlink(outside, entry); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := collectSessionFiles(entry, home); err == nil {
+		t.Fatal("expected rejection of a symlinked entry, got nil")
+	}
+}
+
+// TestCollectSessionFilesTeamMember covers the team-member path with real
+// fixtures, so DiscoverTeamSessions and the parser run end-to-end (no seams).
+func TestCollectSessionFilesTeamMember(t *testing.T) {
+	home := t.TempDir()
+	projects := filepath.Join(home, "projects", "-proj")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parent transcript: valid JSONL with a Task tool spawning a team member.
+	parentUUID := "cc000001-0000-0000-0000-000000000000"
+	main := filepath.Join(projects, parentUUID+".jsonl")
+	if err := os.WriteFile(main, []byte(parentJSONL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Team member file: sibling .jsonl in the same project dir.
+	// First line carries teamName+agentName so ReadTeamSessionMeta recognises it.
+	memberFile := filepath.Join(projects, "worker-session.jsonl")
+	if err := os.WriteFile(memberFile, []byte(memberJSONL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := collectSessionFiles(main, home)
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, f := range files {
+		got[filepath.ToSlash(f.RelPath)] = true
+	}
+
+	wantMember := "root/projects/-proj/worker-session.jsonl"
+	if !got[wantMember] {
+		t.Errorf("team member file not collected; want %s, got %v", wantMember, got)
+	}
+	wantParent := "root/projects/-proj/" + parentUUID + ".jsonl"
+	if !got[wantParent] {
+		t.Errorf("parent transcript not collected; want %s, got %v", wantParent, got)
+	}
+}

--- a/internal/adapter/codex/adapter.go
+++ b/internal/adapter/codex/adapter.go
@@ -59,6 +59,10 @@ func (cxAdapter) FormatDecision(toolName string, toolInput json.RawMessage, p ap
 
 func (cxAdapter) HookOutput(adapter.HookEvent) string { return "" }
 
+func (cxAdapter) CollectSessionFiles(transcriptPath string) ([]adapter.BundledFile, error) {
+	return collectSessionFiles(transcriptPath)
+}
+
 func (cxAdapter) ReadTranscriptView(path string) (transcript.TranscriptView, error) {
 	return ReadTranscriptView(path)
 }

--- a/internal/adapter/codex/collect.go
+++ b/internal/adapter/codex/collect.go
@@ -1,0 +1,68 @@
+package codex
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MunifTanjim/argus/internal/adapter"
+)
+
+// collectSessionFiles gathers the main rollout and every transitively spawned
+// subagent rollout, rooted under ~/.codex so subagents resolve offline.
+func collectSessionFiles(transcriptPath string) ([]adapter.BundledFile, error) {
+	abs, err := filepath.Abs(transcriptPath)
+	if err != nil {
+		return nil, err
+	}
+	home, err := codexHome()
+	if err != nil {
+		return nil, err
+	}
+	home, _ = filepath.Abs(home)
+
+	// The entry must be a real rollout under <home>/sessions, not any other readable
+	// file; everything else is discovered from it.
+	if !adapter.WithinDir(filepath.Join(home, "sessions"), abs) || !strings.HasSuffix(abs, ".jsonl") {
+		return nil, fmt.Errorf("collect: %s is not a session rollout", abs)
+	}
+	if info, err := os.Lstat(abs); err != nil {
+		return nil, err
+	} else if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("collect: %s is not a regular file", abs)
+	}
+	sessionsRoot := sessionsRootFrom(abs)
+
+	var out []adapter.BundledFile
+	seen := make(map[string]bool)
+	var walk func(path string)
+	walk = func(path string) {
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		// Lstat guards against a symlinked rollout escaping the home scope.
+		if info, err := os.Lstat(path); err != nil || !info.Mode().IsRegular() {
+			return
+		}
+		if bf, ok := adapter.RootedFile(home, path); ok {
+			out = append(out, bf)
+		}
+		chunks, err := parseRollout(path)
+		if err != nil {
+			return
+		}
+		for _, c := range chunks {
+			for _, it := range c.Items {
+				for _, sub := range it.Subagents {
+					if sub.ID != "" {
+						walk(findRolloutPathIn(sessionsRoot, sub.ID))
+					}
+				}
+			}
+		}
+	}
+	walk(abs)
+	return out, nil
+}

--- a/internal/adapter/codex/collect_test.go
+++ b/internal/adapter/codex/collect_test.go
@@ -1,0 +1,123 @@
+package codex
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/bundle"
+)
+
+const subagentChildID = "019f278e-50a5-7f83-91f2-c30e8ac18e19"
+
+// seedParentWithChild lays out a parent rollout (from testdata) plus its spawned
+// child rollout under home/sessions, returning the parent's path.
+func seedParentWithChild(t *testing.T, home string) string {
+	t.Helper()
+	dir := filepath.Join(home, "sessions", "2026", "07", "03")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src, err := os.ReadFile("testdata/rollout-parent.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(dir, "rollout-2026-07-03T10-00-00-parent.jsonl")
+	if err := os.WriteFile(parent, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(dir, "rollout-2026-07-03T10-30-00-"+subagentChildID+".jsonl")
+	line := `{"timestamp":"2026-07-03T10:30:00Z","type":"session_meta","payload":{"id":"` + subagentChildID + `","cwd":"/w"}}` + "\n"
+	if err := os.WriteFile(child, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return parent
+}
+
+func TestCollectSessionFilesIncludesSubagents(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	parent := seedParentWithChild(t, home)
+
+	files, err := collectSessionFiles(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("want 2 files (parent + child), got %d: %+v", len(files), files)
+	}
+	var haveChild bool
+	for _, f := range files {
+		if !strings.HasPrefix(f.RelPath, "root/sessions/2026/07/03/") {
+			t.Fatalf("RelPath %q not rooted under root/sessions/", f.RelPath)
+		}
+		if strings.Contains(f.RelPath, subagentChildID) {
+			haveChild = true
+		}
+	}
+	if !haveChild {
+		t.Fatalf("child rollout not collected: %+v", files)
+	}
+}
+
+// TestSubagentFilePathRootRelative verifies resolution follows the passed rootPath
+// (an extracted bundle), not the live ~/.codex.
+func TestSubagentFilePathRootRelative(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir()) // live home has no matching child
+
+	bundleHome := t.TempDir()
+	parent := seedParentWithChild(t, bundleHome)
+
+	p, ok := SubagentFilePath(parent, subagentChildID)
+	if !ok {
+		t.Fatal("SubagentFilePath should resolve child from the bundle root")
+	}
+	if !strings.HasPrefix(p, bundleHome) {
+		t.Fatalf("resolved %q, want a path under bundle home %q", p, bundleHome)
+	}
+
+	// Empty root falls back to the live home, which lacks the child.
+	if _, ok := SubagentFilePath("", subagentChildID); ok {
+		t.Fatal("empty root must not resolve against the (childless) live home")
+	}
+}
+
+// TestOfflineSubagentResolution: a subagent bundled from one home resolves from
+// the extracted temp dir even when the live ~/.codex is empty.
+func TestOfflineSubagentResolution(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	parent := seedParentWithChild(t, home)
+
+	files, err := collectSessionFiles(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcs := make([]bundle.SourceFile, 0, len(files))
+	var entry string
+	for _, f := range files {
+		srcs = append(srcs, bundle.SourceFile{ArchivePath: f.RelPath, SourcePath: f.AbsPath})
+		if f.AbsPath == parent {
+			entry = f.RelPath
+		}
+	}
+	var buf bytes.Buffer
+	if err := bundle.Write(&buf, bundle.Manifest{FormatVersion: bundle.FormatVersion, Agent: Agent, Entry: entry}, srcs); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := t.TempDir()
+	m, err := bundle.Read(&buf, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Point the live home elsewhere: resolution must come from the bundle.
+	t.Setenv("CODEX_HOME", t.TempDir())
+
+	entryPath := filepath.Join(dest, filepath.FromSlash(m.Entry))
+	if _, ok, err := ReadSubagentView(entryPath, subagentChildID); err != nil || !ok {
+		t.Fatalf("offline subagent view: ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/adapter/codex/discovery.go
+++ b/internal/adapter/codex/discovery.go
@@ -234,15 +234,33 @@ func summaryFor(m threadMeta, modelNames map[string]string) *session.Summary {
 }
 
 func findRolloutPath(threadID string) string {
-	dir, err := codexHome()
-	if err != nil {
-		return ""
+	return findRolloutPathIn("", threadID)
+}
+
+// findRolloutPathIn globs for a thread's rollout under sessionsRoot; empty falls
+// back to the live ~/.codex/sessions.
+func findRolloutPathIn(sessionsRoot, threadID string) string {
+	if sessionsRoot == "" {
+		dir, err := codexHome()
+		if err != nil {
+			return ""
+		}
+		sessionsRoot = filepath.Join(dir, "sessions")
 	}
-	matches, err := filepath.Glob(filepath.Join(dir, "sessions", "*", "*", "*", "rollout-*-"+threadID+".jsonl"))
+	matches, err := filepath.Glob(filepath.Join(sessionsRoot, "*", "*", "*", "rollout-*-"+threadID+".jsonl"))
 	if err != nil || len(matches) == 0 {
 		return ""
 	}
 	return matches[0]
+}
+
+// sessionsRootFrom returns the sessions dir for a rollout laid out as
+// <root>/sessions/YYYY/MM/DD/rollout-*.jsonl. Empty in → empty out.
+func sessionsRootFrom(transcriptPath string) string {
+	if transcriptPath == "" {
+		return ""
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(transcriptPath))))
 }
 
 // Falls back to dir's basename when no .git ancestor is found.

--- a/internal/adapter/codex/transcript.go
+++ b/internal/adapter/codex/transcript.go
@@ -13,11 +13,11 @@ func ReadTranscriptView(path string) (transcript.TranscriptView, error) {
 	if err != nil {
 		return transcript.TranscriptView{}, err
 	}
-	stampSubagents(chunks)
+	stampSubagents(chunks, sessionsRootFrom(path))
 	return transcript.TranscriptView{Chunks: chunks}, nil
 }
 
-func stampSubagents(chunks []transcript.Chunk) {
+func stampSubagents(chunks []transcript.Chunk, sessionsRoot string) {
 	var edges map[string]string
 	if p, err := stateDBPath(); err == nil {
 		edges = loadSpawnEdges(p)
@@ -33,13 +33,14 @@ func stampSubagents(chunks []transcript.Chunk) {
 				continue
 			}
 			sub.Status = edges[sub.ID]
-			sub.HasTrace = findRolloutPath(sub.ID) != ""
+			sub.HasTrace = findRolloutPathIn(sessionsRoot, sub.ID) != ""
 		}
 	}
 }
 
 func ReadSubagentView(rootPath, agentID string) (transcript.TranscriptView, bool, error) {
-	path := findRolloutPath(agentID)
+	sessionsRoot := sessionsRootFrom(rootPath)
+	path := findRolloutPathIn(sessionsRoot, agentID)
 	if path == "" {
 		return transcript.TranscriptView{}, false, nil
 	}
@@ -47,13 +48,13 @@ func ReadSubagentView(rootPath, agentID string) (transcript.TranscriptView, bool
 	if err != nil {
 		return transcript.TranscriptView{}, false, err
 	}
-	stampSubagents(chunks) // nested spawns link one level deeper
+	stampSubagents(chunks, sessionsRoot) // nested spawns link one level deeper
 	return transcript.TranscriptView{Chunks: chunks}, true, nil
 }
 
 func FindToolDetail(path, agentID, toolID string) (transcript.ToolDetail, bool, error) {
 	if agentID != "" {
-		if p := findRolloutPath(agentID); p != "" {
+		if p := findRolloutPathIn(sessionsRootFrom(path), agentID); p != "" {
 			path = p
 		} else {
 			return transcript.ToolDetail{}, false, nil
@@ -74,7 +75,7 @@ func FindToolDetail(path, agentID, toolID string) (transcript.ToolDetail, bool, 
 }
 
 func SubagentFilePath(rootPath, agentID string) (string, bool) {
-	if p := findRolloutPath(agentID); p != "" {
+	if p := findRolloutPathIn(sessionsRootFrom(rootPath), agentID); p != "" {
 		return p, true
 	}
 	return "", false
@@ -83,12 +84,13 @@ func SubagentFilePath(rootPath, agentID string) (string, bool) {
 // streamingTranscript tails a growing rollout: a byte cursor reads only newly
 // appended lines, which accumulate and re-fold in memory each Refresh.
 type streamingTranscript struct {
-	path   string
-	offset int64
-	loaded bool
-	lines  []rolloutLine
-	models map[string]string
-	chunks []transcript.Chunk
+	path         string
+	sessionsRoot string
+	offset       int64
+	loaded       bool
+	lines        []rolloutLine
+	models       map[string]string
+	chunks       []transcript.Chunk
 }
 
 func (s *streamingTranscript) Refresh() ([]transcript.Chunk, error) {
@@ -115,13 +117,17 @@ func (s *streamingTranscript) Refresh() ([]transcript.Chunk, error) {
 		s.models = loadModelNames()
 	}
 	chunks := foldRollout(s.lines, s.models)
-	stampSubagents(chunks)
+	stampSubagents(chunks, s.sessionsRoot)
 	s.chunks = chunks
 	return s.chunks, nil
 }
 
 func NewStreamingTranscript(path, rootPath string, isSubagent bool) adapter.StreamingTranscript {
-	return &streamingTranscript{path: path}
+	root := sessionsRootFrom(rootPath)
+	if root == "" {
+		root = sessionsRootFrom(path)
+	}
+	return &streamingTranscript{path: path, sessionsRoot: root}
 }
 
 func ListHistoryProjects() ([]session.HistoryProject, error) { return listHistoryProjects() }

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/MunifTanjim/argus/internal/bundle"
 	"github.com/MunifTanjim/argus/internal/transcript"
 )
 
@@ -70,9 +71,25 @@ const (
 	MethodPushTest = "push.test" // request: PushDeviceRef; result: nil
 	// MethodPushVAPIDKey returns the gateway's VAPID public key for a device to
 	// subscribe with. Empty Key means Web Push is unavailable.
-	MethodPushVAPIDKey = "push.vapidKey" // request: no params; result: PushVAPIDKey
-	MethodPushDesktop  = "push.desktop"  // request: push.Notification; result: nil (render on node if opted in)
+	MethodPushVAPIDKey  = "push.vapidKey"         // request: no params; result: PushVAPIDKey
+	MethodPushDesktop   = "push.desktop"          // request: push.Notification; result: nil (render on node if opted in)
+	MethodSessionExport = "sessions.exportBundle" // request: ExportBundleParams; result: ExportBundleResult
 )
+
+// ExportBundleParams selects a session to export. Metadata is supplied by the
+// client (what it already displays) and written verbatim into the manifest.
+type ExportBundleParams struct {
+	NodeID         string          `json:"node_id,omitempty"` // gateway routing
+	Agent          string          `json:"agent"`
+	TranscriptPath string          `json:"transcript_path"`
+	Metadata       bundle.Metadata `json:"metadata"`
+}
+
+// ExportBundleResult carries the gzipped-tar bundle. Data marshals to base64.
+type ExportBundleResult struct {
+	Filename string `json:"filename"`
+	Data     []byte `json:"data"`
+}
 
 // PushVAPIDKey carries the gateway's VAPID public key (the applicationServerKey a
 // device subscribes with).

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -1,0 +1,266 @@
+// Package bundle reads and writes the .argus session export archive: a gzipped
+// tar of a manifest plus the session's raw tool files under a "root/" subtree.
+package bundle
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// FormatVersion is the current bundle format. Read refuses anything newer.
+const FormatVersion = 1
+
+// manifestName is the tar entry holding the JSON manifest.
+const manifestName = "manifest.json"
+
+// Size caps guard against decompression bombs (a tiny gzip can declare a huge tar
+// entry). Vars, not consts, so tests can shrink them.
+var (
+	maxManifestBytes int64 = 8 << 20 // 8 MiB
+	maxBundleBytes   int64 = 4 << 30 // 4 GiB
+)
+
+// Metadata is the session header snapshot, captured at export time (repo/git
+// context won't exist after extraction). Supplied by the client.
+type Metadata struct {
+	Title        string `json:"title,omitempty"`
+	ModelName    string `json:"model_name,omitempty"`
+	ModelColor   string `json:"model_color,omitempty"`
+	Cwd          string `json:"cwd,omitempty"`
+	Repo         string `json:"repo,omitempty"`
+	GitUserName  string `json:"git_user_name,omitempty"`
+	GitUserEmail string `json:"git_user_email,omitempty"`
+	FirstMessage string `json:"first_message,omitempty"`
+	Tokens       int    `json:"tokens,omitempty"`
+	TurnCount    int    `json:"turn_count,omitempty"`
+	DurationMs   int64  `json:"duration_ms,omitempty"`
+	LastActivity string `json:"last_activity,omitempty"`
+}
+
+// Manifest is the bundle's descriptor.
+type Manifest struct {
+	FormatVersion int      `json:"format_version"`
+	ArgusVersion  string   `json:"argus_version,omitempty"`
+	ExportedAt    string   `json:"exported_at,omitempty"`
+	Agent         string   `json:"agent"`
+	Entry         string   `json:"entry"` // archive path of the main transcript
+	Metadata      Metadata `json:"metadata"`
+}
+
+// SourceFile pairs a file's archive path with its source path on disk.
+type SourceFile struct {
+	ArchivePath string
+	SourcePath  string
+}
+
+// errNotRegular marks a source path that isn't a plain regular file (symlink,
+// dir, device). Such sidecars are skipped like a missing file; the entry is not.
+var errNotRegular = errors.New("bundle: not a regular file")
+
+// Write streams a gzipped tar of manifest + files to w.
+func Write(w io.Writer, m Manifest, files []SourceFile) (err error) {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+	// Close both on every path so a mid-loop error can't leak the writers.
+	defer func() {
+		if cerr := tw.Close(); err == nil {
+			err = cerr
+		}
+		if cerr := gz.Close(); err == nil {
+			err = cerr
+		}
+	}()
+
+	mb, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := writeTarBytes(tw, manifestName, mb); err != nil {
+		return err
+	}
+	// Cap total payload (symmetric with Read) so a runaway session can't force an
+	// unbounded archive into memory.
+	remaining := maxBundleBytes
+	for _, f := range files {
+		if err := writeTarFile(tw, f, &remaining); err != nil {
+			// Optional sidecars can vanish (or turn non-regular) in the window
+			// between collection and write; skip them. The entry is required.
+			if f.ArchivePath != m.Entry && (errors.Is(err, os.ErrNotExist) || errors.Is(err, errNotRegular)) {
+				continue
+			}
+			return fmt.Errorf("bundle %s: %w", f.ArchivePath, err)
+		}
+	}
+	return nil
+}
+
+func writeTarBytes(tw *tar.Writer, name string, b []byte) error {
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(b))}); err != nil {
+		return err
+	}
+	_, err := tw.Write(b)
+	return err
+}
+
+func writeTarFile(tw *tar.Writer, f SourceFile, remaining *int64) error {
+	// Lstat, not Stat: a symlinked source would otherwise be archived with its
+	// target's bytes, escaping the home scope the collectors enforce.
+	info, err := os.Lstat(f.SourcePath)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errNotRegular
+	}
+	if info.Size() > *remaining {
+		return fmt.Errorf("bundle: payload exceeds %d bytes", maxBundleBytes)
+	}
+	src, err := os.Open(f.SourcePath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	if err := tw.WriteHeader(&tar.Header{Name: f.ArchivePath, Mode: 0o644, Size: info.Size()}); err != nil {
+		return err
+	}
+	// Cap at the size declared in the header: a live transcript may grow
+	// between Lstat and Copy, which would otherwise trip "write too long".
+	_, err = io.Copy(tw, io.LimitReader(src, info.Size()))
+	*remaining -= info.Size()
+	return err
+}
+
+// Read extracts a bundle's files into destDir. The manifest must be the first tar
+// entry so its format_version is validated before any body is written; Read rejects
+// a newer version and any entry escaping destDir. On error, destDir may hold
+// partial files.
+func Read(r io.Reader, destDir string) (Manifest, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("bundle: not a gzip archive: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+
+	m, manifestBytes, err := readManifest(tr)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if m.FormatVersion > FormatVersion {
+		return Manifest{}, fmt.Errorf("bundle: format_version %d newer than supported %d (upgrade argus)", m.FormatVersion, FormatVersion)
+	}
+	if m.Entry == "" {
+		return Manifest{}, fmt.Errorf("bundle: manifest has no entry")
+	}
+
+	remaining := maxBundleBytes
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return Manifest{}, fmt.Errorf("bundle: read tar: %w", err)
+		}
+		if err := extractEntry(destDir, hdr, tr, &remaining); err != nil {
+			return Manifest{}, err
+		}
+	}
+
+	// Persist the manifest so an already-extracted destDir can be reused without
+	// re-reading the archive (see ReadManifest).
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return Manifest{}, err
+	}
+	if err := os.WriteFile(filepath.Join(destDir, manifestName), manifestBytes, 0o644); err != nil {
+		return Manifest{}, err
+	}
+	return m, nil
+}
+
+// readManifest consumes the first tar entry, which must be the manifest, and
+// returns it decoded alongside its raw bytes.
+func readManifest(tr *tar.Reader) (Manifest, []byte, error) {
+	hdr, err := tr.Next()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return Manifest{}, nil, fmt.Errorf("bundle: missing %s", manifestName)
+		}
+		return Manifest{}, nil, fmt.Errorf("bundle: read tar: %w", err)
+	}
+	if hdr.Name != manifestName {
+		return Manifest{}, nil, fmt.Errorf("bundle: first entry is %q, want %s", hdr.Name, manifestName)
+	}
+	b, err := io.ReadAll(io.LimitReader(tr, maxManifestBytes+1))
+	if err != nil {
+		return Manifest{}, nil, err
+	}
+	if int64(len(b)) > maxManifestBytes {
+		return Manifest{}, nil, fmt.Errorf("bundle: manifest exceeds %d bytes", maxManifestBytes)
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return Manifest{}, nil, fmt.Errorf("bundle: bad manifest: %w", err)
+	}
+	return m, b, nil
+}
+
+// ReadManifest reads the manifest from an already-extracted bundle directory.
+func ReadManifest(destDir string) (Manifest, error) {
+	b, err := os.ReadFile(filepath.Join(destDir, manifestName))
+	if err != nil {
+		return Manifest{}, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return Manifest{}, fmt.Errorf("bundle: bad manifest: %w", err)
+	}
+	return m, nil
+}
+
+func extractEntry(destDir string, hdr *tar.Header, tr io.Reader, remaining *int64) error {
+	// Bundle paths are always slash-separated and relative; a backslash or
+	// volume name (C:\) only shows up in a traversal attempt.
+	if strings.ContainsRune(hdr.Name, '\\') || filepath.VolumeName(hdr.Name) != "" {
+		return fmt.Errorf("bundle: illegal path %q", hdr.Name)
+	}
+	clean := path.Clean(hdr.Name)
+	if clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		return fmt.Errorf("bundle: illegal path %q", hdr.Name)
+	}
+	target := filepath.Join(destDir, filepath.FromSlash(clean))
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		return os.MkdirAll(target, 0o755)
+	case tar.TypeReg:
+	default:
+		// Bundles only ever contain regular files and directories; reject symlinks,
+		// hardlinks, and device nodes rather than silently materializing them.
+		return fmt.Errorf("bundle: unsupported entry %q (type %d)", hdr.Name, hdr.Typeflag)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	n, err := io.Copy(out, io.LimitReader(tr, *remaining+1))
+	*remaining -= n
+	if err != nil {
+		return err
+	}
+	if *remaining < 0 {
+		return fmt.Errorf("bundle: extracted payload exceeds %d bytes", maxBundleBytes)
+	}
+	return nil
+}

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -264,3 +264,31 @@ func extractEntry(destDir string, hdr *tar.Header, tr io.Reader, remaining *int6
 	}
 	return nil
 }
+
+// WriteDir writes a bundle from an already-extracted directory (manifest.json
+// plus a root/ subtree), such as one produced by RedactTree.
+func WriteDir(w io.Writer, dir string) error {
+	m, err := ReadManifest(dir)
+	if err != nil {
+		return err
+	}
+	var files []SourceFile
+	err = filepath.WalkDir(dir, func(p string, d os.DirEntry, werr error) error {
+		if werr != nil || d.IsDir() {
+			return werr
+		}
+		if filepath.Base(p) == manifestName {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return err
+		}
+		files = append(files, SourceFile{ArchivePath: filepath.ToSlash(rel), SourcePath: p})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return Write(w, m, files)
+}

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -1,0 +1,348 @@
+package bundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteReadRoundtrip(t *testing.T) {
+	src := t.TempDir()
+	txn := filepath.Join(src, "session.jsonl")
+	if err := os.WriteFile(txn, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(src, "subagents", "agent-a.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sub, []byte("subdata"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := Manifest{
+		FormatVersion: FormatVersion, ArgusVersion: "9.9.9", ExportedAt: "2026-07-10T00:00:00Z",
+		Agent: "claude", Entry: "root/session.jsonl",
+		Metadata: Metadata{Title: "hi", Tokens: 42},
+	}
+	files := []SourceFile{
+		{ArchivePath: "root/session.jsonl", SourcePath: txn},
+		{ArchivePath: "root/subagents/agent-a.jsonl", SourcePath: sub},
+	}
+
+	var buf bytes.Buffer
+	if err := Write(&buf, m, files); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	dst := t.TempDir()
+	got, err := Read(&buf, dst)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Entry != "root/session.jsonl" || got.Metadata.Tokens != 42 || got.Agent != "claude" {
+		t.Fatalf("manifest mismatch: %+v", got)
+	}
+	b, err := os.ReadFile(filepath.Join(dst, "root", "session.jsonl"))
+	if err != nil || string(b) != "line1\nline2\n" {
+		t.Fatalf("extracted transcript wrong: %q err=%v", b, err)
+	}
+	b2, _ := os.ReadFile(filepath.Join(dst, "root", "subagents", "agent-a.jsonl"))
+	if string(b2) != "subdata" {
+		t.Fatalf("extracted subagent wrong: %q", b2)
+	}
+}
+
+func TestReadPersistsManifestForReuse(t *testing.T) {
+	src := t.TempDir()
+	txn := filepath.Join(src, "session.jsonl")
+	if err := os.WriteFile(txn, []byte("data\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{
+		FormatVersion: FormatVersion, Agent: "claude", Entry: "root/session.jsonl",
+		Metadata: Metadata{Title: "reuse", Tokens: 7},
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, m, []SourceFile{{ArchivePath: "root/session.jsonl", SourcePath: txn}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	dst := t.TempDir()
+	if _, err := Read(&buf, dst); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	// ReadManifest reads back the persisted manifest without re-extracting.
+	got, err := ReadManifest(dst)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if got.Entry != "root/session.jsonl" || got.Metadata.Title != "reuse" || got.Metadata.Tokens != 7 {
+		t.Fatalf("manifest mismatch: %+v", got)
+	}
+	if _, err := ReadManifest(t.TempDir()); err == nil {
+		t.Fatal("ReadManifest on an un-extracted dir should error")
+	}
+}
+
+func TestWriteCapsGrowingTranscript(t *testing.T) {
+	src := t.TempDir()
+	txn := filepath.Join(src, "session.jsonl")
+	if err := os.WriteFile(txn, bytes.Repeat([]byte("x"), 1<<16), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/session.jsonl"}
+	files := []SourceFile{{ArchivePath: "root/session.jsonl", SourcePath: txn}}
+
+	// A writer appends a bounded amount concurrently while we export. The header
+	// size is fixed at Stat time, so an unbounded copy would trip "write too
+	// long"; growth is capped so the temp file stays small.
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		f, err := os.OpenFile(txn, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		chunk := bytes.Repeat([]byte("y"), 4096)
+		for i := 0; i < 256; i++ { // ~1 MiB total
+			if _, err := f.Write(chunk); err != nil {
+				return
+			}
+		}
+	}()
+
+	dst := t.TempDir()
+	for {
+		var buf bytes.Buffer
+		if err := Write(&buf, m, files); err != nil {
+			t.Fatalf("Write on growing file: %v", err)
+		}
+		if _, err := Read(&buf, dst); err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		select {
+		case <-writerDone:
+			return
+		default:
+		}
+	}
+}
+
+func TestWriteSkipsVanishedSidecar(t *testing.T) {
+	src := t.TempDir()
+	txn := filepath.Join(src, "session.jsonl")
+	if err := os.WriteFile(txn, []byte("data\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/session.jsonl"}
+	files := []SourceFile{
+		{ArchivePath: "root/session.jsonl", SourcePath: txn},
+		{ArchivePath: "root/subagents/gone.jsonl", SourcePath: filepath.Join(src, "subagents", "gone.jsonl")},
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, m, files); err != nil {
+		t.Fatalf("Write should skip vanished sidecar: %v", err)
+	}
+	dst := t.TempDir()
+	if _, err := Read(&buf, dst); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "root", "session.jsonl")); err != nil {
+		t.Fatalf("entry missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "root", "subagents", "gone.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("vanished sidecar should be absent, got err=%v", err)
+	}
+}
+
+func TestWriteCapsTotalPayload(t *testing.T) {
+	orig := maxBundleBytes
+	maxBundleBytes = 16
+	defer func() { maxBundleBytes = orig }()
+
+	src := t.TempDir()
+	txn := filepath.Join(src, "session.jsonl")
+	if err := os.WriteFile(txn, bytes.Repeat([]byte("x"), 64), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/session.jsonl"}
+	files := []SourceFile{{ArchivePath: "root/session.jsonl", SourcePath: txn}}
+	var buf bytes.Buffer
+	if err := Write(&buf, m, files); err == nil {
+		t.Fatal("expected error when payload exceeds cap")
+	}
+}
+
+// A symlinked sidecar is skipped (like a vanished one) rather than archived with
+// its target's bytes; a symlinked entry is a hard error.
+func TestWriteSkipsSymlinkSidecarAndFailsEntry(t *testing.T) {
+	src := t.TempDir()
+	txn := filepath.Join(src, "session.jsonl")
+	if err := os.WriteFile(txn, []byte("data\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("s3cret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(src, "evil.jsonl")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	m := Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/session.jsonl"}
+	files := []SourceFile{
+		{ArchivePath: "root/session.jsonl", SourcePath: txn},
+		{ArchivePath: "root/evil.jsonl", SourcePath: link},
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, m, files); err != nil {
+		t.Fatalf("Write should skip symlink sidecar: %v", err)
+	}
+	dst := t.TempDir()
+	if _, err := Read(&buf, dst); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "root", "evil.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("symlink sidecar should be absent, got err=%v", err)
+	}
+
+	// The same symlink as the entry must fail closed.
+	m.Entry = "root/evil.jsonl"
+	if err := Write(&buf, m, []SourceFile{{ArchivePath: "root/evil.jsonl", SourcePath: link}}); err == nil {
+		t.Fatal("expected error when entry is a symlink")
+	}
+}
+
+func TestWriteFailsOnMissingEntry(t *testing.T) {
+	src := t.TempDir()
+	m := Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/session.jsonl"}
+	files := []SourceFile{{ArchivePath: "root/session.jsonl", SourcePath: filepath.Join(src, "nope.jsonl")}}
+	var buf bytes.Buffer
+	if err := Write(&buf, m, files); err == nil {
+		t.Fatal("expected error when entry transcript is missing")
+	}
+}
+
+func TestReadRejectsNewerFormat(t *testing.T) {
+	src := t.TempDir()
+	f := filepath.Join(src, "x")
+	if err := os.WriteFile(f, []byte("z"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{FormatVersion: FormatVersion + 1, Agent: "claude", Entry: "root/x"}
+	var buf bytes.Buffer
+	if err := Write(&buf, m, []SourceFile{{ArchivePath: "root/x", SourcePath: f}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(&buf, t.TempDir()); err == nil {
+		t.Fatal("expected error for newer format_version")
+	}
+}
+
+func TestReadRejectsPathTraversal(t *testing.T) {
+	// A tar entry escaping destDir must be rejected.
+	var buf bytes.Buffer
+	if err := writeRawTarGz(&buf, Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/x"},
+		map[string][]byte{"../evil": []byte("x")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(&buf, t.TempDir()); err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+}
+
+func TestReadRejectsBackslashPath(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeRawTarGz(&buf, Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/x"},
+		map[string][]byte{`..\evil`: []byte("x")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(&buf, t.TempDir()); err == nil {
+		t.Fatal("expected error for backslash path")
+	}
+}
+
+func TestReadRejectsOversizedPayload(t *testing.T) {
+	orig := maxBundleBytes
+	maxBundleBytes = 16
+	defer func() { maxBundleBytes = orig }()
+
+	var buf bytes.Buffer
+	if err := writeRawTarGz(&buf, Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/x"},
+		map[string][]byte{"root/x": bytes.Repeat([]byte("z"), 64)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(&buf, t.TempDir()); err == nil {
+		t.Fatal("expected error when extracted payload exceeds cap")
+	}
+}
+
+func TestReadRejectsOversizedManifest(t *testing.T) {
+	orig := maxManifestBytes
+	maxManifestBytes = 8
+	defer func() { maxManifestBytes = orig }()
+
+	var buf bytes.Buffer
+	if err := writeRawTarGz(&buf, Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/x"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(&buf, t.TempDir()); err == nil {
+		t.Fatal("expected error when manifest exceeds cap")
+	}
+}
+
+func TestReadRejectsManifestNotFirst(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	body := []byte("x")
+	tw.WriteHeader(&tar.Header{Name: "root/x", Mode: 0o644, Size: int64(len(body))})
+	tw.Write(body)
+	mb, _ := json.MarshalIndent(Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/x"}, "", "  ")
+	tw.WriteHeader(&tar.Header{Name: manifestName, Mode: 0o644, Size: int64(len(mb))})
+	tw.Write(mb)
+	tw.Close()
+	gz.Close()
+
+	if _, err := Read(&buf, t.TempDir()); err == nil {
+		t.Fatal("expected error when manifest is not the first entry")
+	}
+}
+
+func TestReadRejectsSymlinkEntry(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	mb, _ := json.MarshalIndent(Manifest{FormatVersion: FormatVersion, Agent: "claude", Entry: "root/x"}, "", "  ")
+	tw.WriteHeader(&tar.Header{Name: manifestName, Mode: 0o644, Size: int64(len(mb))})
+	tw.Write(mb)
+	tw.WriteHeader(&tar.Header{Name: "root/link", Mode: 0o777, Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"})
+	tw.Close()
+	gz.Close()
+
+	if _, err := Read(&buf, t.TempDir()); err == nil {
+		t.Fatal("expected error for symlink tar entry")
+	}
+}
+
+func writeRawTarGz(w io.Writer, m Manifest, entries map[string][]byte) error {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+	mb, _ := json.MarshalIndent(m, "", "  ")
+	tw.WriteHeader(&tar.Header{Name: "manifest.json", Mode: 0o644, Size: int64(len(mb))})
+	tw.Write(mb)
+	for name, b := range entries {
+		tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(b))})
+		tw.Write(b)
+	}
+	tw.Close()
+	return gz.Close()
+}

--- a/internal/bundle/e2e_test.go
+++ b/internal/bundle/e2e_test.go
@@ -1,0 +1,95 @@
+package bundle_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/adapters"
+	"github.com/MunifTanjim/argus/internal/bundle"
+)
+
+func TestExportViewFidelity(t *testing.T) {
+	// multi_turn.jsonl has no subagents, so path-derived lookups (subagent dir,
+	// team members) return nothing on both sides and DeepEqual holds without any
+	// path-sensitive fields.
+	fixtureSource := filepath.Join("..", "adapter", "claudecode", "parser", "testdata", "multi_turn.jsonl")
+	if _, err := os.Stat(fixtureSource); err != nil {
+		t.Skipf("fixture unavailable: %v", err)
+	}
+
+	// Fake $HOME so claudeHome() and CollectSessionFiles resolve under our temp dir.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Place the fixture under <home>/.claude/projects/-proj/<uuid>.jsonl.
+	projDir := filepath.Join(home, ".claude", "projects", "-proj")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	uuid := "abc12345-0000-0000-0000-000000000000"
+	mainPath := filepath.Join(projDir, uuid+".jsonl")
+	data, err := os.ReadFile(fixtureSource)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(mainPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := adapters.Default()
+
+	orig, err := a.ReadTranscriptView(mainPath)
+	if err != nil {
+		t.Fatalf("ReadTranscriptView (orig): %v", err)
+	}
+	if len(orig.Chunks) == 0 {
+		t.Fatal("fixture produced zero chunks; pick a richer fixture")
+	}
+
+	files, err := a.CollectSessionFiles(mainPath)
+	if err != nil {
+		t.Fatalf("CollectSessionFiles: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("CollectSessionFiles returned no files; HOME env setup failed")
+	}
+
+	srcs := make([]bundle.SourceFile, 0, len(files))
+	entry := ""
+	for _, f := range files {
+		srcs = append(srcs, bundle.SourceFile{ArchivePath: f.RelPath, SourcePath: f.AbsPath})
+		if f.AbsPath == mainPath {
+			entry = f.RelPath
+		}
+	}
+	if entry == "" {
+		t.Fatalf("main transcript not in collected files; files=%v", files)
+	}
+
+	var buf bytes.Buffer
+	if err := bundle.Write(&buf, bundle.Manifest{
+		FormatVersion: bundle.FormatVersion,
+		Agent:         "claude",
+		Entry:         entry,
+	}, srcs); err != nil {
+		t.Fatalf("bundle.Write: %v", err)
+	}
+
+	dest := t.TempDir()
+	m, err := bundle.Read(&buf, dest)
+	if err != nil {
+		t.Fatalf("bundle.Read: %v", err)
+	}
+	extractedPath := filepath.Join(dest, filepath.FromSlash(m.Entry))
+	got, err := a.ReadTranscriptView(extractedPath)
+	if err != nil {
+		t.Fatalf("ReadTranscriptView (extracted): %v", err)
+	}
+
+	if !reflect.DeepEqual(orig.Chunks, got.Chunks) {
+		t.Fatalf("fidelity mismatch: orig=%d chunks, got=%d chunks", len(orig.Chunks), len(got.Chunks))
+	}
+}

--- a/internal/bundle/redact.go
+++ b/internal/bundle/redact.go
@@ -1,0 +1,559 @@
+package bundle
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	_ "modernc.org/sqlite"
+)
+
+// RedactPlaceholder replaces every redacted span in a saved bundle.
+const RedactPlaceholder = "[REDACTED]"
+
+type fileKind int
+
+const (
+	kindText fileKind = iota
+	kindSQLite
+	kindOtherBinary
+)
+
+var sqliteMagic = []byte("SQLite format 3\x00")
+
+// classifyFile sniffs the first 512 bytes: sqlite magic → db, NUL or invalid
+// UTF-8 → binary, else text. A file that changes character past 512 bytes can be
+// misclassified; RedactTree's residual scan is the backstop.
+func classifyFile(path string) (fileKind, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return kindText, err
+	}
+	defer f.Close()
+	head := make([]byte, 512)
+	n, err := f.Read(head)
+	if err != nil && err != io.EOF {
+		return kindText, err
+	}
+	head = head[:n]
+	if bytes.HasPrefix(head, sqliteMagic) {
+		return kindSQLite, nil
+	}
+	if bytes.IndexByte(head, 0) >= 0 || !utf8.Valid(head) {
+		return kindOtherBinary, nil
+	}
+	return kindText, nil
+}
+
+// litVariant is a byte-sequence to search for, attributed to the literal it counts
+// toward (one secret expands into several variants; see expandLiterals).
+type litVariant struct {
+	match []byte
+	owner string
+}
+
+// jsonEscapedForms returns s as it appears inside a JSON string (both HTML-escaping
+// modes), dropping forms equal to s. Transcripts are JSONL, so a secret with " \ <
+// > or & is stored escaped and won't match the raw literal.
+func jsonEscapedForms(s string) []string {
+	var out []string
+	add := func(v string) {
+		if len(v) > 0 && v != s {
+			out = append(out, v)
+		}
+	}
+	if b, err := json.Marshal(s); err == nil && len(b) >= 2 {
+		add(string(b[1 : len(b)-1])) // strip the surrounding quotes (HTML-escaped)
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err == nil {
+		if t := strings.TrimRight(buf.String(), "\n"); len(t) >= 2 {
+			add(t[1 : len(t)-1])
+		}
+	}
+	return out
+}
+
+// expandLiterals returns each literal plus its JSON-escaped forms as byte-variants,
+// sorted longest-first so a shorter variant can't clobber a longer overlapping one.
+// Duplicate byte-sequences are dropped so a shared variant isn't counted twice.
+func expandLiterals(literals []string) []litVariant {
+	var out []litVariant
+	seen := make(map[string]bool)
+	add := func(match, owner string) {
+		if match == "" || seen[match] {
+			return
+		}
+		seen[match] = true
+		out = append(out, litVariant{match: []byte(match), owner: owner})
+	}
+	for _, lit := range literals {
+		if lit == "" {
+			continue
+		}
+		add(lit, lit)
+		for _, v := range jsonEscapedForms(lit) {
+			add(v, lit)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return len(out[i].match) > len(out[j].match) })
+	return out
+}
+
+// redactCell replaces each variant in b with RedactPlaceholder, counting hits
+// against the owning literal. variants must be longest-first. Reports if changed.
+func redactCell(b []byte, variants []litVariant, counts map[string]int) ([]byte, bool) {
+	changed := false
+	for _, v := range variants {
+		n := bytes.Count(b, v.match)
+		if n == 0 {
+			continue
+		}
+		counts[v.owner] += n
+		b = bytes.ReplaceAll(b, v.match, []byte(RedactPlaceholder))
+		changed = true
+	}
+	return b, changed
+}
+
+// redactTextBytes replaces every literal (and its JSON-escaped forms) with
+// RedactPlaceholder, returning the rewritten bytes and per-literal counts.
+func redactTextBytes(b []byte, literals []string) ([]byte, map[string]int) {
+	counts := make(map[string]int, len(literals))
+	out, _ := redactCell(b, expandLiterals(literals), counts)
+	return out, counts
+}
+
+type sqliteEdit struct {
+	table string
+	col   string
+	rowid int64
+	val   []byte
+}
+
+// walkSQLite calls fn for every non-nil cell of every rowid table; it never
+// mutates. Rowid-less tables (WITHOUT ROWID, virtual) are skipped and returned so
+// callers can warn.
+func walkSQLite(db *sql.DB, fn func(table, col string, rowid int64, val []byte)) ([]string, error) {
+	tables, err := sqliteTables(db)
+	if err != nil {
+		return nil, err
+	}
+	var skipped []string
+	for _, tbl := range tables {
+		cols, hasRowid, err := sqliteColumns(db, tbl)
+		if err != nil {
+			return nil, err
+		}
+		if !hasRowid {
+			skipped = append(skipped, tbl)
+			continue
+		}
+		if len(cols) == 0 {
+			continue
+		}
+		sel := `SELECT rowid`
+		for _, c := range cols {
+			sel += `, "` + c + `"`
+		}
+		sel += ` FROM "` + tbl + `"`
+		rows, err := db.Query(sel)
+		if err != nil {
+			return nil, err
+		}
+		dest := make([]any, len(cols)+1)
+		var rowid int64
+		dest[0] = &rowid
+		raw := make([]sql.RawBytes, len(cols))
+		for i := range raw {
+			dest[i+1] = &raw[i]
+		}
+		for rows.Next() {
+			if err := rows.Scan(dest...); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			for i, c := range cols {
+				if raw[i] == nil {
+					continue
+				}
+				val := append([]byte(nil), raw[i]...) // copy before Next invalidates it
+				fn(tbl, c, rowid, val)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		rows.Close()
+	}
+	return skipped, nil
+}
+
+func sqliteTables(db *sql.DB) ([]string, error) {
+	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+func sqliteColumns(db *sql.DB, table string) (cols []string, hasRowid bool, err error) {
+	rows, err := db.Query(`PRAGMA table_info("` + table + `")`)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid, notnull, pk int
+			name, ctype      string
+			dflt             sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return nil, false, err
+		}
+		cols = append(cols, name)
+	}
+	// A plain table (not WITHOUT ROWID) always answers a rowid query; probe it.
+	var probe int64
+	if e := db.QueryRow(`SELECT rowid FROM "` + table + `" LIMIT 1`).Scan(&probe); e == nil || e == sql.ErrNoRows {
+		hasRowid = true
+	}
+	return cols, hasRowid, rows.Err()
+}
+
+func scanSQLite(path string, literals []string) (map[string]int, []string, error) {
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=query_only(true)")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer db.Close()
+	counts := make(map[string]int, len(literals))
+	sorted := expandLiterals(literals)
+	skipped, err := walkSQLite(db, func(_, _ string, _ int64, val []byte) {
+		// Count on a mutated copy so overlapping literals count as redaction would.
+		redactCell(val, sorted, counts)
+	})
+	return counts, skipped, err
+}
+
+func redactSQLite(path string, literals []string) (map[string]int, []string, error) {
+	// journal_mode=DELETE converts a WAL db and drops -wal/-shm sidecars, so no
+	// secret-bearing sidecar is left for WriteDir to zip.
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=journal_mode(DELETE)")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer db.Close()
+	counts := make(map[string]int, len(literals))
+	sorted := expandLiterals(literals)
+	var edits []sqliteEdit
+	skipped, err := walkSQLite(db, func(table, col string, rowid int64, val []byte) {
+		if out, changed := redactCell(val, sorted, counts); changed {
+			edits = append(edits, sqliteEdit{table, col, rowid, out})
+		}
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(edits) > 0 {
+		tx, err := db.Begin()
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, e := range edits {
+			if _, err := tx.Exec(fmt.Sprintf(`UPDATE "%s" SET "%s"=? WHERE rowid=?`, e.table, e.col), e.val, e.rowid); err != nil {
+				tx.Rollback()
+				return nil, nil, err
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, nil, err
+		}
+	}
+	// VACUUM unconditionally (can't run in a transaction): a freed page from a
+	// pre-export delete may still hold a secret that only a rebuild reclaims.
+	if _, err := db.Exec(`VACUUM`); err != nil {
+		return nil, nil, err
+	}
+	return counts, skipped, nil
+}
+
+// Report summarizes a redaction pass: per-literal occurrence counts and warnings
+// for content that could not be safely redacted (e.g. secrets in binary files).
+type Report struct {
+	Counts   map[string]int
+	Warnings []string
+}
+
+// ZeroMatch returns the queried literals that matched nothing anywhere.
+func (r Report) ZeroMatch(literals []string) []string {
+	var out []string
+	for _, lit := range literals {
+		if r.Counts[lit] == 0 {
+			out = append(out, lit)
+		}
+	}
+	return out
+}
+
+func mergeCounts(dst, src map[string]int) {
+	for k, v := range src {
+		dst[k] += v
+	}
+}
+
+// redactMetadata scrubs every string field of the manifest metadata by reflection,
+// so a newly-added string field is scrubbed automatically rather than missed.
+func redactMetadata(m Metadata, literals []string) (Metadata, map[string]int) {
+	counts := make(map[string]int)
+	v := reflect.ValueOf(&m).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() != reflect.String || !f.CanSet() {
+			continue
+		}
+		out, c := redactTextBytes([]byte(f.String()), literals)
+		mergeCounts(counts, c)
+		f.SetString(string(out))
+	}
+	return m, counts
+}
+
+// sqliteSkipWarning describes a table that could not be redacted in place.
+func sqliteSkipWarning(rel, tbl string) string {
+	return fmt.Sprintf(
+		"sqlite table %q in %s not redactable (no rowid / virtual table); manual review needed",
+		tbl, filepath.ToSlash(rel))
+}
+
+// binarySecretWarning describes a secret found in a binary file that cannot be
+// redacted without corrupting it.
+func binarySecretWarning(rel string) string {
+	return "secret in binary file " + filepath.ToSlash(rel) + " (cannot redact)"
+}
+
+// binaryContainsLiteral reports whether any literal, or a JSON-escaped form of one,
+// appears in b — recognizing the same forms redaction removes.
+func binaryContainsLiteral(b []byte, literals []string) bool {
+	for _, v := range expandLiterals(literals) {
+		if bytes.Contains(b, v.match) {
+			return true
+		}
+	}
+	return false
+}
+
+// residualWarning describes a secret found in a file after the redaction pass —
+// a leak the structured redaction did not catch.
+func residualWarning(rel string) string {
+	return "secret survives in " + filepath.ToSlash(rel) + " after redaction (manual review needed)"
+}
+
+// verifyResiduals raw-scans every written file for surviving literals, catching
+// what the structured pass missed (sqlite freed pages, stray sidecars). Files in
+// skip (already flagged by a specific warning) aren't reported again.
+func verifyResiduals(dir string, literals []string, skip map[string]bool) ([]string, error) {
+	var warnings []string
+	err := filepath.WalkDir(dir, func(p string, d os.DirEntry, werr error) error {
+		if werr != nil || d.IsDir() {
+			return werr
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return err
+		}
+		if skip[filepath.ToSlash(rel)] {
+			return nil
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if binaryContainsLiteral(b, literals) {
+			warnings = append(warnings, residualWarning(rel))
+		}
+		return nil
+	})
+	return warnings, err
+}
+
+// Scan previews what a redaction of srcDir would replace, without writing. It reads
+// live sqlite cells only and runs no residual backstop, so it under-reports leaks;
+// never gate a save on Scan alone — RedactTree's Report is authoritative.
+func Scan(srcDir string, literals []string) (Report, error) {
+	rep := Report{Counts: make(map[string]int)}
+	m, err := ReadManifest(srcDir)
+	if err != nil {
+		return rep, err
+	}
+	_, mc := redactMetadata(m.Metadata, literals)
+	mergeCounts(rep.Counts, mc)
+
+	err = filepath.WalkDir(srcDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if filepath.Base(p) == manifestName {
+			return nil // metadata already counted from the parsed manifest
+		}
+		kind, err := classifyFile(p)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(srcDir, p)
+		switch kind {
+		case kindText:
+			b, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return rerr
+			}
+			_, c := redactTextBytes(b, literals)
+			mergeCounts(rep.Counts, c)
+		case kindSQLite:
+			c, skipped, serr := scanSQLite(p, literals)
+			if serr != nil {
+				return serr
+			}
+			mergeCounts(rep.Counts, c)
+			for _, tbl := range skipped {
+				rep.Warnings = append(rep.Warnings, sqliteSkipWarning(rel, tbl))
+			}
+		case kindOtherBinary:
+			b, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return rerr
+			}
+			if binaryContainsLiteral(b, literals) {
+				rep.Warnings = append(rep.Warnings, binarySecretWarning(rel))
+			}
+		}
+		return nil
+	})
+	return rep, err
+}
+
+// RedactTree copies srcDir into dstDir, replacing every literal in text files,
+// sqlite dbs, and the manifest metadata. Binary files that contain a secret are
+// copied unchanged and recorded as warnings. dstDir is created fresh.
+func RedactTree(srcDir, dstDir string, literals []string) (Report, error) {
+	rep := Report{Counts: make(map[string]int)}
+	m, err := ReadManifest(srcDir)
+	if err != nil {
+		return rep, err
+	}
+	redactedMeta, mc := redactMetadata(m.Metadata, literals)
+	mergeCounts(rep.Counts, mc)
+	m.Metadata = redactedMeta
+
+	// Files already flagged by a specific warning are excluded from the residual
+	// backstop so each leak is reported once.
+	warned := make(map[string]bool)
+
+	err = filepath.WalkDir(srcDir, func(p string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(srcDir, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dstDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if filepath.Base(p) == manifestName {
+			mb, err := json.MarshalIndent(m, "", "  ")
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(target, mb, 0o644)
+		}
+		kind, err := classifyFile(p)
+		if err != nil {
+			return err
+		}
+		switch kind {
+		case kindText:
+			b, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			out, c := redactTextBytes(b, literals)
+			mergeCounts(rep.Counts, c)
+			return os.WriteFile(target, out, 0o644)
+		case kindSQLite:
+			if err := copyFile(p, target); err != nil {
+				return err
+			}
+			c, skipped, err := redactSQLite(target, literals)
+			if err != nil {
+				return err
+			}
+			mergeCounts(rep.Counts, c)
+			for _, tbl := range skipped {
+				rep.Warnings = append(rep.Warnings, sqliteSkipWarning(rel, tbl))
+				warned[filepath.ToSlash(rel)] = true
+			}
+			return nil
+		default: // kindOtherBinary
+			b, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			if binaryContainsLiteral(b, literals) {
+				rep.Warnings = append(rep.Warnings, binarySecretWarning(rel))
+				warned[filepath.ToSlash(rel)] = true
+			}
+			return os.WriteFile(target, b, 0o644)
+		}
+	})
+	if err != nil {
+		return rep, err
+	}
+
+	// Backstop: raw-scan the written tree for anything the structured pass missed.
+	residuals, err := verifyResiduals(dstDir, literals, warned)
+	rep.Warnings = append(rep.Warnings, residuals...)
+	return rep, err
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/bundle/redact_e2e_test.go
+++ b/internal/bundle/redact_e2e_test.go
@@ -1,0 +1,38 @@
+package bundle
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteDirRoundTrip(t *testing.T) {
+	src := writeExtractedTree(t, false)
+	redacted := filepath.Join(t.TempDir(), "red")
+	if _, err := RedactTree(src, redacted, []string{"sk-secret"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := WriteDir(&buf, redacted); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-read the bundle and confirm the secret is gone and it still parses.
+	out := t.TempDir()
+	m, err := Read(&buf, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Entry != "root/s.jsonl" {
+		t.Fatalf("entry changed: %q", m.Entry)
+	}
+	body, err := os.ReadFile(filepath.Join(out, "root", "s.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(body, []byte("sk-secret")) {
+		t.Fatal("secret survives a full redact->rebundle->read cycle")
+	}
+}

--- a/internal/bundle/redact_hardening_test.go
+++ b/internal/bundle/redact_hardening_test.go
@@ -1,0 +1,189 @@
+package bundle
+
+import (
+	"bytes"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestRedactLongestFirst: an overlapping shorter literal must not clobber a
+// longer one (leaving a "[REDACTED]123" fragment and a misleading zero-match).
+func TestRedactLongestFirst(t *testing.T) {
+	in := []byte("token sk-abc123 and sk-abc alone")
+	out, counts := redactTextBytes(in, []string{"sk-abc", "sk-abc123"})
+	if bytes.Contains(out, []byte("123")) {
+		t.Fatalf("shorter literal clobbered the longer one: %s", out)
+	}
+	if want := "token [REDACTED] and [REDACTED] alone"; string(out) != want {
+		t.Fatalf("want %q, got %q", want, out)
+	}
+	if counts["sk-abc123"] != 1 {
+		t.Fatalf("want longer literal counted once, got %d", counts["sk-abc123"])
+	}
+	if counts["sk-abc"] != 1 {
+		t.Fatalf("want shorter literal counted once (standalone), got %d", counts["sk-abc"])
+	}
+}
+
+// TestRedactSQLiteReclaimsFreedPage: a secret in a row deleted before export
+// lingers in a freed page with no live cell to edit. The unconditional VACUUM
+// must still scrub it from the raw file.
+func TestRedactSQLiteReclaimsFreedPage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "conv.db")
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE t(v TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO t(v) VALUES(?)`, "sk-secret leaked"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DELETE FROM t`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte("sk-secret")) {
+		t.Skip("sqlite reclaimed the page on its own; nothing to prove here")
+	}
+
+	// No live cell holds the secret, so there are zero edits — the fix is that
+	// VACUUM runs anyway.
+	counts, _, err := redactSQLite(path, []string{"sk-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts["sk-secret"] != 0 {
+		t.Fatalf("expected no live-cell edits, got %d", counts["sk-secret"])
+	}
+	raw, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("sk-secret")) {
+		t.Fatal("freed-page secret survived redaction; VACUUM must reclaim it")
+	}
+}
+
+// TestRedactSQLiteWALLeavesNoSidecar: a WAL-mode source db must redact and be
+// converted to DELETE mode, leaving no -wal/-shm sidecar for WriteDir to zip.
+func TestRedactSQLiteWALLeavesNoSidecar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "conv.db")
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE t(v TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO t(v) VALUES(?)`, "sk-secret"); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	if _, _, err := redactSQLite(path, []string{"sk-secret"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, sfx := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(path + sfx); !os.IsNotExist(err) {
+			t.Fatalf("sidecar %s%s must not survive redaction (err=%v)", filepath.Base(path), sfx, err)
+		}
+	}
+	after, _, err := scanSQLite(path, []string{"sk-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after["sk-secret"] != 0 {
+		t.Fatalf("secret survives in WAL-origin db: %d", after["sk-secret"])
+	}
+}
+
+// TestVerifyResiduals: the backstop reports surviving literals, and honors the
+// skip set so a leak already flagged by a specific warning isn't doubled.
+func TestVerifyResiduals(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "leak.txt"), []byte("has sk-secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "clean.txt"), []byte("nothing here"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	warns, err := verifyResiduals(dir, []string{"sk-secret"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "leak.txt") {
+		t.Fatalf("want one residual naming leak.txt, got %v", warns)
+	}
+
+	warns, err = verifyResiduals(dir, []string{"sk-secret"}, map[string]bool{"leak.txt": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("want no residuals when the file is skipped, got %v", warns)
+	}
+}
+
+// TestRedactTreeSkippedTableWarnedOnce: a secret in a WITHOUT ROWID table can't
+// be scrubbed and genuinely remains in the copied db, but must be reported by
+// exactly one warning (the skip warning) — the residual backstop must not
+// double-report it.
+func TestRedactTreeSkippedTableWarnedOnce(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, manifestName),
+		mustJSON(t, Manifest{FormatVersion: 1, Agent: "claude", Entry: "conv.db", Metadata: Metadata{}}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "conv.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE s(k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO s VALUES(?, ?)`, "k1", "sk-secret"); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	db.Close()
+
+	dst := filepath.Join(t.TempDir(), "out")
+	rep, err := RedactTree(dir, dst, []string{"sk-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	for _, w := range rep.Warnings {
+		if strings.Contains(w, "conv.db") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("want exactly one warning for conv.db, got %d: %v", n, rep.Warnings)
+	}
+	// The secret really is still there (we can't rewrite a rowid-less table).
+	raw, err := os.ReadFile(filepath.Join(dst, "conv.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte("sk-secret")) {
+		t.Fatal("test premise broken: expected the un-redactable secret to remain")
+	}
+}

--- a/internal/bundle/redact_scan_test.go
+++ b/internal/bundle/redact_scan_test.go
@@ -1,0 +1,68 @@
+package bundle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func writeExtractedTree(t *testing.T, secretInBinary bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, manifestName),
+		mustJSON(t, Manifest{FormatVersion: 1, Agent: "claude", Entry: "root/s.jsonl",
+			Metadata: Metadata{Title: "leak sk-secret", FirstMessage: "hi"}}), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(dir, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "s.jsonl"),
+		[]byte(`{"result":"sk-secret in tool output"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if secretInBinary {
+		if err := os.WriteFile(filepath.Join(root, "blob.bin"),
+			[]byte{0x00, 's', 'k', '-', 's', 'e', 'c', 'r', 'e', 't'}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestScanCountsAndMetadata(t *testing.T) {
+	dir := writeExtractedTree(t, false)
+	rep, err := Scan(dir, []string{"sk-secret", "ghost"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// jsonl (1) + metadata Title (1) = 2.
+	if rep.Counts["sk-secret"] != 2 {
+		t.Fatalf("want 2, got %d", rep.Counts["sk-secret"])
+	}
+	if zm := rep.ZeroMatch([]string{"sk-secret", "ghost"}); len(zm) != 1 || zm[0] != "ghost" {
+		t.Fatalf("want [ghost] zero-match, got %v", zm)
+	}
+}
+
+func TestScanWarnsBinarySecret(t *testing.T) {
+	dir := writeExtractedTree(t, true)
+	rep, err := Scan(dir, []string{"sk-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Warnings) != 1 {
+		t.Fatalf("want 1 warning, got %v", rep.Warnings)
+	}
+}

--- a/internal/bundle/redact_sqlite_test.go
+++ b/internal/bundle/redact_sqlite_test.go
@@ -1,0 +1,117 @@
+package bundle
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "conv.db")
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE meta(note TEXT, blob BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO meta(note, blob) VALUES(?, ?)`,
+		"token sk-secret here", []byte("blob has sk-secret too")); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestScanSQLite(t *testing.T) {
+	path := newTestDB(t)
+	counts, _, err := scanSQLite(path, []string{"sk-secret", "absent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts["sk-secret"] != 2 {
+		t.Fatalf("want 2, got %d", counts["sk-secret"])
+	}
+	if counts["absent"] != 0 {
+		t.Fatalf("want 0, got %d", counts["absent"])
+	}
+}
+
+func TestRedactSQLite(t *testing.T) {
+	path := newTestDB(t)
+	counts, _, err := redactSQLite(path, []string{"sk-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts["sk-secret"] != 2 {
+		t.Fatalf("want 2 replaced, got %d", counts["sk-secret"])
+	}
+	// Cells no longer contain the secret.
+	after, _, err := scanSQLite(path, []string{"sk-secret", RedactPlaceholder})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after["sk-secret"] != 0 {
+		t.Fatalf("secret still present in cells: %d", after["sk-secret"])
+	}
+	if after[RedactPlaceholder] != 2 {
+		t.Fatalf("want 2 placeholders, got %d", after[RedactPlaceholder])
+	}
+	// Post-VACUUM the raw file bytes must not contain the secret in freed pages.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("sk-secret")) {
+		t.Fatal("secret survives in raw db bytes after vacuum")
+	}
+}
+
+func TestScanWarnsSkippedSQLiteTable(t *testing.T) {
+	dir := t.TempDir()
+	manifest := Manifest{FormatVersion: 1, Agent: "claude", Entry: "conv.db", Metadata: Metadata{}}
+	mb, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifestName), mb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "conv.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE secrets(k TEXT PRIMARY KEY, v TEXT) WITHOUT ROWID`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO secrets VALUES(?, ?)`, "key1", "sk-secret"); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	db.Close()
+
+	rep, err := Scan(dir, []string{"sk-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, w := range rep.Warnings {
+		if strings.Contains(w, `"secrets"`) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("want warning naming table \"secrets\", got %v", rep.Warnings)
+	}
+}

--- a/internal/bundle/redact_test.go
+++ b/internal/bundle/redact_test.go
@@ -1,0 +1,93 @@
+package bundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRedactTextBytes(t *testing.T) {
+	in := []byte(`{"result":"key sk-abc123 and again sk-abc123"}`)
+	out, counts := redactTextBytes(in, []string{"sk-abc123", "nope"})
+	if string(out) != `{"result":"key [REDACTED] and again [REDACTED]"}` {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	if counts["sk-abc123"] != 2 {
+		t.Fatalf("want 2 occurrences, got %d", counts["sk-abc123"])
+	}
+	if counts["nope"] != 0 {
+		t.Fatalf("want 0 for absent literal, got %d", counts["nope"])
+	}
+}
+
+func TestRedactJSONEscapedQuote(t *testing.T) {
+	// A secret with a quote is stored backslash-escaped inside a JSONL line, so
+	// the raw literal the user pastes never appears verbatim on disk.
+	secret := `p"ass`
+	line, err := json.Marshal(map[string]string{"token": secret})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(line, []byte(secret)) {
+		t.Fatalf("precondition: raw secret should not appear verbatim in %s", line)
+	}
+	out, counts := redactTextBytes(line, []string{secret})
+	if string(out) != `{"token":"[REDACTED]"}` {
+		t.Fatalf("escaped secret not redacted: %s", out)
+	}
+	if counts[secret] != 1 {
+		t.Fatalf("want escaped occurrence counted against the literal, got %d", counts[secret])
+	}
+}
+
+func TestRedactJSONEscapedHTML(t *testing.T) {
+	// encoding/json escapes < > & by default (< etc.); redaction must match
+	// that on-disk form too.
+	secret := "a<b>c"
+	line, err := json.Marshal(map[string]string{"v": secret})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, counts := redactTextBytes(line, []string{secret})
+	if bytes.Contains(out, []byte("u003c")) || counts[secret] == 0 {
+		t.Fatalf("HTML-escaped secret survived: out=%s counts=%d", out, counts[secret])
+	}
+}
+
+func TestRedactTextBytesEmptyLiteralIgnored(t *testing.T) {
+	in := []byte("hello")
+	out, _ := redactTextBytes(in, []string{""})
+	if string(out) != "hello" {
+		t.Fatalf("empty literal must not alter input, got %s", out)
+	}
+}
+
+func TestClassifyFile(t *testing.T) {
+	dir := t.TempDir()
+	text := filepath.Join(dir, "t.jsonl")
+	if err := os.WriteFile(text, []byte(`{"a":1}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sq := filepath.Join(dir, "c.db")
+	if err := os.WriteFile(sq, append([]byte("SQLite format 3\x00"), 0, 0, 0), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "b.bin")
+	if err := os.WriteFile(bin, []byte{0xff, 0x00, 0x01, 0x02}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		path string
+		want fileKind
+	}{{text, kindText}, {sq, kindSQLite}, {bin, kindOtherBinary}} {
+		got, err := classifyFile(tc.path)
+		if err != nil {
+			t.Fatalf("classify %s: %v", tc.path, err)
+		}
+		if got != tc.want {
+			t.Fatalf("classify %s: want %v got %v", tc.path, tc.want, got)
+		}
+	}
+}

--- a/internal/bundle/redact_tree_test.go
+++ b/internal/bundle/redact_tree_test.go
@@ -1,0 +1,42 @@
+package bundle
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRedactTree(t *testing.T) {
+	src := writeExtractedTree(t, false)
+	dst := filepath.Join(t.TempDir(), "out")
+
+	rep, err := RedactTree(src, dst, []string{"sk-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Counts["sk-secret"] != 2 {
+		t.Fatalf("want 2, got %d", rep.Counts["sk-secret"])
+	}
+
+	// jsonl scrubbed.
+	body, err := os.ReadFile(filepath.Join(dst, "root", "s.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(body, []byte("sk-secret")) {
+		t.Fatal("secret survives in redacted jsonl")
+	}
+	if !bytes.Contains(body, []byte(RedactPlaceholder)) {
+		t.Fatal("placeholder missing from redacted jsonl")
+	}
+
+	// manifest metadata scrubbed.
+	m, err := ReadManifest(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains([]byte(m.Metadata.Title), []byte("sk-secret")) {
+		t.Fatalf("secret survives in metadata title: %q", m.Metadata.Title)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -371,6 +371,7 @@ func (s *Server) buildClientServer() *api.Server {
 	// History transcript and tool detail are per-machine: route by node_id.
 	srv.Handle(api.MethodSessionsHistoryTranscript, s.routeByNodeID(api.MethodSessionsHistoryTranscript))
 	srv.Handle(api.MethodSessionHistoryToolDetail, s.routeByNodeID(api.MethodSessionHistoryToolDetail))
+	srv.Handle(api.MethodSessionExport, s.routeByNodeIDOrSole(api.MethodSessionExport))
 	// History sessions route by node_id, then get stamped with that node's id/label
 	// so a client can open a transcript by the session's own node_id.
 	srv.Handle(api.MethodSessionsHistorySessions, func(ctx context.Context, params json.RawMessage) (any, error) {

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -1,11 +1,14 @@
-// Package gitmeta derives lightweight git metadata (the current branch) for a
-// directory by reading git's on-disk files directly — no git subprocess.
+// Package gitmeta derives lightweight git metadata (branch, user identity) for a
+// directory.
 package gitmeta
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/MunifTanjim/argus/internal/shell"
 )
 
 // Branch returns the current branch of the git repository containing dir: the
@@ -34,6 +37,24 @@ func Branch(dir string) string {
 		return s[:7]
 	}
 	return ""
+}
+
+// Identity returns the git user.name and user.email for the repo containing dir.
+// Either is "" if unset or unavailable.
+func Identity(ctx context.Context, dir string) (name, email string) {
+	if dir == "" {
+		return "", ""
+	}
+	return gitConfig(ctx, dir, "user.name"), gitConfig(ctx, dir, "user.email")
+}
+
+// gitConfig returns a git config value resolved from dir, or "" if git fails.
+func gitConfig(ctx context.Context, dir, key string) string {
+	cmd := shell.NewCommandContext(ctx, "git", "-C", dir, "config", key)
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return cmd.StdOut().TrimSpace().String()
 }
 
 // findGitDir walks up from dir to the nearest ".git" entry and returns the git

--- a/internal/gitmeta/gitmeta_test.go
+++ b/internal/gitmeta/gitmeta_test.go
@@ -1,7 +1,9 @@
 package gitmeta
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -111,5 +113,53 @@ func TestBranchHeadWithCRLF(t *testing.T) {
 	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\r\n")
 	if got := Branch(dir); got != "main" {
 		t.Fatalf("Branch = %q, want %q", got, "main")
+	}
+}
+
+func TestIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init")
+	git("config", "user.name", "Ada Lovelace")
+	git("config", "user.email", "ada@example.com")
+
+	name, email := Identity(ctx, dir)
+	if name != "Ada Lovelace" {
+		t.Errorf("name = %q, want %q", name, "Ada Lovelace")
+	}
+	if email != "ada@example.com" {
+		t.Errorf("email = %q, want %q", email, "ada@example.com")
+	}
+}
+
+func TestIdentityEmptyDir(t *testing.T) {
+	name, email := Identity(context.Background(), "")
+	if name != "" || email != "" {
+		t.Fatalf("Identity(\"\") = (%q, %q), want empty", name, email)
+	}
+}
+
+func TestIdentityNotARepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	// Isolate config so a developer's global/system identity can't leak in.
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	name, email := Identity(context.Background(), dir)
+	if name != "" || email != "" {
+		t.Fatalf("Identity(non-repo) = (%q, %q), want empty", name, email)
 	}
 }

--- a/internal/node/handlers.go
+++ b/internal/node/handlers.go
@@ -38,4 +38,5 @@ func (d *Node) registerHandlers(srv *api.Server) {
 	srv.Handle(api.MethodTerminalInput, d.handleTerminalInput)
 	srv.Handle(api.MethodTerminalResize, d.handleTerminalResize)
 	srv.Handle(api.MethodTerminalClose, d.handleTerminalClose)
+	srv.Handle(api.MethodSessionExport, d.handleExportBundle)
 }

--- a/internal/node/handlers_export.go
+++ b/internal/node/handlers_export.go
@@ -1,0 +1,91 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/bundle"
+	"github.com/MunifTanjim/argus/internal/gitmeta"
+)
+
+func (d *Node) handleExportBundle(ctx context.Context, params json.RawMessage) (any, error) {
+	p, err := api.Decode[api.ExportBundleParams](params)
+	if err != nil {
+		return nil, err
+	}
+	if p.TranscriptPath == "" {
+		return nil, fmt.Errorf("exportBundle: transcript_path is required")
+	}
+	a, ok := d.adapters[p.Agent]
+	if !ok {
+		return nil, fmt.Errorf("exportBundle: unknown agent %q", p.Agent)
+	}
+	files, err := a.CollectSessionFiles(p.TranscriptPath)
+	if err != nil {
+		return nil, fmt.Errorf("exportBundle: collect: %w", err)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("exportBundle: no files collected for %s", p.TranscriptPath)
+	}
+
+	entry := ""
+	srcs := make([]bundle.SourceFile, 0, len(files))
+	for _, f := range files {
+		srcs = append(srcs, bundle.SourceFile{ArchivePath: f.RelPath, SourcePath: f.AbsPath})
+		if filepath.Clean(f.AbsPath) == filepath.Clean(p.TranscriptPath) {
+			entry = f.RelPath
+		}
+	}
+	if entry == "" {
+		entry = files[0].RelPath // fallback: first file is the transcript
+	}
+
+	m := bundle.Manifest{
+		FormatVersion: bundle.FormatVersion,
+		ArgusVersion:  d.version,
+		ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+		Agent:         a.Agent(),
+		Entry:         entry,
+		Metadata:      p.Metadata,
+	}
+	m.Metadata.GitUserName, m.Metadata.GitUserEmail = gitmeta.Identity(ctx, p.Metadata.Cwd)
+
+	var buf bytes.Buffer
+	if err := bundle.Write(&buf, m, srcs); err != nil {
+		return nil, fmt.Errorf("exportBundle: write: %w", err)
+	}
+	return api.ExportBundleResult{
+		Filename: suggestFilename(a.Agent(), p.TranscriptPath, p.Metadata),
+		Data:     buf.Bytes(),
+	}, nil
+}
+
+// suggestFilename builds "<agent>--<repo>--<session-id>.argus"; repo is omitted
+// when unknown.
+func suggestFilename(agent, transcriptPath string, md bundle.Metadata) string {
+	label := agent
+	if md.Repo != "" {
+		label += "--" + md.Repo
+	}
+	id := strings.TrimSuffix(filepath.Base(transcriptPath), ".jsonl")
+	label = sanitizeFilenamePart(label)
+	if id == "" {
+		return label + ".argus"
+	}
+	return label + "--" + sanitizeFilenamePart(id) + ".argus"
+}
+
+func sanitizeFilenamePart(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '/' || r == ' ' || r == filepath.Separator {
+			return '-'
+		}
+		return r
+	}, s)
+}

--- a/internal/node/handlers_export_test.go
+++ b/internal/node/handlers_export_test.go
@@ -1,0 +1,64 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/bundle"
+	"github.com/MunifTanjim/argus/internal/session"
+	"github.com/MunifTanjim/argus/internal/tmux"
+)
+
+// newTestNode builds a Node with real adapters and a test version stamp.
+// It uses an empty tmux-client map so no tmux binary is required.
+func newTestNode(t *testing.T) *Node {
+	t.Helper()
+	d := newNode(map[session.TmuxServer]*tmux.Client{})
+	d.SetVersion("test")
+	return d
+}
+
+func TestHandleExportBundle(t *testing.T) {
+	home := t.TempDir()
+	// claudeHome() returns filepath.Join(os.UserHomeDir(), ".claude"), so put the
+	// transcript under {HOME}/.claude/projects/-proj/... so it is collected.
+	claudeHome := filepath.Join(home, ".claude")
+	projects := filepath.Join(claudeHome, "projects", "-proj")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	main := filepath.Join(projects, "abc12345-0000-0000-0000-000000000000.jsonl")
+	if err := os.WriteFile(main, []byte(`{"type":"user"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home) // claudeHome() resolves under here
+
+	d := newTestNode(t)
+	params, _ := json.Marshal(api.ExportBundleParams{
+		Agent: "claude", TranscriptPath: main,
+		Metadata: bundle.Metadata{Title: "demo"},
+	})
+	res, err := d.handleExportBundle(context.Background(), params)
+	if err != nil {
+		t.Fatalf("handleExportBundle: %v", err)
+	}
+	out := res.(api.ExportBundleResult)
+	if out.Filename == "" || len(out.Data) == 0 {
+		t.Fatalf("empty result: %+v", out)
+	}
+	m, err := bundle.Read(bytes.NewReader(out.Data), t.TempDir())
+	if err != nil {
+		t.Fatalf("read bundle: %v", err)
+	}
+	if m.Agent != "claude" || m.Metadata.Title != "demo" || m.FormatVersion != bundle.FormatVersion {
+		t.Fatalf("manifest wrong: %+v", m)
+	}
+	if m.ArgusVersion == "" || m.ExportedAt == "" {
+		t.Fatalf("node did not stamp version/time: %+v", m)
+	}
+}

--- a/internal/tui/export.go
+++ b/internal/tui/export.go
@@ -1,0 +1,112 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/bundle"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+type exportDoneMsg struct {
+	path string
+	err  error
+}
+
+// actExportSession exports the transcript currently open (live or history) to a
+// .argus file in the working directory, reporting the path via a flash message.
+func (m model) actExportSession(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.viewer {
+		return m, nil
+	}
+	agent, path, nodeID, md, ok := m.exportTarget()
+	if !ok {
+		m.flash = "export: no session open"
+		return m, nil
+	}
+	client := m.client
+	m.flash = "exporting…"
+	return m, func() tea.Msg {
+		var res api.ExportBundleResult
+		err := client.Call(api.MethodSessionExport, api.ExportBundleParams{
+			NodeID: nodeID, Agent: agent, TranscriptPath: path, Metadata: md,
+		}, &res)
+		if err != nil {
+			return exportDoneMsg{err: err}
+		}
+		p, werr := writeExportFile(res.Filename, res.Data)
+		return exportDoneMsg{path: p, err: werr}
+	}
+}
+
+// exportTarget resolves the session to export. Export is History-only: either an
+// open transcript or the cursor row in the session list.
+func (m model) exportTarget() (agent, path, nodeID string, md bundle.Metadata, ok bool) {
+	switch m.mode {
+	case modeHistoryTranscript:
+		if m.history.openPath == "" {
+			return "", "", "", bundle.Metadata{}, false
+		}
+		md = historyExportMetadata(m.history.openSession, m.history.project)
+		return m.history.openAgent, m.history.openPath, m.history.openNodeID, md, true
+	case modeHistorySessions:
+		if m.history.sessCursor >= len(m.history.sessions) {
+			return "", "", "", bundle.Metadata{}, false
+		}
+		s := m.history.sessions[m.history.sessCursor]
+		if s.TranscriptPath == "" {
+			return "", "", "", bundle.Metadata{}, false
+		}
+		md = historyExportMetadata(s, m.history.project)
+		return s.Agent, s.TranscriptPath, m.history.project.NodeID, md, true
+	}
+	return "", "", "", bundle.Metadata{}, false
+}
+
+func historyExportMetadata(s session.HistorySession, p session.HistoryProject) bundle.Metadata {
+	return bundle.Metadata{
+		Title:        s.Title,
+		FirstMessage: s.FirstMessage,
+		ModelName:    s.ModelName,
+		ModelColor:   s.ModelColor,
+		LastActivity: s.LastActivity,
+		Tokens:       s.Tokens,
+		TurnCount:    s.TurnCount,
+		DurationMs:   s.DurationMs,
+		Cwd:          p.Cwd,
+		Repo:         p.Repo,
+	}
+}
+
+// writeExportFile writes data to filename in the working directory, adding a
+// numeric suffix if the name is taken. Returns the absolute path written.
+func writeExportFile(filename string, data []byte) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	// filename comes from the (possibly remote) node; strip any directory
+	// components so it can only ever land in cwd, never traverse out of it.
+	base := filepath.Base(filename)
+	if base == "." || base == string(filepath.Separator) || base == ".." {
+		return "", fmt.Errorf("export: node returned invalid filename %q", filename)
+	}
+	filename = base
+	target := filepath.Join(cwd, filename)
+	ext := filepath.Ext(filename)
+	stem := filename[:len(filename)-len(ext)]
+	for i := 1; ; i++ {
+		if _, statErr := os.Stat(target); statErr != nil {
+			break // free slot (not-exist) or unreadable; WriteFile surfaces real errors
+		}
+		target = filepath.Join(cwd, fmt.Sprintf("%s-%d%s", stem, i, ext))
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		return "", err
+	}
+	return target, nil
+}

--- a/internal/tui/export.go
+++ b/internal/tui/export.go
@@ -96,17 +96,23 @@ func writeExportFile(filename string, data []byte) (string, error) {
 		return "", fmt.Errorf("export: node returned invalid filename %q", filename)
 	}
 	filename = base
-	target := filepath.Join(cwd, filename)
 	ext := filepath.Ext(filename)
 	stem := filename[:len(filename)-len(ext)]
-	for i := 1; ; i++ {
-		if _, statErr := os.Stat(target); statErr != nil {
-			break // free slot (not-exist) or unreadable; WriteFile surfaces real errors
-		}
-		target = filepath.Join(cwd, fmt.Sprintf("%s-%d%s", stem, i, ext))
-	}
+	target := nextAvailablePath(cwd, stem, ext)
 	if err := os.WriteFile(target, data, 0o644); err != nil {
 		return "", err
 	}
 	return target, nil
+}
+
+// nextAvailablePath returns dir/base+ext, adding a numeric "-N" suffix before
+// ext until it finds a name that does not exist on disk.
+func nextAvailablePath(dir, base, ext string) string {
+	target := filepath.Join(dir, base+ext)
+	for i := 1; ; i++ {
+		if _, err := os.Stat(target); err != nil {
+			return target // free slot (not-exist) or unreadable; caller surfaces real errors
+		}
+		target = filepath.Join(dir, fmt.Sprintf("%s-%d%s", base, i, ext))
+	}
 }

--- a/internal/tui/export_confirm_test.go
+++ b/internal/tui/export_confirm_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+func TestExportConfirmGate(t *testing.T) {
+	m := model{mode: modeHistoryTranscript, historyView: histTranscript}
+	m.history.openPath = "/x/session.jsonl"
+	m.history.openAgent = "claude"
+
+	// First press arms the confirmation, makes no RPC.
+	res, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'E'})
+	m = res.(model)
+	if !m.pendingExport {
+		t.Fatal("export key should arm pendingExport")
+	}
+	if cmd != nil {
+		t.Fatal("arming export must not return a command")
+	}
+
+	// A non-y key cancels.
+	res, cmd = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'n'})
+	m = res.(model)
+	if m.pendingExport {
+		t.Fatal("non-y key should clear pendingExport")
+	}
+	if cmd != nil {
+		t.Fatal("cancel must not return a command")
+	}
+
+	// Confirming with y runs the export.
+	m.pendingExport = true
+	res, cmd = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'y'})
+	m = res.(model)
+	if m.pendingExport {
+		t.Fatal("y should clear pendingExport")
+	}
+	if cmd == nil {
+		t.Fatal("y should trigger the export command")
+	}
+}
+
+func TestExportConfirmGateSessionList(t *testing.T) {
+	m := model{mode: modeHistorySessions}
+	m.history.sessions = []session.HistorySession{{SessionID: "s1", Agent: "claude", TranscriptPath: "/x/s1.jsonl"}}
+	m.history.project = session.HistoryProject{Repo: "argus", Cwd: "/x"}
+
+	res, cmd := m.handleHistorySessionsKey(tea.KeyPressMsg{Code: 'E'})
+	m = res.(model)
+	if !m.pendingExport || cmd != nil {
+		t.Fatalf("export key should arm confirm without a command: pending=%v cmd=%v", m.pendingExport, cmd != nil)
+	}
+
+	res, cmd = m.handleHistorySessionsKey(tea.KeyPressMsg{Code: 'y'})
+	m = res.(model)
+	if m.pendingExport || cmd == nil {
+		t.Fatalf("y should clear pending and run export: pending=%v cmd=%v", m.pendingExport, cmd != nil)
+	}
+}
+
+func TestExportKeyInertOnViewer(t *testing.T) {
+	m := model{mode: modeHistoryTranscript, historyView: histTranscript, viewer: true}
+	m.history.openPath = "/x/session.jsonl"
+	res, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'E'})
+	if res.(model).pendingExport {
+		t.Fatal("viewer must not arm export")
+	}
+	if cmd != nil {
+		t.Fatal("viewer export key must be inert")
+	}
+}
+
+func TestBundleExtractDirContentAddressed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.argus")
+	content := bytes.Repeat([]byte("argus-bundle-payload!"), 4096) // > 64 KiB chunk
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d1, err := bundleExtractDir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d2, err := bundleExtractDir(path); err != nil || d2 != d1 {
+		t.Fatalf("same bundle should map to same dir: %q vs %q (err=%v)", d1, d2, err)
+	}
+
+	// Same content at a different path (copy/rename) reuses the extraction.
+	copyPath := filepath.Join(t.TempDir(), "renamed.argus")
+	if err := os.WriteFile(copyPath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if dc, err := bundleExtractDir(copyPath); err != nil || dc != d1 {
+		t.Fatalf("copied bundle should reuse dir: got %q want %q (err=%v)", dc, d1, err)
+	}
+
+	// Edited content maps elsewhere.
+	if err := os.WriteFile(path, append(content, 'X'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if de, err := bundleExtractDir(path); err != nil || de == d1 {
+		t.Fatalf("edited bundle should map to a different dir: got %q (err=%v)", de, err)
+	}
+}

--- a/internal/tui/export_test.go
+++ b/internal/tui/export_test.go
@@ -1,0 +1,65 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteExportFileDedupes(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir(dir)
+
+	p1, err := writeExportFile("s.argus", []byte("a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(p1) != "s.argus" {
+		t.Fatalf("first write name: %s", p1)
+	}
+	p2, err := writeExportFile("s.argus", []byte("b"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p2 == p1 {
+		t.Fatalf("second write should not overwrite: %s", p2)
+	}
+	if _, err := os.Stat(p2); err != nil {
+		t.Fatalf("second file missing: %v", err)
+	}
+	if !filepath.IsAbs(p1) {
+		t.Fatalf("expected absolute path, got %s", p1)
+	}
+	if !filepath.IsAbs(p2) {
+		t.Fatalf("expected absolute path for p2, got %s", p2)
+	}
+}
+
+// The node-supplied filename is untrusted: any directory component is stripped so
+// the write can only land in cwd, and a degenerate name is rejected.
+func TestWriteExportFileRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir(dir)
+	// Resolve after chdir: on macOS t.TempDir() is under /var but Getwd reports the
+	// real /private/var, so compare against the resolved cwd, not dir.
+	wantDir, _ := os.Getwd()
+
+	p, err := writeExportFile("../../etc/evil.argus", []byte("a"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if filepath.Dir(p) != wantDir {
+		t.Fatalf("write escaped cwd: %s (want dir %s)", p, wantDir)
+	}
+	if filepath.Base(p) != "evil.argus" {
+		t.Fatalf("directory components not stripped: %s", p)
+	}
+
+	if _, err := writeExportFile("..", []byte("a")); err == nil {
+		t.Fatal("expected rejection of degenerate filename")
+	}
+}

--- a/internal/tui/fileclient.go
+++ b/internal/tui/fileclient.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/MunifTanjim/argus/internal/adapter"
+	"github.com/MunifTanjim/argus/internal/adapters"
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/bundle"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// fileClient is an offline tui.Client backed by an extracted .argus bundle. It
+// answers the read-only history RPCs from disk and no-ops everything live.
+type fileClient struct {
+	destDir   string
+	manifest  bundle.Manifest
+	adapter   adapter.Adapter
+	entryPath string // absolute path to the main transcript file
+	events    chan api.Notification
+	states    chan bool
+	closeOnce sync.Once
+}
+
+func newFileClient(destDir string, m bundle.Manifest) (*fileClient, error) {
+	a := adapters.ByAgent(m.Agent)
+	if a == nil {
+		return nil, fmt.Errorf("view: unknown agent %q in bundle", m.Agent)
+	}
+	return &fileClient{
+		destDir:   destDir,
+		manifest:  m,
+		adapter:   a,
+		entryPath: filepath.Join(destDir, filepath.FromSlash(m.Entry)),
+		events:    make(chan api.Notification),
+		states:    make(chan bool),
+	}, nil
+}
+
+func (c *fileClient) syntheticProject() session.HistoryProject {
+	md := c.manifest.Metadata
+	label := md.Repo
+	if label == "" {
+		label = md.Title
+	}
+	if label == "" {
+		label = filepath.Base(md.Cwd)
+	}
+	return session.HistoryProject{
+		ProjectDir:   c.destDir,
+		Cwd:          md.Cwd,
+		Repo:         md.Repo,
+		Label:        label,
+		SessionCount: 1,
+		LastActivity: md.LastActivity,
+	}
+}
+
+func (c *fileClient) syntheticSession() session.HistorySession {
+	md := c.manifest.Metadata
+	return session.HistorySession{
+		SessionID:      "exported",
+		Agent:          c.manifest.Agent,
+		Title:          md.Title,
+		FirstMessage:   md.FirstMessage,
+		TranscriptPath: c.entryPath,
+		ModelName:      md.ModelName,
+		ModelColor:     md.ModelColor,
+		LastActivity:   md.LastActivity,
+		Tokens:         md.Tokens,
+		TurnCount:      md.TurnCount,
+		DurationMs:     md.DurationMs,
+	}
+}
+
+func (c *fileClient) Call(method string, params, out any) error {
+	switch method {
+	case api.MethodServerInfo:
+		return assign(out, api.ServerInfo{Version: c.manifest.ArgusVersion})
+	case api.MethodSessionsList:
+		return assign(out, []session.Session{})
+	case api.MethodSessionsHistoryProjects:
+		return assign(out, []session.HistoryProject{c.syntheticProject()})
+	case api.MethodSessionsHistorySessions:
+		return assign(out, session.HistorySessionPage{Items: []session.HistorySession{c.syntheticSession()}})
+	case api.MethodSessionsHistoryTranscript:
+		p, err := decodeParams[api.HistoryTranscriptParams](params)
+		if err != nil {
+			return err
+		}
+		if p.AgentID != "" {
+			v, _, err := c.adapter.ReadSubagentView(c.entryPath, p.AgentID)
+			if err != nil {
+				return err
+			}
+			return assign(out, v)
+		}
+		v, err := c.adapter.ReadTranscriptView(c.entryPath)
+		if err != nil {
+			return err
+		}
+		return assign(out, v)
+	case api.MethodSessionHistoryToolDetail:
+		p, err := decodeParams[api.HistoryToolDetailParams](params)
+		if err != nil {
+			return err
+		}
+		td, _, err := c.adapter.FindToolDetail(c.entryPath, p.AgentID, p.ToolID)
+		if err != nil {
+			return err
+		}
+		return assign(out, td)
+	default:
+		return nil // live-only methods are no-ops offline
+	}
+}
+
+func (c *fileClient) Events() <-chan api.Notification { return c.events }
+func (c *fileClient) States() <-chan bool             { return c.states }
+func (c *fileClient) Reconnect()                      {}
+
+// Close releases the client. The extracted destDir is left in place: it's a
+// deterministic per-bundle cache (see RunBundle) reused on the next open.
+func (c *fileClient) Close() error {
+	c.closeOnce.Do(func() { close(c.events) })
+	return nil
+}
+
+// assign marshals v then unmarshals into out, mirroring how ReconnectingClient.Call
+// populates the out pointer via JSON-RPC decoding.
+func assign(out, v any) error {
+	if out == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, out)
+}
+
+func decodeParams[T any](params any) (T, error) {
+	var t T
+	b, err := json.Marshal(params)
+	if err != nil {
+		return t, err
+	}
+	return t, json.Unmarshal(b, &t)
+}

--- a/internal/tui/fileclient_test.go
+++ b/internal/tui/fileclient_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/bundle"
+	"github.com/MunifTanjim/argus/internal/session"
+	"github.com/MunifTanjim/argus/internal/transcript"
+)
+
+func copyFileForTest(t *testing.T, src, dst string) error {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func TestFileClientServesHistory(t *testing.T) {
+	// Reuse a real claudecode transcript fixture from the parser testdata.
+	fixture := filepath.Join("..", "adapter", "claudecode", "parser", "testdata", "multi_turn.jsonl")
+	dir := t.TempDir()
+	// Lay the fixture where manifest.Entry points.
+	entry := "root/session.jsonl"
+	if err := copyFileForTest(t, fixture, filepath.Join(dir, filepath.FromSlash(entry))); err != nil {
+		t.Fatalf("fixture unavailable: %v", err)
+	}
+	m := bundle.Manifest{Agent: "claude", Entry: entry, Metadata: bundle.Metadata{Title: "T"}}
+	fc, err := newFileClient(dir, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var page session.HistorySessionPage
+	if err := fc.Call(api.MethodSessionsHistorySessions, api.HistorySessionsParams{}, &page); err != nil {
+		t.Fatalf("historySessions: %v", err)
+	}
+	if len(page.Items) != 1 || page.Items[0].Title != "T" {
+		t.Fatalf("want one session titled T, got %+v", page.Items)
+	}
+
+	var view transcript.TranscriptView
+	if err := fc.Call(api.MethodSessionsHistoryTranscript, api.HistoryTranscriptParams{
+		TranscriptPath: filepath.Join(dir, filepath.FromSlash(entry)), Agent: "claude",
+	}, &view); err != nil {
+		t.Fatalf("historyTranscript: %v", err)
+	}
+	if len(view.Chunks) == 0 {
+		t.Fatal("expected chunks from fixture")
+	}
+}
+
+func TestFileClientCloseIdempotent(t *testing.T) {
+	fixture := filepath.Join("..", "adapter", "claudecode", "parser", "testdata", "multi_turn.jsonl")
+	dir := t.TempDir()
+	entry := "root/session.jsonl"
+	if err := copyFileForTest(t, fixture, filepath.Join(dir, filepath.FromSlash(entry))); err != nil {
+		t.Fatalf("fixture unavailable: %v", err)
+	}
+	m := bundle.Manifest{Agent: "claude", Entry: entry, Metadata: bundle.Metadata{Title: "T"}}
+	fc, err := newFileClient(dir, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fc.Close(); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("first Close: %v", err)
+	}
+	// Second call must not panic.
+	if err := fc.Close(); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+}
+
+func TestFileClientSubagentDrill(t *testing.T) {
+	// Fixture mirrors the claudecode subagents layout:
+	//   destDir/root/session.jsonl             (main transcript)
+	//   destDir/root/session/subagents/agent-abc1234.jsonl  (subagent file)
+	baseFixture := filepath.Join("..", "adapter", "claudecode", "parser", "testdata", "test-session.jsonl")
+	subagentFixture := filepath.Join("..", "adapter", "claudecode", "parser", "testdata", "test-session", "subagents", "agent-abc1234.jsonl")
+
+	dir := t.TempDir()
+	entry := "root/session.jsonl"
+	entryAbs := filepath.Join(dir, filepath.FromSlash(entry))
+	if err := copyFileForTest(t, baseFixture, entryAbs); err != nil {
+		t.Fatalf("main fixture unavailable: %v", err)
+	}
+	// subagentsDir for session.jsonl is session/subagents/
+	subDir := filepath.Join(filepath.Dir(entryAbs), "session", "subagents")
+	if err := copyFileForTest(t, subagentFixture, filepath.Join(subDir, "agent-abc1234.jsonl")); err != nil {
+		t.Fatalf("subagent fixture unavailable: %v", err)
+	}
+
+	m := bundle.Manifest{Agent: "claude", Entry: entry, Metadata: bundle.Metadata{Title: "T"}}
+	fc, err := newFileClient(dir, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fc.Close()
+
+	var view transcript.TranscriptView
+	if err := fc.Call(api.MethodSessionsHistoryTranscript, api.HistoryTranscriptParams{
+		TranscriptPath: entryAbs, Agent: "claude", AgentID: "abc1234",
+	}, &view); err != nil {
+		t.Fatalf("subagent Call: %v", err)
+	}
+	if len(view.Chunks) == 0 {
+		t.Fatal("expected chunks from subagent fixture")
+	}
+}

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -294,6 +294,12 @@ func (m model) handleHistoryTranscriptKey(msg tea.KeyPressMsg) (tea.Model, tea.C
 	if mm, cmd, ok := m.takePendingExport(msg); ok {
 		return mm, cmd
 	}
+	if mm, cmd, ok := m.takePendingRedactSave(msg); ok {
+		return mm, cmd
+	}
+	if mm, cmd, ok := m.handleRedactKey(msg); ok {
+		return mm, cmd
+	}
 	if key.Matches(msg, transcriptKeys.Back) {
 		if m.historyView == histDetail {
 			if m.popDetail() { // root frame → back to transcript
@@ -402,13 +408,17 @@ func renderCardList(cards []string, cursor, avail int) string {
 func (m model) historyTranscriptView() string {
 	header := centerBlock(indentBlock(m.historyTranscriptHeader(), strings.Repeat(" ", contentPadX)), m.containerWidth(), m.width)
 	body := m.historyBody() // reuses live transcript/detail renderers (read-only)
+	if m.redactListActive() {
+		// The list (D) replaces the transcript body so the queued secrets are visible.
+		body = centerBlock(indentBlock(m.redactListBody(), strings.Repeat(" ", contentPadX)), m.containerWidth(), m.width)
+	}
 
 	binds := []key.Binding{transcriptKeys.ScrollUp, transcriptKeys.TurnNext, transcriptKeys.Fold, transcriptKeys.Detail, transcriptKeys.Bottom}
 	if !m.viewer {
 		binds = append(binds, transcriptKeys.Resume) // resume is meaningless offline
 	}
 	binds = append(binds, transcriptKeys.Back)
-	footer := m.exportOrFlashFooter(m.footer(binds...))
+	footer := m.redactFooter(m.exportOrFlashFooter(m.footer(binds...)))
 	return pinFooter(header+"\n\n"+body, footer, m.width, m.height)
 }
 

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -145,8 +145,36 @@ func (m model) actHistProjOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, m.fetchHistSessions(p.NodeID, p.ProjectDir, 0)
 }
 
+// takePendingExport consumes an armed export confirmation: "y" runs the export,
+// any other key cancels. ok reports that the key was handled here.
+func (m model) takePendingExport(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
+	if !m.pendingExport {
+		return m, nil, false
+	}
+	m.pendingExport = false
+	if msg.String() == "y" {
+		mm, cmd := m.actExportSession(msg)
+		return mm, cmd, true
+	}
+	return m, nil, true
+}
+
+// exportOrFlashFooter overrides footer with the export prompt or a transient flash.
+func (m model) exportOrFlashFooter(footer string) string {
+	switch {
+	case m.pendingExport:
+		return asstStyle.Render("export this session? y/n")
+	case m.flash != "":
+		return asstStyle.Render(m.flash)
+	}
+	return footer
+}
+
 func (m model) handleHistorySessionsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.flash = "" // any key dismisses a transient flash; the action may re-set it
+	if mm, cmd, ok := m.takePendingExport(msg); ok {
+		return mm, cmd
+	}
 	if mm, cmd, ok := m.dispatch(msg, historySessionsTable); ok {
 		return mm, cmd
 	}
@@ -162,8 +190,17 @@ var historySessionsTable = []keyTableEntry{
 	{historySessionsKeys.HalfDown, model.actHistSessHalfDown},
 	{historySessionsKeys.Open, model.actHistSessOpen},
 	{historySessionsKeys.Resume, model.actHistSessResume},
+	{transcriptKeys.Export, model.actHistSessExport},
 	{historySessionsKeys.More, model.actHistSessMore},
 	{historySessionsKeys.Back, model.actHistSessBack},
+}
+
+func (m model) actHistSessExport(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.history.sessCursor >= len(m.history.sessions) {
+		return m, nil
+	}
+	m.pendingExport = true
+	return m, nil
 }
 
 func (m model) actHistSessUp(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -237,6 +274,7 @@ func (m model) actHistSessOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	s := m.history.sessions[m.history.sessCursor]
 	m.history.title = historySessionTitle(s)
+	m.history.openSession = s
 	// Address for follow-up per-tool detail fetches on this transcript.
 	m.history.openNodeID, m.history.openPath, m.history.openAgent = m.history.project.NodeID, s.TranscriptPath, s.Agent
 	m.history.openSessionID, m.history.openResumable = s.SessionID, s.Resumable
@@ -253,6 +291,9 @@ func (m model) actHistSessOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 func (m model) handleHistoryTranscriptKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.flash = "" // any key dismisses a transient flash; the action may re-set it
+	if mm, cmd, ok := m.takePendingExport(msg); ok {
+		return mm, cmd
+	}
 	if key.Matches(msg, transcriptKeys.Back) {
 		if m.historyView == histDetail {
 			if m.popDetail() { // root frame → back to transcript
@@ -260,14 +301,24 @@ func (m model) handleHistoryTranscriptKey(msg tea.KeyPressMsg) (tea.Model, tea.C
 			}
 			return m, nil
 		}
+		if m.viewer {
+			return m, tea.Quit
+		}
 		m.mode = modeHistorySessions
 		return m, nil
 	}
-	if key.Matches(msg, transcriptKeys.Resume) && m.historyView == histTranscript {
+	if key.Matches(msg, transcriptKeys.Resume) && m.historyView == histTranscript && !m.viewer {
 		return m.startHistoryResume(m.history.openResumable, m.history.openNodeID, m.history.openAgent, m.history.openSessionID)
 	}
 	if m.historyView == histDetail {
 		return m.handleDetailKey(msg)
+	}
+	if key.Matches(msg, transcriptKeys.Export) && m.historyView == histTranscript {
+		if m.viewer {
+			return m, nil
+		}
+		m.pendingExport = true
+		return m, nil
 	}
 	return m.handleTranscriptKey(msg)
 }
@@ -321,15 +372,12 @@ func (m model) historySessionsView() string {
 		cards[i] = historySessionRow(s, i == m.history.sessCursor, cardW, showAgent)
 	}
 	body := renderCardList(cards, m.history.sessCursor, max(1, m.height-4))
-	binds := []key.Binding{historySessionsKeys.Up, historySessionsKeys.Bottom, historySessionsKeys.Open, historySessionsKeys.Resume}
+	binds := []key.Binding{historySessionsKeys.Up, historySessionsKeys.Bottom, historySessionsKeys.Open, historySessionsKeys.Resume, transcriptKeys.Export}
 	if m.history.hasMore {
 		binds = append(binds, historySessionsKeys.More)
 	}
 	binds = append(binds, historySessionsKeys.Back)
-	footer := m.footer(binds...)
-	if m.flash != "" {
-		footer = asstStyle.Render(m.flash)
-	}
+	footer := m.exportOrFlashFooter(m.footer(binds...))
 	return pinFooter(centerBlock(title+"\n\n"+body, cardW, m.width), footer, m.width, m.height)
 }
 
@@ -352,6 +400,40 @@ func renderCardList(cards []string, cursor, avail int) string {
 }
 
 func (m model) historyTranscriptView() string {
+	header := centerBlock(indentBlock(m.historyTranscriptHeader(), strings.Repeat(" ", contentPadX)), m.containerWidth(), m.width)
+	body := m.historyBody() // reuses live transcript/detail renderers (read-only)
+
+	binds := []key.Binding{transcriptKeys.ScrollUp, transcriptKeys.TurnNext, transcriptKeys.Fold, transcriptKeys.Detail, transcriptKeys.Bottom}
+	if !m.viewer {
+		binds = append(binds, transcriptKeys.Resume) // resume is meaningless offline
+	}
+	binds = append(binds, transcriptKeys.Back)
+	footer := m.exportOrFlashFooter(m.footer(binds...))
+	return pinFooter(header+"\n\n"+body, footer, m.width, m.height)
+}
+
+// historyTranscriptHeader renders the open-transcript header: a manifest-driven
+// summary offline (no live node/history breadcrumb), else the history breadcrumb.
+func (m model) historyTranscriptHeader() string {
+	if m.viewer {
+		s := m.history.openSession
+		title := s.Title
+		if title == "" {
+			title = s.FirstMessage
+		}
+		label := m.history.project.Label
+		if label == "" {
+			label = "session"
+		}
+		header := headerStyle.Render("argus · " + label)
+		if title != "" {
+			header += dimStyle.Render("  " + truncate(title, 50))
+		}
+		if s.ModelName != "" {
+			header += dimStyle.Render("  · " + s.ModelName)
+		}
+		return header
+	}
 	parts := []string{"argus", "history"}
 	if lbl := m.history.project.Label; lbl != "" {
 		parts = append(parts, lbl)
@@ -360,14 +442,7 @@ func (m model) historyTranscriptView() string {
 	if m.history.title != "" {
 		header += dimStyle.Render("  " + truncate(m.history.title, 60))
 	}
-	header = centerBlock(indentBlock(header, strings.Repeat(" ", contentPadX)), m.containerWidth(), m.width)
-	body := m.historyBody() // reuses live transcript/detail renderers (read-only)
-	footer := m.footer(transcriptKeys.ScrollUp, transcriptKeys.TurnNext, transcriptKeys.Fold,
-		transcriptKeys.Detail, transcriptKeys.Bottom, transcriptKeys.Resume, transcriptKeys.Back)
-	if m.flash != "" {
-		footer = asstStyle.Render(m.flash)
-	}
-	return pinFooter(header+"\n\n"+body, footer, m.width, m.height)
+	return header
 }
 
 // --- row rendering ------------------------------------------------------------

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -68,6 +68,7 @@ var transcriptKeys = struct {
 	ScrollUp, ScrollDown, TurnNext, TurnPrev, CardNext, CardPrev, HalfUp, HalfDown key.Binding
 	Top, Bottom, Fold, Detail, ExpandAll, CollapseAll                              key.Binding
 	Raw, Answer, Export, Back, Resume                                              key.Binding
+	Redact, RedactSave, RedactList                                                 key.Binding
 }{
 	ScrollUp:    nb([]string{"up"}, "↑/↓", "scroll"),
 	ScrollDown:  nb([]string{"down"}, "", ""),
@@ -88,6 +89,9 @@ var transcriptKeys = struct {
 	Export:      nb([]string{"E"}, "E", "export"),
 	Back:        nb([]string{"esc", "escape", "q"}, "esc", "back"),
 	Resume:      nb([]string{"R"}, "R", "resume"),
+	Redact:      nb([]string{"d"}, "d", "redact"),
+	RedactList:  nb([]string{"D"}, "D", "redactions"),
+	RedactSave:  nb([]string{"W"}, "W", "save redacted"),
 }
 
 var detailKeys = struct {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -67,7 +67,7 @@ var listKeys = struct {
 var transcriptKeys = struct {
 	ScrollUp, ScrollDown, TurnNext, TurnPrev, CardNext, CardPrev, HalfUp, HalfDown key.Binding
 	Top, Bottom, Fold, Detail, ExpandAll, CollapseAll                              key.Binding
-	Raw, Answer, Back, Resume                                                      key.Binding
+	Raw, Answer, Export, Back, Resume                                              key.Binding
 }{
 	ScrollUp:    nb([]string{"up"}, "↑/↓", "scroll"),
 	ScrollDown:  nb([]string{"down"}, "", ""),
@@ -85,6 +85,7 @@ var transcriptKeys = struct {
 	CollapseAll: nb([]string{"O"}, "", ""),
 	Raw:         nb([]string{"ctrl+s"}, "ctrl+s", "raw"),
 	Answer:      nb([]string{"tab"}, "tab", "answer"),
+	Export:      nb([]string{"E"}, "E", "export"),
 	Back:        nb([]string{"esc", "escape", "q"}, "esc", "back"),
 	Resume:      nb([]string{"R"}, "R", "resume"),
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -82,6 +82,7 @@ type model struct {
 	height       int
 	reconnecting bool // connection dropped; the client is retrying
 	hasDark      bool // terminal background; drives glamour/highlight styling
+	viewer       bool // offline viewer mode: opens directly in transcript view
 
 	mode         viewMode
 	screenReturn viewMode // mode to restore when leaving the live screen (ctrl+])
@@ -105,6 +106,7 @@ type model struct {
 	prompt promptState // compose-then-submit draft for the prompt dock
 
 	pendingKill     bool   // awaiting kill confirmation in list view
+	pendingExport   bool   // awaiting export confirmation in history transcript view
 	pendingResumeID string // resumed session id to select once it appears in the list
 	flash           string // transient list-view status (e.g. why a jump was refused)
 
@@ -141,15 +143,16 @@ type transcriptState struct {
 // historyState holds the read-only History view: the project list, a project's
 // paginated session list, and the open transcript's title.
 type historyState struct {
-	projects   []session.HistoryProject
-	projCursor int
-	err        error
-	project    session.HistoryProject // the project being drilled into
-	sessions   []session.HistorySession
-	sessCursor int
-	hasMore    bool
-	loading    bool
-	title      string // header for the open historical transcript
+	projects    []session.HistoryProject
+	projCursor  int
+	err         error
+	project     session.HistoryProject // the project being drilled into
+	sessions    []session.HistorySession
+	sessCursor  int
+	hasMore     bool
+	loading     bool
+	title       string                 // header for the open historical transcript
+	openSession session.HistorySession // retained for export metadata
 	// openNodeID/openPath/openAgent route per-tool detail fetches to the right adapter.
 	openNodeID    string
 	openPath      string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/x/vt"
 
+	"github.com/MunifTanjim/argus/internal/bundle"
 	"github.com/MunifTanjim/argus/internal/logbuf"
 	"github.com/MunifTanjim/argus/internal/session"
 	"github.com/MunifTanjim/argus/internal/transcript"
@@ -83,6 +84,11 @@ type model struct {
 	reconnecting bool // connection dropped; the client is retrying
 	hasDark      bool // terminal background; drives glamour/highlight styling
 	viewer       bool // offline viewer mode: opens directly in transcript view
+
+	redactMode   bool        // --redact: interactive redaction affordance in the viewer
+	bundlePath   string      // source .argus path (for the -redacted output name)
+	redactSrcDir string      // extracted cache dir to redact from
+	redact       redactState // queued literals + input/confirm state
 
 	mode         viewMode
 	screenReturn viewMode // mode to restore when leaving the live screen (ctrl+])
@@ -203,4 +209,19 @@ func (m *model) syncPromptDraft() {
 		m.resetPromptState()
 		m.prompt.key = k
 	}
+}
+
+// redactState holds queued secrets plus input/confirm state for interactive redaction.
+type redactState struct {
+	literals    []string
+	inputActive bool
+	input       string
+	listActive  bool
+	listCursor  int
+	listReturn  bool // input was opened from the list (D); reopen it when the input closes
+	pendingSave bool
+	warnConfirm bool // prepare found un-scrubbable content; require an extra ack before saving
+	report      *bundle.Report
+	tempPath    string // staged bundle awaiting confirmation; renamed to outPath on save
+	outPath     string // resolved sibling bundle path
 }

--- a/internal/tui/pinfooter_test.go
+++ b/internal/tui/pinfooter_test.go
@@ -1,0 +1,47 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+func TestPinFooterWrapsLongFooterWithinViewport(t *testing.T) {
+	const width, height = 24, 8
+	body := "transcript"
+	footer := "⚠ 2 item(s) hold secrets that can't be removed — they WILL remain in the export. y save anyway · any cancel"
+
+	out := pinFooter(body, footer, width, height)
+	lines := strings.Split(out, "\n")
+
+	// Nothing clips: the whole thing fits the viewport height exactly.
+	if len(lines) != height {
+		t.Fatalf("pinned output = %d lines, want %d (footer must not overflow the viewport)", len(lines), height)
+	}
+	// Every line stays within the terminal width (footer wrapped, not truncated).
+	for i, l := range lines {
+		if w := lipgloss.Width(l); w > width {
+			t.Fatalf("line %d width %d exceeds terminal width %d: %q", i, w, width, l)
+		}
+	}
+	// All of the footer's words survive across the wrapped lines.
+	joined := lipgloss.NewStyle().Render(strings.Join(lines, " "))
+	for _, word := range []string{"secrets", "remain", "cancel"} {
+		if !strings.Contains(joined, word) {
+			t.Fatalf("wrapped footer dropped %q:\n%s", word, out)
+		}
+	}
+}
+
+func TestPinFooterShortFooterUnchanged(t *testing.T) {
+	const width, height = 40, 6
+	out := pinFooter("body", "esc back", width, height)
+	lines := strings.Split(out, "\n")
+	if len(lines) != height {
+		t.Fatalf("short footer: got %d lines, want %d", len(lines), height)
+	}
+	if !strings.Contains(lines[height-1], "esc back") {
+		t.Fatalf("short footer should sit on the last row, got %q", lines[height-1])
+	}
+}

--- a/internal/tui/redact.go
+++ b/internal/tui/redact.go
@@ -1,0 +1,285 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/MunifTanjim/argus/internal/bundle"
+)
+
+// redactPreparedMsg carries a staged redaction: the finished bundle in a temp
+// file, plus the report whose warnings gate the save.
+type redactPreparedMsg struct {
+	tempPath string // staged bundle awaiting confirmation
+	outPath  string // rename target on confirm
+	report   bundle.Report
+	err      error
+}
+
+type redactDoneMsg struct {
+	path     string
+	warnings []string // content that could not be scrubbed and remains in the export
+	sidecar  string   // path of the written .warnings.txt, if any
+	err      error
+}
+
+// redactPrepareCmd redacts into a temp tree and stages the bundle as a hidden
+// sibling of the destination; redactCommitCmd creates the final -redacted name
+// only on confirm, so an unacknowledged leak never lands under a clean name.
+func (m model) redactPrepareCmd() tea.Cmd {
+	srcDir, out := m.redactSrcDir, redactOutputPath(m.bundlePath)
+	lits := append([]string(nil), m.redact.literals...)
+	return func() tea.Msg {
+		tmpDir, err := os.MkdirTemp("", "argus-redact-*")
+		if err != nil {
+			return redactPreparedMsg{err: err}
+		}
+		defer os.RemoveAll(tmpDir)
+		rep, err := bundle.RedactTree(srcDir, tmpDir, lits)
+		if err != nil {
+			return redactPreparedMsg{err: err}
+		}
+		// Same dir as the destination so commit is an atomic rename.
+		f, err := os.CreateTemp(filepath.Dir(out), ".argus-redacted-*")
+		if err != nil {
+			return redactPreparedMsg{err: err}
+		}
+		tmpPath := f.Name()
+		if err := bundle.WriteDir(f, tmpDir); err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return redactPreparedMsg{err: err}
+		}
+		if err := f.Close(); err != nil {
+			os.Remove(tmpPath)
+			return redactPreparedMsg{err: err}
+		}
+		return redactPreparedMsg{tempPath: tmpPath, outPath: out, report: rep}
+	}
+}
+
+// redactCommitCmd renames the staged bundle to its final name and, when content
+// couldn't be scrubbed, writes a sidecar listing the files that still hold secrets.
+func (m model) redactCommitCmd() tea.Cmd {
+	tmpPath, out := m.redact.tempPath, m.redact.outPath
+	warnings := append([]string(nil), m.redact.report.Warnings...)
+	return func() tea.Msg {
+		if err := os.Rename(tmpPath, out); err != nil {
+			os.Remove(tmpPath)
+			return redactDoneMsg{err: err}
+		}
+		sidecar := ""
+		if len(warnings) > 0 {
+			if err := writeWarningsSidecar(out, warnings); err == nil {
+				sidecar = warningsSidecarPath(out)
+			}
+		}
+		return redactDoneMsg{path: out, warnings: warnings, sidecar: sidecar}
+	}
+}
+
+// redactAbortCmd deletes a staged bundle the user declined to save.
+func redactAbortCmd(tmpPath string) tea.Cmd {
+	return func() tea.Msg {
+		if tmpPath != "" {
+			os.Remove(tmpPath)
+		}
+		return nil
+	}
+}
+
+// warningsSidecarPath is the sidecar path for a bundle's unscrubbed-content notes.
+func warningsSidecarPath(bundlePath string) string {
+	return bundlePath + ".warnings.txt"
+}
+
+func writeWarningsSidecar(bundlePath string, warnings []string) error {
+	body := "Secrets that could NOT be removed from " + filepath.Base(bundlePath) +
+		" — review before sharing:\n\n" + strings.Join(warnings, "\n") + "\n"
+	return os.WriteFile(warningsSidecarPath(bundlePath), []byte(body), 0o644)
+}
+
+// redactOutputPath returns <stem>-redacted<ext> next to srcPath, suffixed if taken.
+func redactOutputPath(srcPath string) string {
+	dir := filepath.Dir(srcPath)
+	ext := filepath.Ext(srcPath)
+	stem := filepath.Base(srcPath)
+	stem = stem[:len(stem)-len(ext)]
+	return nextAvailablePath(dir, stem+"-redacted", ext)
+}
+
+// redactListActive reports whether the queued-redactions list is open.
+func (m model) redactListActive() bool {
+	return m.redactActive() && m.redact.listActive
+}
+
+// redactListBody renders the queued redactions with the delete cursor. Literals
+// are shown in full so they can be told apart and managed.
+func (m model) redactListBody() string {
+	if len(m.redact.literals) == 0 {
+		return dimStyle.Render("no redactions queued — press d to add a secret")
+	}
+	var b strings.Builder
+	b.WriteString(asstStyle.Render(fmt.Sprintf("queued redactions (%d)", len(m.redact.literals))))
+	b.WriteString("\n\n")
+	for i, lit := range m.redact.literals {
+		marker := "  "
+		row := dimStyle.Render(lit)
+		if i == m.redact.listCursor {
+			marker = cursorStyle.Render("▸ ")
+			row = cursorStyle.Render(lit)
+		}
+		b.WriteString(marker + row)
+		if i < len(m.redact.literals)-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func (m model) redactFooter(base string) string {
+	switch {
+	case m.redact.inputActive:
+		return asstStyle.Render("redact (paste secret): " + m.redact.input + "▊  enter add · esc cancel")
+	case m.redact.listActive:
+		return asstStyle.Render(fmt.Sprintf("redactions: %d  j/k move · x delete · esc close", len(m.redact.literals)))
+	case m.redact.pendingSave && m.redact.warnConfirm && m.redact.report != nil:
+		// Danger first, so it can't be truncated behind a y/n prompt.
+		line := fmt.Sprintf("⚠ %d item(s) hold secrets that can't be removed — they WILL remain in the export. y save anyway · any cancel",
+			len(m.redact.report.Warnings))
+		return StyleErrorBold.Render(line)
+	case m.redact.pendingSave && m.redact.report != nil:
+		occ := 0
+		for _, v := range m.redact.report.Counts {
+			occ += v
+		}
+		line := fmt.Sprintf("redact %d secret(s), %d occurrence(s) → %s? y/n",
+			len(m.redact.literals), occ, filepath.Base(m.redact.outPath))
+		if zm := m.redact.report.ZeroMatch(m.redact.literals); len(zm) > 0 {
+			line += "  ⚠ no match: " + strings.Join(zm, ", ")
+		}
+		return asstStyle.Render(line)
+	case m.flash != "": // transient flash (save done / error) beats the queued-count hint
+		return base
+	case len(m.redact.literals) > 0:
+		return asstStyle.Render(fmt.Sprintf("%d redaction(s) queued · d add · D list · W save", len(m.redact.literals)))
+	case m.redactMode:
+		return asstStyle.Render("redact: d add secret")
+	}
+	return base
+}
+
+// takePendingRedactSave consumes an armed save confirmation; non-"y" cancels. With
+// warnConfirm, the first "y" only acknowledges the warning and a second saves, so a
+// single reflexive keypress can't blow past "secrets will remain".
+func (m model) takePendingRedactSave(msg tea.KeyPressMsg) (model, tea.Cmd, bool) {
+	if !m.redact.pendingSave {
+		return m, nil, false
+	}
+	if msg.String() != "y" {
+		tmp := m.redact.tempPath
+		m.redact.pendingSave, m.redact.warnConfirm, m.redact.tempPath = false, false, ""
+		return m, redactAbortCmd(tmp), true
+	}
+	if m.redact.warnConfirm {
+		m.redact.warnConfirm = false // acknowledged; next y saves
+		return m, nil, true
+	}
+	m.redact.pendingSave = false
+	cmd := m.redactCommitCmd()
+	m.redact.tempPath = ""
+	return m, cmd, true
+}
+
+// redactActive reports whether redaction keys are live. Queued literals are
+// bundle-wide, so redaction stays available in both the transcript and detail views.
+func (m model) redactActive() bool {
+	return m.redactMode && m.mode == modeHistoryTranscript
+}
+
+// handleRedactKey processes redaction keys and input. ok reports the key was consumed.
+func (m model) handleRedactKey(msg tea.KeyPressMsg) (model, tea.Cmd, bool) {
+	if !m.redactActive() {
+		return m, nil, false
+	}
+	if m.redact.listActive {
+		switch {
+		case key.Matches(msg, transcriptKeys.Back):
+			m.redact.listActive = false
+			return m, nil, true
+		case msg.Text == "j":
+			m.redact.listCursor = min(m.redact.listCursor+1, max(0, len(m.redact.literals)-1))
+			return m, nil, true
+		case msg.Text == "k":
+			m.redact.listCursor = max(0, m.redact.listCursor-1)
+			return m, nil, true
+		case msg.Text == "x":
+			if i := m.redact.listCursor; i < len(m.redact.literals) {
+				m.redact.literals = append(m.redact.literals[:i], m.redact.literals[i+1:]...)
+				m.redact.listCursor = max(0, min(i, len(m.redact.literals)-1))
+			}
+			return m, nil, true
+		case key.Matches(msg, transcriptKeys.Redact): // d: add another, then return here
+			m.redact.listActive, m.redact.listReturn = false, true
+			m.redact.inputActive, m.redact.input = true, ""
+			return m, nil, true
+		}
+		return m, nil, true
+	}
+	if m.redact.inputActive {
+		return m.handleRedactInput(msg)
+	}
+	switch {
+	case key.Matches(msg, transcriptKeys.Redact):
+		m.redact.inputActive = true
+		m.redact.input = ""
+		return m, nil, true
+	case key.Matches(msg, transcriptKeys.RedactList):
+		m.redact.listActive = true
+		m.redact.listCursor = 0
+		return m, nil, true
+	case key.Matches(msg, transcriptKeys.RedactSave):
+		if len(m.redact.literals) == 0 {
+			m.flash = "no redactions queued"
+			return m, nil, true
+		}
+		return m, m.redactPrepareCmd(), true
+	}
+	return m, nil, false
+}
+
+func (m model) handleRedactInput(msg tea.KeyPressMsg) (model, tea.Cmd, bool) {
+	switch msg.Code {
+	case tea.KeyEnter:
+		if s := m.redact.input; s != "" {
+			m.redact.literals = append(m.redact.literals, s)
+			m.flash = "redaction queued"
+		}
+		m.redact.inputActive, m.redact.input = false, ""
+		if m.redact.listReturn { // came from the list — reopen it on the new entry
+			m.redact.listActive, m.redact.listReturn = true, false
+			m.redact.listCursor = max(0, len(m.redact.literals)-1)
+		}
+		return m, nil, true
+	case tea.KeyEscape:
+		m.redact.inputActive, m.redact.input = false, ""
+		if m.redact.listReturn {
+			m.redact.listActive, m.redact.listReturn = true, false
+		}
+		return m, nil, true
+	case tea.KeyBackspace:
+		if n := len(m.redact.input); n > 0 {
+			m.redact.input = m.redact.input[:n-1]
+		}
+		return m, nil, true
+	}
+	if msg.Text != "" {
+		m.redact.input += msg.Text
+	}
+	return m, nil, true
+}

--- a/internal/tui/redact_test.go
+++ b/internal/tui/redact_test.go
@@ -1,0 +1,449 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/MunifTanjim/argus/internal/bundle"
+)
+
+func newRedactModel() model {
+	m := model{mode: modeHistoryTranscript, historyView: histTranscript, viewer: true, redactMode: true}
+	m.history.openPath = "/x/s.jsonl"
+	return m
+}
+
+func TestRedactInputQueuesLiteral(t *testing.T) {
+	m := newRedactModel()
+
+	// 'd' opens the input.
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m = res.(model)
+	if !m.redact.inputActive {
+		t.Fatal("d should open the redact input")
+	}
+
+	// Type "sk".
+	for _, r := range "sk" {
+		res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: r, Text: string(r)})
+		m = res.(model)
+	}
+	if m.redact.input != "sk" {
+		t.Fatalf("input buffer = %q, want sk", m.redact.input)
+	}
+
+	// Enter commits.
+	res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = res.(model)
+	if m.redact.inputActive {
+		t.Fatal("enter should close the input")
+	}
+	if len(m.redact.literals) != 1 || m.redact.literals[0] != "sk" {
+		t.Fatalf("literals = %v, want [sk]", m.redact.literals)
+	}
+}
+
+func TestRedactInputWorksInDetailView(t *testing.T) {
+	// Queued literals apply bundle-wide, so redaction keys must stay live after
+	// drilling into the detail view, not just on the transcript page.
+	m := newRedactModel()
+	m.historyView = histDetail
+
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m = res.(model)
+	if !m.redact.inputActive {
+		t.Fatal("d should open the redact input in the detail view")
+	}
+
+	// A drill-down navigation key must still reach the detail handler when the
+	// redact input isn't capturing (i.e. redaction doesn't swallow detail nav).
+	m.redact.inputActive = false
+	if m.redactActive() && func() bool {
+		_, _, ok := m.handleRedactKey(tea.KeyPressMsg{Code: 'j', Text: "j"})
+		return ok
+	}() {
+		t.Fatal("j must fall through to detail navigation, not be consumed by redaction")
+	}
+}
+
+func TestRedactInputEscCancels(t *testing.T) {
+	m := newRedactModel()
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m = res.(model)
+	res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m = res.(model)
+	if m.redact.inputActive || len(m.redact.literals) != 0 {
+		t.Fatal("esc should cancel input without queuing")
+	}
+}
+
+func TestRedactKeysInertWithoutFlag(t *testing.T) {
+	m := newRedactModel()
+	m.redactMode = false
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if res.(model).redact.inputActive {
+		t.Fatal("d must not open redact input when --redact is off")
+	}
+}
+
+func writeMinimalExtraction(t *testing.T, dir string) {
+	t.Helper()
+	man := `{"format_version":1,"agent":"claude","entry":"root/s.jsonl","metadata":{"title":"t"}}`
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(man), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(dir, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "s.jsonl"), []byte(`{"r":"sk-secret"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedactSaveWritesSiblingBundle(t *testing.T) {
+	src := t.TempDir()
+	writeMinimalExtraction(t, src)
+
+	m := newRedactModel()
+	m.redactSrcDir = src
+	m.bundlePath = filepath.Join(t.TempDir(), "session.argus")
+	m.redact.literals = []string{"sk-secret"}
+
+	res, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'W', Text: "W"})
+	m = res.(model)
+	if cmd == nil {
+		t.Fatal("W with queued literals should run a prepare command")
+	}
+	msg := cmd()
+	res, _ = m.Update(msg)
+	m = res.(model)
+	if !m.redact.pendingSave {
+		t.Fatal("prepare result should arm pendingSave")
+	}
+
+	// The final -redacted name must not exist until the user confirms; the work is
+	// staged to a temp file so an unacknowledged residual never lands under it.
+	wantPath := filepath.Join(filepath.Dir(m.bundlePath), "session-redacted.argus")
+	if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+		t.Fatalf("final bundle must not exist before confirmation, stat err = %v", err)
+	}
+	if m.redact.tempPath == "" {
+		t.Fatal("prepare should stage a temp bundle path")
+	}
+	if _, err := os.Stat(m.redact.tempPath); err != nil {
+		t.Fatalf("staged temp bundle should exist: %v", err)
+	}
+
+	res, cmd = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m = res.(model)
+	if cmd == nil {
+		t.Fatal("y should run the save command")
+	}
+	done := cmd().(redactDoneMsg)
+	if done.err != nil {
+		t.Fatalf("save failed: %v", done.err)
+	}
+	if _, err := os.Stat(done.path); err != nil {
+		t.Fatalf("redacted bundle not written: %v", err)
+	}
+	if filepath.Base(done.path) != "session-redacted.argus" {
+		t.Fatalf("unexpected output name: %s", done.path)
+	}
+}
+
+// writeExtractionWithBinarySecret builds an extraction whose secret lives in a
+// binary file, so RedactTree can't scrub it and must warn.
+func writeExtractionWithBinarySecret(t *testing.T, dir, secret string) {
+	t.Helper()
+	man := `{"format_version":1,"agent":"claude","entry":"root/s.jsonl","metadata":{"title":"t"}}`
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(man), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(dir, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "s.jsonl"), []byte(`{"r":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A NUL byte in the head marks this binary; the secret rides in the tail.
+	blob := append([]byte{0x00, 0x01, 0x02}, []byte(secret)...)
+	if err := os.WriteFile(filepath.Join(root, "blob.bin"), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedactSaveWritesWarningsSidecar(t *testing.T) {
+	src := t.TempDir()
+	writeExtractionWithBinarySecret(t, src, "sk-secret")
+
+	m := newRedactModel()
+	m.redactSrcDir = src
+	m.bundlePath = filepath.Join(t.TempDir(), "session.argus")
+	m.redact.literals = []string{"sk-secret"}
+
+	// Prepare: RedactTree finds the un-scrubbable binary secret and arms warnConfirm.
+	res, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'W', Text: "W"})
+	m = res.(model)
+	res, _ = m.Update(cmd())
+	m = res.(model)
+	if !m.redact.pendingSave || !m.redact.warnConfirm {
+		t.Fatalf("prepare should arm warnConfirm for the binary secret, got %+v", m.redact)
+	}
+
+	// First y acknowledges the warning, second y commits.
+	res, cmd = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m = res.(model)
+	if cmd != nil {
+		t.Fatal("first y should only acknowledge, not save")
+	}
+	_, cmd = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("second y should run the save")
+	}
+	done := cmd().(redactDoneMsg)
+	if done.err != nil {
+		t.Fatalf("save failed: %v", done.err)
+	}
+	if done.sidecar == "" {
+		t.Fatal("warnings should produce a sidecar path")
+	}
+	body, err := os.ReadFile(done.sidecar)
+	if err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+	if !contains(string(body), "blob.bin") {
+		t.Fatalf("sidecar should name the leaking file, got:\n%s", body)
+	}
+}
+
+func TestRedactFooterStates(t *testing.T) {
+	m := newRedactModel()
+
+	// Idle with a queued literal: shows count + key hint.
+	m.redact.literals = []string{"a"}
+	if got := m.redactFooter("BASE"); got == "BASE" {
+		t.Fatal("expected redact hint, got base footer")
+	}
+
+	// Input active: shows the buffer.
+	m.redact.inputActive, m.redact.input = true, "sk-x"
+	if got := m.redactFooter("BASE"); !contains(got, "sk-x") {
+		t.Fatalf("input footer should echo buffer, got %q", got)
+	}
+	m.redact.inputActive = false
+
+	// Pending save: shows confirm.
+	rep := bundle.Report{Counts: map[string]int{"a": 2}}
+	m.redact.report = &rep
+	m.redact.pendingSave = true
+	if got := m.redactFooter("BASE"); !contains(got, "y/n") {
+		t.Fatalf("confirm footer should ask y/n, got %q", got)
+	}
+}
+
+func contains(s, sub string) bool { return strings.Contains(s, sub) }
+
+func TestRedactFooterFlashSurfaces(t *testing.T) {
+	m := newRedactModel()
+	m.redact.literals = []string{"a"}
+	m.flash = "redacted: /tmp/x-redacted.argus"
+
+	// Flash must win over the queued-count hint.
+	if got := m.redactFooter("SENTINEL_BASE"); got != "SENTINEL_BASE" {
+		t.Fatalf("flash should surface via base, got %q", got)
+	}
+
+	// Pending-save modal must still win over flash.
+	rep := bundle.Report{Counts: map[string]int{"a": 1}}
+	m.redact.report = &rep
+	m.redact.pendingSave = true
+	if got := m.redactFooter("SENTINEL_BASE"); !contains(got, "y/n") {
+		t.Fatalf("confirm modal must beat flash, got %q", got)
+	}
+}
+
+func TestRedactWarnConfirmTwoStep(t *testing.T) {
+	m := newRedactModel()
+	m.bundlePath = filepath.Join(t.TempDir(), "s.argus")
+	m.redact.literals = []string{"sk-secret"}
+	rep := bundle.Report{
+		Counts:   map[string]int{"sk-secret": 1},
+		Warnings: []string{"secret in binary file root/blob.bin (cannot redact)"},
+	}
+
+	res, _ := m.Update(redactPreparedMsg{report: rep, outPath: m.bundlePath + ".tmp"})
+	m = res.(model)
+	if !m.redact.pendingSave || !m.redact.warnConfirm {
+		t.Fatalf("prepare with warnings should arm pendingSave+warnConfirm, got %+v", m.redact)
+	}
+
+	// First 'y' only acknowledges the warning — no save command yet.
+	res, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m = res.(model)
+	if cmd != nil {
+		t.Fatal("first y should acknowledge the warning, not save")
+	}
+	if m.redact.warnConfirm || !m.redact.pendingSave {
+		t.Fatalf("first y should clear warnConfirm but keep pendingSave, got %+v", m.redact)
+	}
+
+	// Second 'y' performs the save.
+	_, cmd = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("second y should run the save command")
+	}
+}
+
+func TestRedactWarnConfirmCancels(t *testing.T) {
+	m := newRedactModel()
+	m.bundlePath = filepath.Join(t.TempDir(), "s.argus")
+	m.redact.literals = []string{"sk-secret"}
+
+	// A real staged temp file stands in for the prepared bundle; cancelling must
+	// delete it so a partially-redacted copy isn't left behind.
+	staged := filepath.Join(t.TempDir(), ".argus-redacted-stage")
+	if err := os.WriteFile(staged, []byte("staged"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rep := bundle.Report{Counts: map[string]int{"sk-secret": 1}, Warnings: []string{"w"}}
+	res, _ := m.Update(redactPreparedMsg{report: rep, tempPath: staged, outPath: m.bundlePath})
+	m = res.(model)
+
+	// Any non-y key cancels the whole flow at the warning stage.
+	res, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	m = res.(model)
+	if m.redact.pendingSave || m.redact.warnConfirm {
+		t.Fatalf("n should cancel both flags, got %+v", m.redact)
+	}
+	if cmd == nil {
+		t.Fatal("cancel should return a cleanup command")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("abort command should produce no message, got %v", msg)
+	}
+	if _, err := os.Stat(staged); !os.IsNotExist(err) {
+		t.Fatalf("staged temp bundle should be deleted on cancel, stat err = %v", err)
+	}
+}
+
+func TestRedactFooterWarnConfirm(t *testing.T) {
+	m := newRedactModel()
+	rep := bundle.Report{Counts: map[string]int{"a": 1}, Warnings: []string{"w1", "w2"}}
+	m.redact.report = &rep
+	m.redact.pendingSave = true
+	m.redact.warnConfirm = true
+
+	got := m.redactFooter("BASE")
+	if contains(got, "y/n") {
+		t.Fatalf("warn stage must not show the plain y/n confirm, got %q", got)
+	}
+	if !contains(got, "remain") {
+		t.Fatalf("warn stage must warn that secrets remain, got %q", got)
+	}
+}
+
+func TestRedactDoneSurfacesWarnings(t *testing.T) {
+	m := newRedactModel()
+	res, _ := m.Update(redactDoneMsg{path: "/tmp/x-redacted.argus", warnings: []string{"w1", "w2"}})
+	m = res.(model)
+	if !contains(m.flash, "warning") {
+		t.Fatalf("done flash should surface warnings, got %q", m.flash)
+	}
+}
+
+func TestRedactListBodyRendersQueuedLiterals(t *testing.T) {
+	m := newRedactModel()
+	m.redact.literals = []string{"sk-supersecret", "ghp-token"}
+
+	// Opening the list (D) must actually show the queued secrets, not just a count.
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'D', Text: "D"})
+	m = res.(model)
+	if !m.redactListActive() {
+		t.Fatal("D should activate the redaction list")
+	}
+
+	body := m.redactListBody()
+	if !contains(body, "queued redactions (2)") {
+		t.Fatalf("list body should show a heading with the count, got:\n%s", body)
+	}
+	// Literals are shown in full so the user can tell them apart and manage them.
+	if !contains(body, "sk-supersecret") || !contains(body, "ghp-token") {
+		t.Fatalf("list body should show the queued literals in full, got:\n%s", body)
+	}
+	if !contains(body, "▸") {
+		t.Fatalf("list body should mark the cursor row, got:\n%s", body)
+	}
+}
+
+func TestRedactListBodyEmptyState(t *testing.T) {
+	m := newRedactModel()
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'D', Text: "D"})
+	m = res.(model)
+	if got := m.redactListBody(); !contains(got, "no redactions queued") {
+		t.Fatalf("empty list should explain how to add, got %q", got)
+	}
+}
+
+func TestRedactAddFromListReturnsToList(t *testing.T) {
+	m := newRedactModel()
+
+	// Open the (empty) list, then press d to add — the empty-state hint promises this.
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'D', Text: "D"})
+	m = res.(model)
+	res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m = res.(model)
+	if !m.redact.inputActive || m.redact.listActive {
+		t.Fatalf("d on the list should open the input and hide the list, got %+v", m.redact)
+	}
+
+	for _, r := range "sk-x" {
+		res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: r, Text: string(r)})
+		m = res.(model)
+	}
+	res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = res.(model)
+
+	if len(m.redact.literals) != 1 || m.redact.literals[0] != "sk-x" {
+		t.Fatalf("literal not queued: %v", m.redact.literals)
+	}
+	if !m.redact.listActive || m.redact.inputActive {
+		t.Fatalf("after adding, should return to the list, got %+v", m.redact)
+	}
+	if m.redact.listCursor != 0 {
+		t.Fatalf("cursor should land on the new entry, got %d", m.redact.listCursor)
+	}
+}
+
+func TestRedactListDelete(t *testing.T) {
+	m := newRedactModel()
+	m.redact.literals = []string{"aaa", "bbb", "ccc"}
+
+	// Open the list.
+	res, _ := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'D', Text: "D"})
+	m = res.(model)
+	if !m.redact.listActive {
+		t.Fatal("D should open the redaction list")
+	}
+
+	// Move to index 1 and delete.
+	res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	m = res.(model)
+	res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	m = res.(model)
+	if len(m.redact.literals) != 2 || m.redact.literals[1] != "ccc" {
+		t.Fatalf("delete failed: %v", m.redact.literals)
+	}
+
+	// Esc closes.
+	res, _ = m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m = res.(model)
+	if m.redact.listActive {
+		t.Fatal("esc should close the list")
+	}
+}

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/ansi"
 	"github.com/charmbracelet/glamour/styles"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/MunifTanjim/argus/internal/transcript"
 )
@@ -202,11 +203,18 @@ func centerLine(line string, width int) string {
 	return strings.Repeat(" ", pad) + line
 }
 
-// pinFooter stacks body and a width-centered footer, filling the gap with blank
-// lines so the footer lands on the last row of a height-tall viewport.
+// pinFooter stacks body and a width-centered footer on the last rows of a
+// height-tall viewport. A footer wider than the terminal wraps onto multiple lines
+// (rather than clipping) and the gap shrinks to keep them all on-screen.
 func pinFooter(body, footer string, width, height int) string {
-	gap := max(1, height-lipgloss.Height(body))
-	return body + strings.Repeat("\n", gap) + centerLine(footer, width)
+	footer = xansi.Wrap(footer, max(1, width), "")
+	fLines := strings.Split(footer, "\n")
+	for i, l := range fLines {
+		fLines[i] = centerLine(l, width)
+	}
+	// Reserve fH rows for the footer: total = bodyH + gap + (fH-1) == height.
+	gap := max(1, height-lipgloss.Height(body)-(len(fLines)-1))
+	return body + strings.Repeat("\n", gap) + strings.Join(fLines, "\n")
 }
 
 // truncateLines caps content to maxLines, returning the text and hidden count.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -85,7 +85,7 @@ func newViewerModel(client *fileClient, hasDark bool) model {
 
 // RunBundle extracts and validates the bundle before launching the TUI, so a bad
 // bundle errors out without ever opening the alt-screen.
-func RunBundle(bundlePath string) error {
+func RunBundle(bundlePath string, redact bool) error {
 	pruneOldExtractions()
 
 	dest, err := bundleExtractDir(bundlePath)
@@ -106,7 +106,7 @@ func RunBundle(bundlePath string) error {
 	if err != nil {
 		return err
 	}
-	return RunViewer(client)
+	return RunViewer(client, bundlePath, redact)
 }
 
 // extractPrefix marks argus view's extraction and temp dirs in TempDir so
@@ -228,12 +228,15 @@ func extractBundle(bundlePath, dest string) (bundle.Manifest, error) {
 
 // RunViewer runs the TUI as an offline viewer over an extracted .argus bundle,
 // opening directly in the transcript view.
-func RunViewer(client *fileClient) error {
+func RunViewer(client *fileClient, bundlePath string, redact bool) error {
 	hasDark := lipgloss.HasDarkBackground(os.Stdin, os.Stderr)
 	initTheme(hasDark)
 	initIcons()
 	initStyles()
 	m := newViewerModel(client, hasDark)
+	m.redactMode = redact
+	m.bundlePath = bundlePath
+	m.redactSrcDir = client.destDir
 	p := tea.NewProgram(m)
 	_, err := p.Run()
 	cerr := client.Close()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3,12 +3,19 @@
 package tui
 
 import (
+	"encoding/binary"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 
 	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/bundle"
 	"github.com/MunifTanjim/argus/internal/logbuf"
 )
 
@@ -60,4 +67,178 @@ func Run(client Client, logs *logbuf.Buffer) error {
 	}
 	_, err := p.Run()
 	return err
+}
+
+// newViewerModel builds a model seeded to display the single exported session
+// from an offline file-backed client, opened directly in the transcript view.
+func newViewerModel(client *fileClient, hasDark bool) model {
+	m := newModel(client, hasDark, nil)
+	m.viewer = true
+	m.mode = modeHistoryTranscript
+	m.history.openNodeID = ""
+	m.history.openPath = client.entryPath
+	m.history.openAgent = client.manifest.Agent
+	m.history.openSession = client.syntheticSession()
+	m.history.project = client.syntheticProject()
+	return m
+}
+
+// RunBundle extracts and validates the bundle before launching the TUI, so a bad
+// bundle errors out without ever opening the alt-screen.
+func RunBundle(bundlePath string) error {
+	pruneOldExtractions()
+
+	dest, err := bundleExtractDir(bundlePath)
+	if err != nil {
+		return err
+	}
+
+	m, err := bundle.ReadManifest(dest)
+	if err != nil {
+		// Unpack into a fresh temp dir, then atomically swap it in so a crash
+		// mid-extract can't leave a partial dir a later run would reuse.
+		if m, err = extractBundle(bundlePath, dest); err != nil {
+			return err
+		}
+	}
+
+	client, err := newFileClient(dest, m)
+	if err != nil {
+		return err
+	}
+	return RunViewer(client)
+}
+
+// extractPrefix marks argus view's extraction and temp dirs in TempDir so
+// pruneOldExtractions can find them.
+const extractPrefix = "argus-view-"
+
+// extractionMaxAge is not refreshed on reuse, so a still-wanted bundle past this
+// age is re-extracted on the next view.
+const extractionMaxAge = 48 * time.Hour
+
+// pruneOldExtractions bounds TempDir growth from viewing many distinct bundles.
+func pruneOldExtractions() {
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-extractionMaxAge)
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), extractPrefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), e.Name()))
+	}
+}
+
+// bundleExtractDir keys the extraction dir by content hash so a renamed or copied
+// bundle reuses its extraction. bundleHash samples only size + head/tail, so a
+// mid-file same-size edit can alias an older one — fine here, bundles are
+// regenerated whole, not edited in place.
+func bundleExtractDir(bundlePath string) (string, error) {
+	f, err := os.Open(bundlePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h, err := bundleHash(f)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("%s%016x", extractPrefix, h)), nil
+}
+
+// bundleHashChunk is the head/tail block size sampled by bundleHash.
+const bundleHashChunk = 65536
+
+// bundleHash hashes a file by size plus its head and tail chunks (whole file when
+// smaller than a chunk).
+func bundleHash(f *os.File) (uint64, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	size := info.Size()
+	sum := uint64(size)
+	if size < bundleHashChunk {
+		buf := make([]byte, size)
+		if _, err := io.ReadFull(f, buf); err != nil {
+			return 0, err
+		}
+		return sum + sumWords(buf), nil
+	}
+	buf := make([]byte, bundleHashChunk)
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		return 0, err
+	}
+	sum += sumWords(buf)
+	if _, err := f.ReadAt(buf, size-bundleHashChunk); err != nil {
+		return 0, err
+	}
+	return sum + sumWords(buf), nil
+}
+
+func sumWords(b []byte) uint64 {
+	var sum uint64
+	for len(b) >= 8 {
+		sum += binary.LittleEndian.Uint64(b)
+		b = b[8:]
+	}
+	if len(b) > 0 { // trailing <8 bytes (small-file path): pad so they still count
+		var tail [8]byte
+		copy(tail[:], b)
+		sum += binary.LittleEndian.Uint64(tail[:])
+	}
+	return sum
+}
+
+func extractBundle(bundlePath, dest string) (bundle.Manifest, error) {
+	f, err := os.Open(bundlePath)
+	if err != nil {
+		return bundle.Manifest{}, err
+	}
+	defer f.Close()
+
+	tmp, err := os.MkdirTemp(os.TempDir(), extractPrefix+"tmp-*")
+	if err != nil {
+		return bundle.Manifest{}, err
+	}
+	m, err := bundle.Read(f, tmp)
+	if err != nil {
+		_ = os.RemoveAll(tmp)
+		return bundle.Manifest{}, err
+	}
+	_ = os.RemoveAll(dest) // clear any stale/partial dir before swapping in
+	if err := os.Rename(tmp, dest); err != nil {
+		// Lost a race with a concurrent extraction, or a cross-device rename: an
+		// existing dest is a valid extraction, so drop ours and reuse it.
+		_ = os.RemoveAll(tmp)
+		if rm, rerr := bundle.ReadManifest(dest); rerr == nil {
+			return rm, nil
+		}
+		return bundle.Manifest{}, err
+	}
+	return m, nil
+}
+
+// RunViewer runs the TUI as an offline viewer over an extracted .argus bundle,
+// opening directly in the transcript view.
+func RunViewer(client *fileClient) error {
+	hasDark := lipgloss.HasDarkBackground(os.Stdin, os.Stderr)
+	initTheme(hasDark)
+	initIcons()
+	initStyles()
+	m := newViewerModel(client, hasDark)
+	p := tea.NewProgram(m)
+	_, err := p.Run()
+	cerr := client.Close()
+	if err != nil {
+		return err
+	}
+	return cerr
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -74,6 +76,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.PasteMsg:
 		switch {
 		case msg.Content == "":
+		case m.redact.inputActive:
+			m.redact.input += msg.Content
+			return m, nil
 		case m.mode == modeScreen:
 			m.sendTermKey(m.termID, []byte(msg.Content))
 			return m, nil
@@ -219,6 +224,34 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.flash = "exported: " + msg.path
 		}
+		return m, nil
+	case redactPreparedMsg:
+		if msg.err != nil {
+			m.flash = "redact failed: " + msg.err.Error()
+			return m, nil
+		}
+		r := msg.report
+		m.redact.report = &r
+		m.redact.tempPath = msg.tempPath
+		m.redact.outPath = msg.outPath
+		m.redact.pendingSave = true
+		m.redact.warnConfirm = len(r.Warnings) > 0 // extra ack when content can't be scrubbed
+		return m, nil
+	case redactDoneMsg:
+		switch {
+		case msg.err != nil:
+			m.flash = "redact failed: " + msg.err.Error()
+		case msg.sidecar != "":
+			m.flash = fmt.Sprintf("redacted with %d warning(s) (secrets remain); see %s",
+				len(msg.warnings), filepath.Base(msg.sidecar))
+		case len(msg.warnings) > 0:
+			m.flash = fmt.Sprintf("redacted with %d warning(s) (secrets remain): %s", len(msg.warnings), msg.path)
+		default:
+			m.flash = "redacted: " + msg.path
+		}
+		m.redact.report = nil
+		m.redact.warnConfirm = false
+		m.redact.tempPath = ""
 		return m, nil
 	case termOpenedMsg:
 		if msg.termID == m.termID && msg.err != nil {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -22,7 +22,12 @@ import (
 // appear before dropping the pending auto-select (see clearPendingResumeMsg).
 const resumeSelectTimeout = 30 * time.Second
 
-func (m model) Init() tea.Cmd { return tea.Batch(m.refreshCmd(), spinResumeCmd()) }
+func (m model) Init() tea.Cmd {
+	if m.viewer {
+		return m.fetchHistTranscript(m.history.openNodeID, m.history.openPath, m.history.openAgent)
+	}
+	return tea.Batch(m.refreshCmd(), spinResumeCmd())
+}
 
 // spinResumeCmd re-arms the list spinner on a timer, so it resumes even when no
 // registry event arrives.
@@ -206,6 +211,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case clearPendingResumeMsg:
 		if m.pendingResumeID == msg.id {
 			m.pendingResumeID = ""
+		}
+		return m, nil
+	case exportDoneMsg:
+		if msg.err != nil {
+			m.flash = "export failed: " + msg.err.Error()
+		} else {
+			m.flash = "exported: " + msg.path
 		}
 		return m, nil
 	case termOpenedMsg:

--- a/internal/tui/viewer_test.go
+++ b/internal/tui/viewer_test.go
@@ -1,0 +1,96 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/MunifTanjim/argus/internal/bundle"
+)
+
+func newTestViewerModel(t *testing.T) (model, *fileClient) {
+	t.Helper()
+	fixture := filepath.Join("..", "adapter", "claudecode", "parser", "testdata", "multi_turn.jsonl")
+	dir := t.TempDir()
+	entry := "root/session.jsonl"
+	if err := copyFileForTest(t, fixture, filepath.Join(dir, filepath.FromSlash(entry))); err != nil {
+		t.Fatalf("fixture unavailable: %v", err)
+	}
+	m := bundle.Manifest{Agent: "claude", Entry: entry, Metadata: bundle.Metadata{Title: "T"}}
+	fc, err := newFileClient(dir, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return newViewerModel(fc, false), fc
+}
+
+func TestViewerModelStartsInTranscript(t *testing.T) {
+	model, fc := newTestViewerModel(t)
+	if !model.viewer {
+		t.Fatal("want model.viewer == true")
+	}
+	if model.mode != modeHistoryTranscript {
+		t.Fatalf("want modeHistoryTranscript, got %v", model.mode)
+	}
+	if model.history.openAgent != "claude" {
+		t.Fatalf("want openAgent=claude, got %q", model.history.openAgent)
+	}
+	if model.history.openPath != fc.entryPath {
+		t.Fatalf("want openPath=%q, got %q", fc.entryPath, model.history.openPath)
+	}
+	if model.history.openSession.Title != "T" {
+		t.Fatalf("openSession not seeded from manifest: got title %q", model.history.openSession.Title)
+	}
+}
+
+func TestViewerHeaderFromManifest(t *testing.T) {
+	m, _ := newTestViewerModel(t)
+	h := m.historyTranscriptHeader()
+	if !strings.Contains(h, "T") {
+		t.Fatalf("viewer header should show manifest title/label, got %q", h)
+	}
+	if strings.Contains(h, "history") {
+		t.Fatalf("viewer header must not show the history breadcrumb, got %q", h)
+	}
+}
+
+func TestViewerResumeInert(t *testing.T) {
+	m, _ := newTestViewerModel(t)
+	m.historyView = histTranscript
+	res, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: 'R'})
+	if cmd != nil {
+		t.Fatal("resume key in viewer should be inert")
+	}
+	if res.(model).mode != modeHistoryTranscript {
+		t.Fatal("resume key in viewer should not change mode")
+	}
+}
+
+// TestViewerBackQuits asserts that pressing the Back key at the top transcript
+// level in viewer mode returns a tea.Quit command rather than navigating to the
+// (non-existent) session list.
+func TestViewerBackQuits(t *testing.T) {
+	m, _ := newTestViewerModel(t)
+	m.historyView = histTranscript // ensure top level, no detail frames
+
+	_, cmd := m.handleHistoryTranscriptKey(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("back key in viewer: want non-nil quit cmd, got nil")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("back key in viewer: want QuitMsg from cmd(), got %T", cmd())
+	}
+}
+
+// TestViewerExportInert asserts that pressing the export key in viewer mode is a
+// no-op: actExportSession returns a nil command so no RPC is made and no file is
+// written.
+func TestViewerExportInert(t *testing.T) {
+	m, _ := newTestViewerModel(t)
+	_, cmd := m.actExportSession(tea.KeyPressMsg{})
+	if cmd != nil {
+		t.Fatalf("actExportSession in viewer: want nil cmd, got non-nil")
+	}
+}


### PR DESCRIPTION
## Summary

Export an argus session to a single shareable `.argus` file, view it offline in the full TUI, and redact secrets before sharing — no node, gateway, or config required.

- **Export** — `E` in a live or history transcript writes a `.argus` to the working directory.
- **View** — `argus view <file.argus>` opens the bundle in the real transcript UI (scroll, fold, drill into tool calls and subagent traces).
- **Redact** — `argus view <file.argus> --redact` queues secrets interactively (`d` add, `D` list, `W` save) and writes a scrubbed `<name>-redacted.argus`.

## Design

- A `.argus` is a gzipped tar of the session's **raw** tool files plus a `manifest.json` — not a parsed snapshot. Re-parsing at view time means parser improvements apply to old bundles and the viewer reuses the exact live parse path. `format_version` guards forward compatibility.
- The offline viewer implements the `tui.Client` interface over the extracted dir, so subagent drill and per-tool detail work with no rendering changes.

## Redaction

Bundles carry raw tool I/O, so a secret can slip in. `--redact` byte-matches queued literals (and their JSON-escaped forms) across text files, the antigravity sqlite db (SQL walk + `VACUUM` to purge freed pages), and manifest metadata, replacing each occurrence with `[REDACTED]`.

- Writes a new sibling bundle; the source and extraction cache are never mutated. The final `-redacted` name appears only after confirmation.
- Content that can't be safely scrubbed (binaries, rowid-less sqlite tables) is flagged, never silently shipped. A post-write residual scan backstops the structured pass, and a `.warnings.txt` sidecar lists anything left behind.
- v1 is literal-string redaction only.

## Testing

`go test ./...`, `go build ./...`, `go vet ./...` all clean. Coverage spans bundle roundtrip/version-refuse/traversal, per-adapter collection, the export RPC, the offline client (incl. subagent drill), and redaction (text/sqlite/metadata, post-`VACUUM` raw-byte assertion, residual backstop, and a redact→rebundle→reopen e2e).

## Note

`.argus` files carry raw session data (system prompts, full tool I/O) — share only with people you trust; `--redact` scrubs specific values first.
