### PR TITLE
feat: show current git branch in session view

### DIFF
--- a/app/lib/models/session.dart
+++ b/app/lib/models/session.dart
@@ -157,6 +157,7 @@ class Session {
   final SessionSource source;
   final FrontendKind frontend;
   final String? repo;
+  final String? branch;
   final Summary? summary;
   final Interaction? interaction;
   final String? nodeId;
@@ -176,6 +177,7 @@ class Session {
     this.cwd,
     this.transcriptPath,
     this.repo,
+    this.branch,
     this.summary,
     this.interaction,
     this.nodeId,
@@ -196,6 +198,7 @@ class Session {
         source: sourceFromWire(j['source'] as String?),
         frontend: frontendFromWire(j['frontend'] as String?),
         repo: j['repo'] as String?,
+        branch: j['branch'] as String?,
         summary: j['summary'] == null
             ? null
             : Summary.fromJson(j['summary'] as Map<String, dynamic>),

--- a/app/lib/ui/session_detail_screen.dart
+++ b/app/lib/ui/session_detail_screen.dart
@@ -154,9 +154,19 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen>
                         fontFamily: 'monospace',
                         color: statusColor(live.status))),
                 const SizedBox(width: 8),
-                Expanded(
+                Flexible(
                     child: Text(title,
                         maxLines: 1, overflow: TextOverflow.ellipsis)),
+                if (live.branch?.isNotEmpty ?? false)
+                  Tooltip(
+                    message: live.branch!,
+                    triggerMode: TooltipTriggerMode.tap,
+                    child: const Padding(
+                      padding: EdgeInsets.only(left: 8),
+                      child: Icon(Icons.commit, size: 18),
+                    ),
+                  ),
+                const Spacer(),
                 if (live.frontend != FrontendKind.tmux)
                   Padding(
                     padding: const EdgeInsets.only(left: 8),

--- a/app/test/models/session_test.dart
+++ b/app/test/models/session_test.dart
@@ -9,6 +9,7 @@ const _sessionJson = '''
   "id":"macbook:%3","agent":"claude","status":"awaiting_input","source":"discovered",
   "tmux":{"server":"default","pane_id":"%3","session_name":"argus","window_index":0,"current_path":"/home/u/argus"},
   "repo":"argus",
+  "branch":"feat/session-git-branch",
   "summary":{"model_name":"Opus 4.8","model_color":"#d3869b","has_context":true,"context_pct":42.5,"tokens":12300,"task":"fix bug","last_activity":"2026-06-20T10:00:00Z"},
   "interaction":{"kind":"permission","tool_name":"bash","tool_input":"go test ./..."},
   "node_id":"macbook","node_label":"MacBook"
@@ -21,6 +22,7 @@ void main() {
     expect(s.id, 'macbook:%3');
     expect(s.status, SessionStatus.awaitingInput);
     expect(s.repo, 'argus');
+    expect(s.branch, 'feat/session-git-branch');
     expect(s.tmux.paneId, '%3');
     expect(s.tmux.server, TmuxServerKind.default_);
     expect(s.summary!.contextPct, 42.5);
@@ -37,6 +39,7 @@ void main() {
     expect(s.summary, isNull);
     expect(s.interaction, isNull);
     expect(s.repo, isNull);
+    expect(s.branch, isNull);
     expect(s.tmux.server, TmuxServerKind.argus);
   });
 

--- a/app/test/ui/session_detail_screen_test.dart
+++ b/app/test/ui/session_detail_screen_test.dart
@@ -14,7 +14,8 @@ import 'package:argus/state/transcript_controller.dart';
 import 'package:argus/ui/session_detail_screen.dart';
 import '../support/fake_session_repository.dart';
 
-Session _s({String? agentSessionId, String? name}) => Session.fromJson({
+Session _s({String? agentSessionId, String? name, String? branch}) =>
+    Session.fromJson({
       'id': 'mac:%1',
       'agent': 't',
       'status': 'working',
@@ -28,6 +29,7 @@ Session _s({String? agentSessionId, String? name}) => Session.fromJson({
         'current_path': '/p',
       },
       'repo': 'argus',
+      'branch': ?branch,
       'node_label': 'mac',
       'agent_session_id': ?agentSessionId,
       'name': ?name,
@@ -71,9 +73,9 @@ class _FakeSessionControl extends FakeSessionRepository {
   }
 }
 
-Widget _app(List<Override> overrides) => ProviderScope(
+Widget _app(List<Override> overrides, {Session? session}) => ProviderScope(
       overrides: overrides,
-      child: MaterialApp(home: SessionDetailScreen(session: _s())),
+      child: MaterialApp(home: SessionDetailScreen(session: session ?? _s())),
     );
 
 List<Override> _baseOverrides() => [
@@ -123,6 +125,21 @@ void main() {
     ]));
     await tester.pump();
     expect(find.byIcon(Icons.terminal), findsOneWidget);
+  });
+
+  testWidgets('shows branch icon with branch name tooltip when set',
+      (tester) async {
+    await tester.pumpWidget(_app(_baseOverrides(),
+        session: _s(branch: 'feat/session-git-branch')));
+    await tester.pump();
+    expect(find.byIcon(Icons.commit), findsOneWidget);
+    expect(find.byTooltip('feat/session-git-branch'), findsOneWidget);
+  });
+
+  testWidgets('no branch icon when branch is absent', (tester) async {
+    await tester.pumpWidget(_app(_baseOverrides()));
+    await tester.pump();
+    expect(find.byIcon(Icons.commit), findsNothing);
   });
 
   testWidgets('AppBar has overflow PopupMenuButton', (tester) async {

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -1,0 +1,79 @@
+// Package gitmeta derives lightweight git metadata (the current branch) for a
+// directory by reading git's on-disk files directly — no git subprocess.
+package gitmeta
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Branch returns the current branch of the git repository containing dir: the
+// name after "ref: refs/heads/" in HEAD, or the short (7-char) commit SHA when
+// HEAD is detached. Returns "" when dir is empty, not in a repo, or HEAD is
+// unreadable.
+func Branch(dir string) string {
+	gitDir := findGitDir(dir)
+	if gitDir == "" {
+		return ""
+	}
+	head, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return ""
+	}
+	s := strings.TrimSpace(string(head))
+	if ref, ok := strings.CutPrefix(s, "ref: refs/heads/"); ok {
+		return ref
+	}
+	if strings.HasPrefix(s, "ref:") {
+		// Symbolic ref outside refs/heads/ (e.g. a tag): not a branch.
+		return ""
+	}
+	// Detached HEAD: HEAD holds a raw commit SHA.
+	if len(s) >= 7 {
+		return s[:7]
+	}
+	return ""
+}
+
+// findGitDir walks up from dir to the nearest ".git" entry and returns the git
+// directory: the ".git" dir itself, or — for worktrees/submodules where ".git"
+// is a file containing "gitdir: <path>" — the path it points to. Returns "" if
+// none is found.
+func findGitDir(dir string) string {
+	for d := dir; d != ""; {
+		git := filepath.Join(d, ".git")
+		if info, err := os.Stat(git); err == nil {
+			if info.IsDir() {
+				return git
+			}
+			if target := readGitFile(git); target != "" {
+				return target
+			}
+		}
+		parent := filepath.Dir(d)
+		if parent == d { // reached the filesystem root
+			break
+		}
+		d = parent
+	}
+	return ""
+}
+
+// readGitFile reads a ".git" file's "gitdir: <path>" line and returns the path
+// (absolute, resolved against the file's directory when relative). Returns "" on
+// any problem.
+func readGitFile(gitFile string) string {
+	data, err := os.ReadFile(gitFile)
+	if err != nil {
+		return ""
+	}
+	target, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+	if !ok {
+		return ""
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(gitFile), target)
+	}
+	return target
+}

--- a/internal/gitmeta/gitmeta_test.go
+++ b/internal/gitmeta/gitmeta_test.go
@@ -1,0 +1,115 @@
+package gitmeta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile writes content to path, creating parent dirs.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBranchNormal(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\n")
+	if got := Branch(dir); got != "main" {
+		t.Fatalf("Branch = %q, want %q", got, "main")
+	}
+}
+
+func TestBranchWithSlashes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/feat/session-git-branch\n")
+	if got := Branch(dir); got != "feat/session-git-branch" {
+		t.Fatalf("Branch = %q, want %q", got, "feat/session-git-branch")
+	}
+}
+
+func TestBranchDetachedHead(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "1234567890abcdef1234567890abcdef12345678\n")
+	if got := Branch(dir); got != "1234567" {
+		t.Fatalf("Branch = %q, want %q (short sha)", got, "1234567")
+	}
+}
+
+func TestBranchNestedSubdir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\n")
+	sub := filepath.Join(dir, "a", "b", "c")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := Branch(sub); got != "main" {
+		t.Fatalf("Branch = %q, want %q", got, "main")
+	}
+}
+
+func TestBranchWorktreeGitFile(t *testing.T) {
+	dir := t.TempDir()
+	// Real git dir for the worktree, elsewhere on disk.
+	realGitDir := filepath.Join(t.TempDir(), "worktrees", "wt1")
+	writeFile(t, filepath.Join(realGitDir, "HEAD"), "ref: refs/heads/feature\n")
+	// The worktree's .git is a file pointing at the real git dir.
+	writeFile(t, filepath.Join(dir, ".git"), "gitdir: "+realGitDir+"\n")
+	if got := Branch(dir); got != "feature" {
+		t.Fatalf("Branch = %q, want %q", got, "feature")
+	}
+}
+
+func TestBranchNotARepo(t *testing.T) {
+	dir := t.TempDir()
+	if got := Branch(dir); got != "" {
+		t.Fatalf("Branch = %q, want empty", got)
+	}
+}
+
+func TestBranchEmptyDir(t *testing.T) {
+	if got := Branch(""); got != "" {
+		t.Fatalf("Branch = %q, want empty", got)
+	}
+}
+
+func TestBranchUnreadableHead(t *testing.T) {
+	dir := t.TempDir()
+	// .git dir exists but no HEAD file.
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := Branch(dir); got != "" {
+		t.Fatalf("Branch = %q, want empty", got)
+	}
+}
+
+func TestBranchSymbolicRefNotHeads(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/tags/v1.0\n")
+	if got := Branch(dir); got != "" {
+		t.Fatalf("Branch = %q, want empty (non-heads symbolic ref)", got)
+	}
+}
+
+func TestBranchWorktreeRelativeGitdir(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git-real", "HEAD"), "ref: refs/heads/feature\n")
+	writeFile(t, filepath.Join(dir, ".git"), "gitdir: ./.git-real\n")
+	if got := Branch(dir); got != "feature" {
+		t.Fatalf("Branch = %q, want %q", got, "feature")
+	}
+}
+
+func TestBranchHeadWithCRLF(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\r\n")
+	if got := Branch(dir); got != "main" {
+		t.Fatalf("Branch = %q, want %q", got, "main")
+	}
+}

--- a/internal/node/subscribe_branch_test.go
+++ b/internal/node/subscribe_branch_test.go
@@ -1,0 +1,62 @@
+package node
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/registry"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// TestSubscribeRefreshesBranch proves opening a session (transcript.subscribe)
+// recomputes the git branch from its cwd and publishes it, so a mid-session
+// checkout is picked up when the session is next opened.
+func TestSubscribeRefreshesBranch(t *testing.T) {
+	d := newNode(nil)
+
+	// A git repo dir with a branch, used as the session cwd.
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".git", "HEAD"), []byte("ref: refs/heads/feat/session-git-branch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tmp := writeTempTranscript(t)
+	s, _ := d.reg.ApplyHook(registry.HookUpdate{
+		AgentSessionID: "b1",
+		Cwd:            repo,
+		TranscriptPath: tmp,
+		Status:         session.StatusIdle,
+	})
+
+	// Subscribe to registry events after the session exists so the channel is clean.
+	events, cancel := d.reg.Subscribe()
+	defer cancel()
+
+	fn := &fakeNotifier{ch: make(chan api.Notification, 8)}
+	ctx := api.WithNotifier(context.Background(), fn)
+	if _, err := d.handleTranscriptSubscribe(ctx, mustJSON(api.TranscriptSubscribeParams{
+		SubID:     "sub",
+		SessionID: s.ID,
+	})); err != nil {
+		t.Fatalf("handleTranscriptSubscribe: %v", err)
+	}
+
+	if got, _ := d.reg.Get(s.ID); got.Branch != "feat/session-git-branch" {
+		t.Fatalf("stored branch = %q, want feat/session-git-branch", got.Branch)
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Type != registry.EventUpdated || ev.Session.Branch != "feat/session-git-branch" {
+			t.Fatalf("event = %+v, want updated with branch feat/session-git-branch", ev)
+		}
+	default:
+		t.Fatal("expected an EventUpdated carrying the branch")
+	}
+}

--- a/internal/node/subscriptions.go
+++ b/internal/node/subscriptions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MunifTanjim/argus/internal/adapter"
 	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/gitmeta"
 	"github.com/MunifTanjim/argus/internal/transcript"
 )
 
@@ -96,23 +97,23 @@ func (d *Node) getOrCreateConnSubs(ctx context.Context, n api.Notifier) *connSub
 
 // resolveTranscriptPath returns the file to tail for a subscription: the session
 // transcript, or a subagent file when AgentID is set.
-func (d *Node) resolveTranscriptPath(p api.TranscriptSubscribeParams) (path, root string, a adapter.Adapter, err error) {
+func (d *Node) resolveTranscriptPath(p api.TranscriptSubscribeParams) (path, root, cwd string, a adapter.Adapter, err error) {
 	s, ok := d.reg.Get(p.SessionID)
 	if !ok {
-		return "", "", nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "unknown session: " + p.SessionID}
+		return "", "", "", nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "unknown session: " + p.SessionID}
 	}
 	if s.TranscriptPath == "" {
-		return "", "", nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session has no transcript: " + p.SessionID}
+		return "", "", "", nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session has no transcript: " + p.SessionID}
 	}
 	a = d.adapterFor(s.Agent)
 	if p.AgentID == "" {
-		return s.TranscriptPath, s.TranscriptPath, a, nil
+		return s.TranscriptPath, s.TranscriptPath, s.Cwd, a, nil
 	}
 	sub, ok := a.SubagentFilePath(s.TranscriptPath, p.AgentID)
 	if !ok {
-		return "", "", nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "unknown subagent: " + p.AgentID}
+		return "", "", "", nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "unknown subagent: " + p.AgentID}
 	}
-	return sub, s.TranscriptPath, a, nil
+	return sub, s.TranscriptPath, s.Cwd, a, nil
 }
 
 // diffChunks returns the first index at which cur differs from old, and whether
@@ -157,9 +158,16 @@ func (d *Node) handleTranscriptSubscribe(ctx context.Context, params json.RawMes
 		return nil, &api.RPCError{Code: api.CodeInternalError, Message: "no connection notifier"}
 	}
 	cs := d.getOrCreateConnSubs(ctx, n)
-	path, root, a, err := d.resolveTranscriptPath(p)
+	path, root, cwd, a, err := d.resolveTranscriptPath(p)
 	if err != nil {
 		return nil, err
+	}
+
+	// Opening a session is a reliable moment to refresh its git branch: a
+	// mid-session checkout fires no agent hook, so we recompute from cwd here.
+	// Subagent opens (AgentID set) share the parent cwd, so skip them.
+	if p.AgentID == "" && cwd != "" {
+		d.reg.SetBranch(p.SessionID, gitmeta.Branch(cwd))
 	}
 
 	st := a.NewStreamingTranscript(path, root, p.AgentID != "")

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -308,6 +308,20 @@ func (r *Registry) ClearInteraction(id string) {
 	r.publish(Event{Type: EventUpdated, Session: *s})
 }
 
+// SetBranch updates a session's current git branch, publishing an update only
+// when it changes. No-op for an unknown id. Called when a client opens a session
+// (path-derived, so it catches a mid-session checkout).
+func (r *Registry) SetBranch(id, branch string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s := r.sessions[id]
+	if s == nil || s.Branch == branch {
+		return
+	}
+	s.Branch = branch
+	r.publish(Event{Type: EventUpdated, Session: *s})
+}
+
 // HookUpdate carries the correlation keys and fields from an agent hook event. Empty
 // string fields leave an existing session unchanged. A non-empty Status sets the
 // status; StatusDead removes the session.

--- a/internal/registry/set_branch_test.go
+++ b/internal/registry/set_branch_test.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+func TestSetBranchPublishesUpdate(t *testing.T) {
+	r := New()
+	r.ReconcileSessions("claude", []DiscoveredSession{
+		{HasPane: true, Server: session.TmuxServerDefault, PaneID: "%0", SessionName: "a"},
+	})
+	id := "default:%0"
+
+	ch, cancel := r.Subscribe()
+	defer cancel()
+
+	r.SetBranch(id, "feat/x")
+
+	ev := <-ch
+	if ev.Type != EventUpdated {
+		t.Fatalf("event type = %q, want updated", ev.Type)
+	}
+	if ev.Session.Branch != "feat/x" {
+		t.Fatalf("branch = %q, want feat/x", ev.Session.Branch)
+	}
+
+	if s, _ := r.Get(id); s.Branch != "feat/x" {
+		t.Fatalf("stored branch = %q, want feat/x", s.Branch)
+	}
+}
+
+func TestSetBranchNoOpWhenUnchanged(t *testing.T) {
+	r := New()
+	r.ReconcileSessions("claude", []DiscoveredSession{
+		{HasPane: true, Server: session.TmuxServerDefault, PaneID: "%0"},
+	})
+	id := "default:%0"
+	r.SetBranch(id, "main")
+
+	ch, cancel := r.Subscribe()
+	defer cancel()
+
+	r.SetBranch(id, "main") // unchanged: must not publish
+
+	select {
+	case ev := <-ch:
+		t.Fatalf("unexpected event for unchanged branch: %+v", ev)
+	default:
+	}
+}
+
+func TestSetBranchUnknownIDIsNoOp(t *testing.T) {
+	r := New()
+	ch, cancel := r.Subscribe()
+	defer cancel()
+
+	r.SetBranch("nope", "main") // must not panic or publish
+
+	select {
+	case ev := <-ch:
+		t.Fatalf("unexpected event for unknown id: %+v", ev)
+	default:
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -176,6 +176,11 @@ type Session struct {
 	// (path-derived, not from the transcript).
 	Repo string `json:"repo,omitempty"`
 
+	// Branch is the current git branch of the session directory, when known
+	// (path-derived, refreshed when a client opens the session). Empty outside a
+	// repo; a short commit SHA when HEAD is detached.
+	Branch string `json:"branch,omitempty"`
+
 	// Summary is the cached transcript digest for list views (nil until computed).
 	Summary *Summary `json:"summary,omitempty"`
 

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -381,8 +381,12 @@ func (m model) sessionView() string {
 	if name != "" {
 		parts = append(parts, name)
 	}
-	header := headerStyle.Render(strings.Join(parts, " · ")) +
-		dimStyle.Render(fmt.Sprintf("  [%s] %s", paneTag(s), statusWord(s)))
+	header := headerStyle.Render(strings.Join(parts, " · "))
+	if s.Branch != "" {
+		branch := Icon.Branch.Render() + lipgloss.NewStyle().Foreground(ColorGitBranch).Render(" "+s.Branch)
+		header += headerStyle.Render(" · ") + branch
+	}
+	header += dimStyle.Render(fmt.Sprintf("  [%s] %s", paneTag(s), statusWord(s)))
 	header = centerBlock(indentBlock(header, strings.Repeat(" ", contentPadX)), m.containerWidth(), m.width)
 
 	body := m.historyBody()

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -96,6 +96,29 @@ func sessionModel(ix *session.Interaction) model {
 	return m
 }
 
+func TestSessionHeaderShowsBranch(t *testing.T) {
+	m := sessionModel(nil)
+	s := m.sessions["s1"]
+	s.Repo = "argus"
+	s.Branch = "feat/session-git-branch"
+	m.sessions["s1"] = s
+
+	out := ansi.Strip(m.sessionView())
+	if !strings.Contains(out, "feat/session-git-branch") {
+		t.Errorf("header missing branch name:\n%s", out)
+	}
+	if !strings.Contains(out, Icon.Branch.Glyph) {
+		t.Errorf("header missing branch glyph:\n%s", out)
+	}
+
+	// No branch → no branch glyph in the header.
+	s.Branch = ""
+	m.sessions["s1"] = s
+	if strings.Contains(ansi.Strip(m.sessionView()), Icon.Branch.Glyph) {
+		t.Error("branch glyph shown when branch is empty")
+	}
+}
+
 func TestSessionTabTogglesFocusOnlyWhenPending(t *testing.T) {
 	m := sessionModel(nil)
 	res, _ := m.handleSessionKey(tea.KeyPressMsg{Code: '\t'})


### PR DESCRIPTION
Shows the current git branch in the session view header, in both the TUI and the app.

Branch is derived server-side from the session cwd (like `Repo`) by reading `.git/HEAD` directly — no `git` subprocess. Refreshed when a client opens a session, since a mid-session `git checkout` fires no agent hook. Header-only, never in the session list.