### PR TITLE
fix(claudecode): surface sessions stuck at startup prompts

### DIFF
--- a/app/lib/models/enums.dart
+++ b/app/lib/models/enums.dart
@@ -1,9 +1,11 @@
-enum SessionStatus { discovered, working, awaitingInput, idle, dead, unknown }
+enum SessionStatus { discovered, starting, working, awaitingInput, idle, dead, unknown }
 
 SessionStatus statusFromWire(String? s) {
   switch (s) {
     case 'discovered':
       return SessionStatus.discovered;
+    case 'starting':
+      return SessionStatus.starting;
     case 'working':
       return SessionStatus.working;
     case 'awaiting_input':

--- a/app/lib/ui/session_detail_screen.dart
+++ b/app/lib/ui/session_detail_screen.dart
@@ -257,12 +257,14 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen>
             if (conn != ConnState.connected)
               _Banner(state: conn, message: connError),
             Expanded(
-              // Spinner until the first snapshot arrives, so an empty session
-              // shows progress rather than a blank feed. error stops the spinner.
-              child: !st.loaded && st.error == null
-                  ? const Center(child: CircularProgressIndicator())
-                  : TranscriptFeed(
-                      detailRef: ToolDetailRef.live(_sid), chunks: st.chunks),
+              // Spinner until the first snapshot arrives; error stops it.
+              child: switch (live.status) {
+                SessionStatus.starting => const _StartingNotice(),
+                _ when !st.loaded && st.error == null =>
+                  const Center(child: CircularProgressIndicator()),
+                _ => TranscriptFeed(
+                    detailRef: ToolDetailRef.live(_sid), chunks: st.chunks),
+              },
             ),
             if (live.interaction != null)
               InteractionBar(
@@ -303,6 +305,38 @@ class _Banner extends StatelessWidget {
           style: TextStyle(
               color: failed ? AppColors.error : AppColors.secondary,
               fontSize: 12)),
+    );
+  }
+}
+
+class _StartingNotice extends StatelessWidget {
+  const _StartingNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.hourglass_empty,
+                size: 48, color: AppColors.secondary),
+            SizedBox(height: 16),
+            Text(
+              'Session is starting or waiting at a startup prompt.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Tap the terminal icon to open the live screen and continue.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: AppColors.secondary),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/lib/ui/status_style.dart
+++ b/app/lib/ui/status_style.dart
@@ -11,6 +11,8 @@ String statusGlyph(SessionStatus s) {
     case SessionStatus.idle:
     case SessionStatus.discovered:
       return '○';
+    case SessionStatus.starting:
+      return '◌';
     case SessionStatus.dead:
       return '×';
     case SessionStatus.unknown:
@@ -28,6 +30,7 @@ Color statusColor(SessionStatus s) {
       return const Color(0xFFfb4934);
     case SessionStatus.idle:
     case SessionStatus.discovered:
+    case SessionStatus.starting:
     case SessionStatus.unknown:
       return const Color(0xFF928374);
   }

--- a/app/test/ui/session_detail_screen_test.dart
+++ b/app/test/ui/session_detail_screen_test.dart
@@ -11,8 +11,26 @@ import 'package:argus/state/gateway.dart';
 import 'package:argus/state/sessions.dart';
 import 'package:argus/state/transcript.dart';
 import 'package:argus/state/transcript_controller.dart';
+import 'package:argus/ui/interaction_bar.dart';
 import 'package:argus/ui/session_detail_screen.dart';
 import '../support/fake_session_repository.dart';
+
+Session _sStarting() => Session.fromJson({
+      'id': 'mac:%1',
+      'agent': 't',
+      'status': 'starting',
+      'source': 'discovered',
+      'frontend': 'tmux',
+      'tmux': {
+        'server': 'argus',
+        'pane_id': '%1',
+        'session_name': 's',
+        'window_index': 0,
+        'current_path': '/p',
+      },
+      'repo': 'argus',
+      'node_label': 'mac',
+    });
 
 Session _s({String? agentSessionId, String? name, String? branch}) =>
     Session.fromJson({
@@ -215,5 +233,20 @@ void main() {
     expect(find.textContaining('post-clear line'), findsOneWidget);
     expect(find.textContaining('pre-clear line'), findsNothing);
     expect(repo.stores, hasLength(2)); // re-opened onto the fresh store
+  });
+
+  testWidgets('starting session shows startup notice and no input bar',
+      (tester) async {
+    await tester.pumpWidget(_app(
+      [
+        gatewayProvider.overrideWithValue(null),
+        transcriptProvider('mac:%1')
+            .overrideWith(() => _SeededTranscript(const [])),
+      ],
+      session: _sStarting(),
+    ));
+    await tester.pump();
+    expect(find.textContaining('startup prompt'), findsOneWidget);
+    expect(find.byType(InteractionBar), findsNothing);
   });
 }

--- a/internal/adapter/claudecode/discovery.go
+++ b/internal/adapter/claudecode/discovery.go
@@ -87,6 +87,9 @@ type paneInfo struct {
 // structural + identity fields only — ScanOnce fills Summary/StatusHint.
 func buildDiscovered(procs map[int]string, paneByTTY map[string]paneInfo, entries []procSession) []registry.DiscoveredSession {
 	var out []registry.DiscoveredSession
+	// seenPaneK tracks panes already emitted (by either pass) so the pane-only pass
+	// never adds a second record for one pane — distinct pids can share a tty→pane.
+	seenPaneK := map[string]bool{}
 	for _, ps := range entries {
 		tty, alive := procs[ps.PID]
 		if !alive {
@@ -100,20 +103,11 @@ func buildDiscovered(procs map[int]string, paneByTTY map[string]paneInfo, entrie
 		}
 		if tty != "" {
 			if pi, ok := paneByTTY[normalizeTTY(tty)]; ok {
-				d.HasPane = true
-				d.Server = pi.server
-				d.PaneID = pi.paneID
-				d.SessionName = pi.sessionName
-				d.WindowIndex = pi.windowIndex
-				d.CurrentPath = pi.currentPath
-				if pi.currentPath != "" {
-					d.Repo = repoName(pi.currentPath)
-				}
+				bindPane(&d, pi)
+				seenPaneK[registry.PaneKey(pi.server, pi.paneID)] = true
 			}
 		}
-		if d.HasPane {
-			d.Frontend = session.FrontendTmux
-		} else {
+		if !d.HasPane {
 			d.Frontend = frontendFor(ps.Entrypoint, false)
 		}
 		if ps.Cwd != "" {
@@ -123,7 +117,44 @@ func buildDiscovered(procs map[int]string, paneByTTY map[string]paneInfo, entrie
 		}
 		out = append(out, d)
 	}
+
+	// Pane-only pass: a live claude on a pane with no proc-session file yet (stuck at
+	// the startup gate) is otherwise invisible and can't be opened to unblock. Skip
+	// paneless procs: their empty AgentSessionID collides on the shared "claude:" key.
+	for _, tty := range procs {
+		if tty == "" {
+			continue
+		}
+		pi, ok := paneByTTY[normalizeTTY(tty)]
+		if !ok {
+			continue
+		}
+		paneK := registry.PaneKey(pi.server, pi.paneID)
+		if seenPaneK[paneK] {
+			continue
+		}
+		seenPaneK[paneK] = true
+		var d registry.DiscoveredSession
+		bindPane(&d, pi)
+		d.Cwd = pi.currentPath
+		out = append(out, d)
+	}
 	return out
+}
+
+// bindPane sets d's pane fields and tmux frontend. Cwd is left to the caller: the
+// entries pass keeps the proc-session cwd, the pane-only pass adopts the pane's.
+func bindPane(d *registry.DiscoveredSession, pi paneInfo) {
+	d.HasPane = true
+	d.Server = pi.server
+	d.PaneID = pi.paneID
+	d.SessionName = pi.sessionName
+	d.WindowIndex = pi.windowIndex
+	d.CurrentPath = pi.currentPath
+	d.Frontend = session.FrontendTmux
+	if pi.currentPath != "" {
+		d.Repo = repoName(pi.currentPath)
+	}
 }
 
 // serverClient pairs a logical tmux server with its CLI client.

--- a/internal/adapter/claudecode/discovery_test.go
+++ b/internal/adapter/claudecode/discovery_test.go
@@ -168,6 +168,111 @@ func TestCachedTranscriptStatusHint(t *testing.T) {
 	}
 }
 
+// TestBuildDiscoveredPaneOnly: a file-less live claude on a pane is emitted;
+// the other procs (see inline) are not.
+func TestBuildDiscoveredPaneOnly(t *testing.T) {
+	procs := map[int]string{
+		100: "ttys002", // has a proc-session file below → entries pass, not pane-only
+		500: "ttys003", // live on a pane, no file → pane-only
+		600: "ttys099", // tty but no pane → skipped
+		700: "",        // ttyless → skipped
+		800: "ttys002", // shares pid 100's tty/pane, no file → must not double-emit that pane
+	}
+	paneByTTY := map[string]paneInfo{
+		"ttys002": {server: session.TmuxServerArgus, paneID: "%0", sessionName: "s0", currentPath: "/repo/a"},
+		"ttys003": {server: session.TmuxServerArgus, paneID: "%1", sessionName: "s1", currentPath: "/repo/b"},
+	}
+	entries := []procSession{
+		{PID: 100, SessionID: "tmux-1", Entrypoint: "cli", Cwd: "/x"},
+	}
+
+	var paneOnly []registry.DiscoveredSession
+	full := map[string]registry.DiscoveredSession{}
+	for _, d := range buildDiscovered(procs, paneByTTY, entries) {
+		if d.AgentSessionID == "" {
+			paneOnly = append(paneOnly, d)
+		} else {
+			full[d.AgentSessionID] = d
+		}
+	}
+
+	// The pid with a file is emitted once (not double-counted by the pane-only pass).
+	if len(full) != 1 || full["tmux-1"].PaneID != "%0" {
+		t.Fatalf("entries pass: %+v", full)
+	}
+	// Only 500 is surfaced pane-only.
+	if len(paneOnly) != 1 {
+		t.Fatalf("want 1 pane-only session, got %d: %+v", len(paneOnly), paneOnly)
+	}
+	po := paneOnly[0]
+	if !po.HasPane || po.PaneID != "%1" || po.Frontend != session.FrontendTmux ||
+		po.AgentSessionID != "" || po.Cwd != "/repo/b" || po.Repo != repoName("/repo/b") {
+		t.Fatalf("pane-only session: %+v", po)
+	}
+}
+
+// TestScanOnceSurfacesStuckPaneThenUpgrades drives a real tmux pane. First scan sees
+// a live claude on that pane with no proc-session file (stuck at the trust/model
+// gate): it must surface as an attachable pane-keyed session. Once the proc-session
+// file appears, the next scan upgrades the same record in place with the session id.
+func TestScanOnceSurfacesStuckPaneThenUpgrades(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	ctx := context.Background()
+	client := tmux.New("argus-stuck-test")
+	t.Cleanup(func() { _ = client.KillServer(ctx) })
+	if _, err := client.NewSession(ctx, tmux.NewSessionOpts{Name: "s1"}); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	panes, err := client.ListPanes(ctx)
+	if err != nil || len(panes) == 0 {
+		t.Fatalf("ListPanes: err=%v len=%d", err, len(panes))
+	}
+	pane := panes[0]
+	tty := normalizeTTY(pane.TTY)
+
+	dir := t.TempDir()
+	claudeSessionsDirOverride = dir
+	t.Cleanup(func() { claudeSessionsDirOverride = "" })
+
+	orig := runPS
+	t.Cleanup(func() { runPS = orig })
+	runPS = func() (string, error) { return "  4242 " + tty + " S+ claude", nil }
+
+	reg := registry.New()
+	d := NewDiscoverer(reg, map[session.TmuxServer]*tmux.Client{session.TmuxServerArgus: client})
+
+	// Stuck at the gate: live claude on the pane, no proc-session file yet.
+	if err := d.ScanOnce(ctx); err != nil {
+		t.Fatalf("ScanOnce: %v", err)
+	}
+	id := "argus:" + pane.PaneID
+	s, ok := reg.Get(id)
+	if !ok {
+		t.Fatalf("stuck session %s should be surfaced", id)
+	}
+	if !s.Controllable() || s.Frontend != session.FrontendTmux || s.AgentSessionID != "" {
+		t.Fatalf("stuck session should be an attachable pane-only record: %+v", s)
+	}
+
+	// Gate cleared: claude writes its proc-session file → next scan upgrades in place.
+	if err := os.WriteFile(filepath.Join(dir, "4242.json"),
+		[]byte(`{"pid":4242,"sessionId":"c1","cwd":"/repo","name":"n","entrypoint":"cli"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.ScanOnce(ctx); err != nil {
+		t.Fatalf("ScanOnce: %v", err)
+	}
+	s2, ok := reg.Get(id)
+	if !ok {
+		t.Fatalf("session %s should survive the upgrade scan (not pruned)", id)
+	}
+	if s2.AgentSessionID != "c1" || s2.Tmux.PaneID != pane.PaneID {
+		t.Fatalf("session should upgrade in place with the session id: %+v", s2)
+	}
+}
+
 func TestBuildDiscovered(t *testing.T) {
 	procs := map[int]string{100: "ttys002", 200: "", 300: "ttys009"}
 	paneByTTY := map[string]paneInfo{

--- a/internal/node/handlers_session.go
+++ b/internal/node/handlers_session.go
@@ -245,7 +245,28 @@ func (d *Node) handleSessionSpawn(ctx context.Context, params json.RawMessage) (
 	if err != nil {
 		return nil, err
 	}
-	return api.SpawnResult{SessionID: string(session.TmuxServerArgus) + ":" + paneID, PaneID: paneID}, nil
+	// Discovery registers the session, but only once the agent process is visible in
+	// ps — which can lag the pane's creation. Retry with backoff so the session shows
+	// up without a manual refresh, stopping early once it's registered.
+	sid := string(session.TmuxServerArgus) + ":" + paneID
+	go d.rescanUntilRegistered(sid)
+	return api.SpawnResult{SessionID: sid, PaneID: paneID}, nil
+}
+
+// rescanUntilRegistered rescans discovery with backoff until the given session id
+// appears in the registry or the attempts are exhausted. Covers the window between a
+// spawned pane existing and the agent process becoming visible to discovery's ps probe.
+func (d *Node) rescanUntilRegistered(id string) {
+	// Leading 0 scans immediately (Sleep(0) is a no-op) to catch the fast case, then
+	// backs off while waiting for the process to appear in ps.
+	backoffs := []time.Duration{0, 250 * time.Millisecond, 500 * time.Millisecond, 750 * time.Millisecond, 1500 * time.Millisecond, 2 * time.Second}
+	for _, wait := range backoffs {
+		time.Sleep(wait)
+		d.scan(context.Background())
+		if _, ok := d.reg.Get(id); ok {
+			return
+		}
+	}
 }
 
 // launchPane opens a new tmux pane running command in cwd. A blank sessionName

--- a/internal/node/handlers_session_test.go
+++ b/internal/node/handlers_session_test.go
@@ -8,11 +8,53 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MunifTanjim/argus/internal/adapter"
 	"github.com/MunifTanjim/argus/internal/api"
 	"github.com/MunifTanjim/argus/internal/registry"
 	"github.com/MunifTanjim/argus/internal/session"
 	"github.com/MunifTanjim/argus/internal/tmux"
 )
+
+// fakeDiscoverer registers the target session on its Nth ScanOnce, modelling the
+// spawn→ps lag: the process only becomes visible to discovery after a few scans.
+type fakeDiscoverer struct {
+	calls    int
+	after    int
+	register func()
+}
+
+func (f *fakeDiscoverer) ScanOnce(context.Context) error {
+	f.calls++
+	if f.calls >= f.after {
+		f.register()
+	}
+	return nil
+}
+
+// The post-spawn rescan must retry until the session is registered, then stop as
+// soon as it appears (not run the full backoff schedule).
+func TestRescanUntilRegisteredStopsWhenFound(t *testing.T) {
+	d := newNode(map[session.TmuxServer]*tmux.Client{
+		session.TmuxServerArgus: tmux.New("argus-rescan-test"),
+	})
+	id := "argus:%7"
+	fd := &fakeDiscoverer{after: 3, register: func() {
+		d.reg.ReconcileSessions("claude", []registry.DiscoveredSession{{
+			HasPane: true, Server: session.TmuxServerArgus, PaneID: "%7",
+			Frontend: session.FrontendTmux,
+		}})
+	}}
+	d.discs = []adapter.Discoverer{fd}
+
+	d.rescanUntilRegistered(id)
+
+	if _, ok := d.reg.Get(id); !ok {
+		t.Fatalf("session %s should be registered after retries", id)
+	}
+	if fd.calls != 3 {
+		t.Fatalf("rescan should stop as soon as the session appears: got %d scans, want 3", fd.calls)
+	}
+}
 
 // A node without tmux must advertise no spawn support and reject sessions.spawn
 // with an error, even if a client bypasses the UI gating.

--- a/internal/registry/reconcile_sessions_test.go
+++ b/internal/registry/reconcile_sessions_test.go
@@ -126,6 +126,106 @@ func TestReconcileSessionsLearnsClaudeOntoPaneRecord(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionsPaneOnlyStarting(t *testing.T) {
+	r := New()
+	// Pane-only discovery record: has a pane, no AgentSessionID (still at a gate).
+	r.ReconcileSessions("claude", []DiscoveredSession{
+		{HasPane: true, Server: session.TmuxServerDefault, PaneID: "%7"},
+	})
+	s, ok := r.Get("default:%7")
+	if !ok {
+		t.Fatal("pane-only session missing")
+	}
+	if s.Status != session.StatusStarting {
+		t.Fatalf("pane-only session status: want starting, got %q", s.Status)
+	}
+	if s.Interaction != nil {
+		t.Fatalf("starting session must not synthesize an interaction, got %+v", s.Interaction)
+	}
+}
+
+func TestReconcileSessionsStartingUpgradesToIdle(t *testing.T) {
+	r := New()
+	// First scan: pane-only, stuck at a startup gate.
+	r.ReconcileSessions("claude", []DiscoveredSession{
+		{HasPane: true, Server: session.TmuxServerDefault, PaneID: "%7"},
+	})
+	// Second scan: proc-session file appeared → same pane now carries an
+	// AgentSessionID, still no transcript.
+	r.ReconcileSessions("claude", []DiscoveredSession{
+		{HasPane: true, Server: session.TmuxServerDefault, PaneID: "%7", AgentSessionID: "sess-1"},
+	})
+	s, _ := r.Get("default:%7")
+	if s.Status != session.StatusIdle {
+		t.Fatalf("upgraded session status: want idle, got %q", s.Status)
+	}
+	if s.Interaction == nil || s.Interaction.Kind != session.InteractionIdle {
+		t.Fatalf("upgraded session must synthesize idle interaction, got %+v", s.Interaction)
+	}
+}
+
+// A pane-only discovered session (no AgentSessionID — e.g. a claude stuck at a
+// startup gate before it writes its session id) must be created as an attachable
+// pane-keyed record and survive a later scan that still only sees the pane, so it
+// isn't pruned while the user is trying to open it.
+func TestReconcileSessionsPaneOnlyControllableAndSurvives(t *testing.T) {
+	r := New()
+	paneOnly := DiscoveredSession{
+		HasPane: true, Server: session.TmuxServerArgus, PaneID: "%3",
+		Frontend: session.FrontendTmux,
+	}
+	r.ReconcileSessions("claude", []DiscoveredSession{paneOnly})
+
+	s, ok := r.Get("argus:%3")
+	if !ok || !s.Controllable() || s.AgentSessionID != "" || s.Frontend != session.FrontendTmux {
+		t.Fatalf("pane-only session not created controllable: ok=%v %+v", ok, s)
+	}
+
+	// Still stuck: an identical pane-only scan must keep it alive.
+	r.ReconcileSessions("claude", []DiscoveredSession{paneOnly})
+	if _, ok := r.Get("argus:%3"); !ok {
+		t.Fatal("pane-only session should survive a rescan that still sees the pane")
+	}
+}
+
+// A pane-only session (no AgentSessionID) is kept alive solely by its pane. When
+// the process exits and the pane is gone from the scan, it has no claude id to
+// fall back on and must be pruned — e.g. a short-lived `claude -p` run.
+func TestReconcileSessionsPaneOnlyPrunedWhenPaneGone(t *testing.T) {
+	r := New()
+	r.ReconcileSessions("claude", []DiscoveredSession{
+		{HasPane: true, Server: session.TmuxServerArgus, PaneID: "%3", Frontend: session.FrontendTmux},
+	})
+	if _, ok := r.Get("argus:%3"); !ok {
+		t.Fatal("pane-only session should be created")
+	}
+	r.ReconcileSessions("claude", nil)
+	if _, ok := r.Get("argus:%3"); ok {
+		t.Error("pane-only session should be pruned once the pane is gone")
+	}
+}
+
+// A pane-only record must not clobber the cwd/repo a proc-session already set for
+// the same pane: the pane's current path can drift (the user cd's in a subshell)
+// while the authoritative launch cwd stays fixed.
+func TestReconcileSessionsPaneOnlyDoesNotOverwriteCwd(t *testing.T) {
+	r := New()
+	r.ReconcileSessions("claude", []DiscoveredSession{{
+		AgentSessionID: "c0", HasPane: true, Server: session.TmuxServerDefault,
+		PaneID: "%0", Frontend: session.FrontendTmux, Cwd: "/work/repo", Repo: "repo",
+	}})
+	// Transient scan: proc-session file unreadable, only the pane seen with a
+	// drifted current path.
+	r.ReconcileSessions("claude", []DiscoveredSession{{
+		HasPane: true, Server: session.TmuxServerDefault, PaneID: "%0",
+		Frontend: session.FrontendTmux, Cwd: "/tmp/sub", Repo: "sub",
+	}})
+	s, _ := r.Get("default:%0")
+	if s.Cwd != "/work/repo" || s.Repo != "repo" {
+		t.Fatalf("pane-only scan overwrote authoritative cwd/repo: %+v", s)
+	}
+}
+
 func TestReconcileSessionsNeverDowngradesFrontend(t *testing.T) {
 	r := New()
 	r.ReconcileSessions("claude", []DiscoveredSession{
@@ -151,9 +251,8 @@ func TestReconcileSessionsCrossServerLiveness(t *testing.T) {
 	if n := len(r.Snapshot()); n != 2 {
 		t.Fatalf("same pane id on two servers = 2 sessions, got %d", n)
 	}
-	// Scan that finds only the default server's session must not prune argus's,
-	// because the global found-set still contains argus this call... so instead
-	// model a scan that genuinely no longer sees argus:
+	// A scan that no longer sees the argus pane must prune it, even though
+	// default:%0 shares the pane id.
 	r.ReconcileSessions("claude", []DiscoveredSession{
 		tmuxDisc("c0", "%0", "a", session.TmuxServerDefault),
 	})

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -48,9 +48,9 @@ func New() *Registry {
 	}
 }
 
-// paneKey identifies a pane across servers; pane ids are only unique per server,
+// PaneKey identifies a pane across servers; pane ids are only unique per server,
 // so the server must be part of the key.
-func paneKey(server session.TmuxServer, paneID string) string {
+func PaneKey(server session.TmuxServer, paneID string) string {
 	return string(server) + ":" + paneID
 }
 
@@ -140,7 +140,7 @@ func (r *Registry) ReconcileSessions(agent string, found []DiscoveredSession) {
 	for _, f := range found {
 		paneK := ""
 		if f.HasPane {
-			paneK = paneKey(f.Server, f.PaneID)
+			paneK = PaneKey(f.Server, f.PaneID)
 			seenPane[paneK] = true
 		}
 		if f.AgentSessionID != "" {
@@ -196,10 +196,14 @@ func (r *Registry) ReconcileSessions(agent string, found []DiscoveredSession) {
 		if f.Name != "" {
 			s.Name = f.Name
 		}
-		if f.Cwd != "" {
+		// A pane-only record (no AgentSessionID) carries the pane's current path, not
+		// an authoritative proc-session cwd — only seed it, never overwrite a value a
+		// proc-session/hook already set (the user may have cd'd within the pane).
+		paneOnly := f.AgentSessionID == ""
+		if f.Cwd != "" && !(paneOnly && s.Cwd != "") {
 			s.Cwd = f.Cwd
 		}
-		if f.Repo != "" {
+		if f.Repo != "" && !(paneOnly && s.Repo != "") {
 			s.Repo = f.Repo
 		}
 		setTranscriptPath(s, f.TranscriptPath)
@@ -222,7 +226,7 @@ func (r *Registry) ReconcileSessions(agent string, found []DiscoveredSession) {
 		pk := ""
 		alive := false
 		if s.Tmux.PaneID != "" {
-			pk = paneKey(s.Tmux.Server, s.Tmux.PaneID)
+			pk = PaneKey(s.Tmux.Server, s.Tmux.PaneID)
 			if seenPane[pk] {
 				alive = true
 			}
@@ -257,20 +261,22 @@ func setTranscriptPath(s *session.Session, path string) {
 	s.Summary = nil
 }
 
-// applyStatusHint seeds a transcript-derived status onto a still-StatusDiscovered
-// session (no authoritative hook status yet). An idle hint also synthesizes an idle
-// Interaction so clients show the compose. A missing hint on a pane-bearing session
-// (freshly opened, no transcript yet) defaults to idle so clients can send the first
-// prompt. Caller holds r.mu.
+// applyStatusHint seeds a transcript-derived status onto a still-provisional session
+// (StatusDiscovered/StatusStarting only). An idle hint also synthesizes an idle
+// Interaction so clients show the compose. Caller holds r.mu.
 func applyStatusHint(s *session.Session, hint session.Status) {
-	if s.Status != session.StatusDiscovered {
+	if s.Status != session.StatusDiscovered && s.Status != session.StatusStarting {
 		return
 	}
 	if hint == "" {
 		if s.Tmux.PaneID == "" {
 			return // no pane = can't type into it, leave discovered
 		}
-		hint = session.StatusIdle
+		if s.AgentSessionID == "" {
+			s.Status = session.StatusStarting // pane still at a startup gate, not ready
+			return
+		}
+		hint = session.StatusIdle // has a session id but no transcript yet: ready for the first prompt
 	}
 	s.Status = hint
 	if hint == session.StatusIdle && s.Interaction == nil {
@@ -356,7 +362,7 @@ func (r *Registry) ApplyHook(u HookUpdate) (session.Session, bool) {
 
 	pKey := ""
 	if u.PaneID != "" {
-		pKey = paneKey(u.Server, u.PaneID)
+		pKey = PaneKey(u.Server, u.PaneID)
 	}
 
 	var s *session.Session

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -9,6 +9,9 @@ type Status string
 const (
 	// StatusDiscovered: found (e.g. a tmux pane) but no hook event yet.
 	StatusDiscovered Status = "discovered"
+	// StatusStarting: has a tmux pane but hasn't reached the REPL yet (still at a
+	// startup gate — trust/theme/login). Not ready for input.
+	StatusStarting Status = "starting"
 	// StatusWorking: actively processing (between prompt submit and stop, or a tool call).
 	StatusWorking Status = "working"
 	// StatusAwaitingInput: blocked on the user (e.g. a permission prompt).
@@ -29,6 +32,8 @@ func (s Status) Label() string {
 		return "awaiting"
 	case StatusIdle:
 		return "idle"
+	case StatusStarting:
+		return "starting"
 	case StatusDiscovered:
 		return "discovered"
 	case StatusDead:

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -96,6 +96,8 @@ func statusColor(s session.Status) color.Color {
 		return ColorOngoing
 	case session.StatusAwaitingInput:
 		return ColorAccent
+	case session.StatusStarting:
+		return ColorTextMuted
 	case session.StatusIdle:
 		return ColorTextDim
 	default: // dead / discovered

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -214,7 +214,13 @@ func (m model) actHistSessResume(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	s := m.history.sessions[m.history.sessCursor]
-	if !s.Resumable {
+	return m.startHistoryResume(s.Resumable, m.history.project.NodeID, s.Agent, s.SessionID)
+}
+
+// startHistoryResume gates a resume on the session's resumability and a known
+// working directory, flashing the reason when it can't proceed.
+func (m model) startHistoryResume(resumable bool, nodeID, agent, sessionID string) (tea.Model, tea.Cmd) {
+	if !resumable {
 		m.flash = "resume not supported for this session"
 		return m, nil
 	}
@@ -222,7 +228,7 @@ func (m model) actHistSessResume(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.flash = "resume unavailable: unknown working directory"
 		return m, nil
 	}
-	return m, m.resumeCmd(m.history.project.NodeID, s.Agent, s.SessionID, m.history.project.Cwd)
+	return m, m.resumeCmd(nodeID, agent, sessionID, m.history.project.Cwd)
 }
 
 func (m model) actHistSessOpen(tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -258,15 +264,7 @@ func (m model) handleHistoryTranscriptKey(msg tea.KeyPressMsg) (tea.Model, tea.C
 		return m, nil
 	}
 	if key.Matches(msg, transcriptKeys.Resume) && m.historyView == histTranscript {
-		if !m.history.openResumable {
-			m.flash = "resume not supported for this session"
-			return m, nil
-		}
-		if m.history.project.Cwd == "" {
-			m.flash = "resume unavailable: unknown working directory"
-			return m, nil
-		}
-		return m, m.resumeCmd(m.history.openNodeID, m.history.openAgent, m.history.openSessionID, m.history.project.Cwd)
+		return m.startHistoryResume(m.history.openResumable, m.history.openNodeID, m.history.openAgent, m.history.openSessionID)
 	}
 	if m.historyView == histDetail {
 		return m.handleDetailKey(msg)

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -118,6 +118,9 @@ func (m model) sessionFooter() string {
 		if m.sessionInteraction() != nil {
 			binds = append(binds, transcriptKeys.Answer)
 		}
+		if m.sessions[m.selectedID].Status == session.StatusStarting {
+			binds = append(binds, sessionKeys.Raw)
+		}
 		return m.footer(binds...)
 	}
 }
@@ -389,6 +392,10 @@ func (m model) sessionView() string {
 	header += dimStyle.Render(fmt.Sprintf("  [%s] %s", paneTag(s), statusWord(s)))
 	header = centerBlock(indentBlock(header, strings.Repeat(" ", contentPadX)), m.containerWidth(), m.width)
 
+	if s.Status == session.StatusStarting {
+		return pinFooter(header+"\n\n"+startingNotice(m), m.sessionFooter(), m.width, m.height)
+	}
+
 	body := m.historyBody()
 	if m.sessionInteraction() != nil {
 		_, dockH := m.sessionLayout()
@@ -409,4 +416,14 @@ func (m model) sessionView() string {
 		body = body + "\n" + centerBlock(dock, m.containerWidth(), m.width)
 	}
 	return pinFooter(header+"\n\n"+body, m.sessionFooter(), m.width, m.height)
+}
+
+// startingNotice renders the startup-gate message centered in place of the
+// absent transcript.
+func startingNotice(m model) string {
+	lines := []string{
+		"Session is starting or waiting at a startup prompt.",
+		"Press " + sessionKeys.Raw.Help().Key + " to open the live screen and continue.",
+	}
+	return centerBlock(dimStyle.Render(strings.Join(lines, "\n")), m.containerWidth(), m.width)
 }

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -439,8 +439,7 @@ func TestSubagentLeafBackDoesNotTearDownSubscription(t *testing.T) {
 	}
 	m.transcriptCache = map[string]cachedTranscript{}
 
-	// Populate a transcript chunk with a live subagent item (no inlined trace: it
-	// will be streamed).
+	// A live subagent item with no inlined trace: it will be streamed.
 	agentItem := transcript.Item{
 		Kind:      transcript.ItemSubagent,
 		Subagents: []transcript.Subagent{{Type: "explorer", HasTrace: true, ID: "agent42"}},
@@ -659,5 +658,43 @@ func TestSessionCardAgentLabelGated(t *testing.T) {
 	hidden := ansi.Strip(m.sessionCard(s, false, 78, false))
 	if strings.Contains(hidden, "Codex") {
 		t.Errorf("showAgent=false should not render agent label:\n%s", hidden)
+	}
+}
+
+func TestSessionFooterIncludesRawHintWhenStarting(t *testing.T) {
+	foot := func(m model) string { m.width = 120; return ansi.Strip(m.sessionFooter()) }
+
+	m := sessionModel(nil)
+	s := m.sessions["s1"]
+	s.Status = session.StatusStarting
+	m.sessions["s1"] = s
+
+	if !strings.Contains(foot(m), "ctrl+s") {
+		t.Errorf("starting session footer should include ctrl+s hint: %q", foot(m))
+	}
+
+	// Non-starting session should not include ctrl+s in the default footer.
+	s.Status = session.StatusIdle
+	m.sessions["s1"] = s
+	if strings.Contains(foot(m), "ctrl+s") {
+		t.Errorf("idle session footer should not include ctrl+s hint: %q", foot(m))
+	}
+}
+
+func TestSessionViewStartingShowsNotice(t *testing.T) {
+	m := sessionModel(nil)
+	s := m.sessions["s1"]
+	s.Status = session.StatusStarting
+	m.sessions["s1"] = s
+
+	out := ansi.Strip(m.sessionView())
+	if !strings.Contains(out, "startup prompt") {
+		t.Errorf("starting session should show the startup notice:\n%s", out)
+	}
+	if !strings.Contains(out, "live screen") {
+		t.Errorf("starting notice should point to the live screen:\n%s", out)
+	}
+	if !strings.Contains(out, "starting") {
+		t.Errorf("header should show the starting status word:\n%s", out)
 	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -96,6 +96,8 @@ func statusGlyph(s session.Status) string {
 		return "◆"
 	case session.StatusIdle:
 		return "○"
+	case session.StatusStarting:
+		return "◌"
 	case session.StatusDead:
 		return "✗"
 	default:
@@ -186,12 +188,12 @@ func (m model) listView() string {
 	}
 	title += "    " + m.homeTabs(modeList)
 
-	// Empty state: centered welcome with the argus wordmark.
+	// Empty state.
 	if len(m.order) == 0 {
 		return m.emptyListView(title)
 	}
 
-	// Populated: centered, scrollable session cards.
+	// Populated.
 	cardW := min(m.containerWidth(), 78)
 	if cardW < 30 {
 		cardW = 30


### PR DESCRIPTION
Claude sessions that stall at a startup prompt (trust workspace / change model) never showed in the list, so they couldn't be opened and unblocked remotely — discovery only registers a session once it writes its proc-session file, which a stuck Claude hasn't done yet.

**Fix:** register from the live process + its tmux pane alone, before the file exists; the record upgrades in place once the file appears. Adds a bounded post-spawn rescan for the process→ps lag, plus TUI/app "starting" states for the new status.

Claude-only for now; Codex/Antigravity have the same gap.