### PR TITLE
fix: scope live screen guard to tui tmux window

### DIFF
--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -386,6 +386,10 @@ type TerminalOpenParams struct {
 	SessionID string `json:"session_id"`
 	Cols      int    `json:"cols"`
 	Rows      int    `json:"rows"`
+	// ClientPane is the caller's own tmux pane ($TMUX_PANE) when co-located on the
+	// session's server; empty otherwise (e.g. the mobile app). The node uses it to
+	// refuse an open that would share the agent pane's window.
+	ClientPane string `json:"client_pane,omitempty"`
 }
 
 // TerminalOutput is server→client output from a terminal session (base64-encoded data).

--- a/internal/node/handlers_terminal.go
+++ b/internal/node/handlers_terminal.go
@@ -214,12 +214,16 @@ func (d *Node) handleTerminalOpen(ctx context.Context, params json.RawMessage) (
 	if err != nil {
 		return nil, err
 	}
-	// A mirror grouped onto a window a local client is displaying fights that
-	// client over shared window size and zoom (visible glitching). Refuse instead.
-	if visible, err := c.WindowVisible(ctx, s.Tmux.PaneID, d.isMirror); err != nil {
-		return nil, err
-	} else if visible {
-		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session is visible in your local tmux; use the pane directly"}
+	// A mirror grouped onto the caller's own tmux window fights that client over the
+	// window's size and zoom (visible glitching), so refuse that case. ClientPane must
+	// name a pane on this session's tmux server (clientPaneFor scopes it); the
+	// comparison is meaningless across servers.
+	if p.ClientPane != "" {
+		if same, err := c.PanesShareWindow(ctx, p.ClientPane, s.Tmux.PaneID); err != nil {
+			return nil, err
+		} else if same {
+			return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session shares your tmux window; use the pane directly"}
+		}
 	}
 	cols, rows := clampSize(p.Cols, p.Rows)
 	ct := d.termsFor(ctx, n)

--- a/internal/node/handlers_terminal_test.go
+++ b/internal/node/handlers_terminal_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -97,6 +98,67 @@ func TestTerminalOpenStreamsAndCloses(t *testing.T) {
 	}
 
 	if _, err := d.handleTerminalClose(ctx, mustJSON(api.TerminalCloseParams{TermID: "t1"})); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTerminalOpenSharedWindowGuard: an open is refused only when the caller's pane
+// shares the agent pane's window. A pane shares a window with itself, so passing the
+// agent pane as ClientPane exercises the shared-window case.
+func TestTerminalOpenSharedWindowGuard(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+	pane, err := c.NewSession(ctx, tmux.NewSessionOpts{Name: "origin", Command: "sh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A second, independent session gives us a pane in a different window.
+	other, err := c.NewSession(ctx, tmux.NewSessionOpts{Name: "elsewhere", Command: "sh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := newNode(map[session.TmuxServer]*tmux.Client{session.TmuxServerDefault: c})
+	d.mirrorPrefix, d.mirrorSuffix = "_", "_"
+	sessionID := seedSession(t, d, session.TmuxLocation{
+		Server: session.TmuxServerDefault, PaneID: pane,
+		SessionName: "origin", WindowIndex: 0,
+	})
+
+	notif := newRecordingNotifier()
+	octx := api.WithNotifier(ctx, notif)
+
+	// Caller in the agent's own window: refused with an invalid-request error.
+	_, err = d.handleTerminalOpen(octx, mustJSON(api.TerminalOpenParams{
+		TermID: "t1", SessionID: sessionID, Cols: 80, Rows: 24, ClientPane: pane,
+	}))
+	var rpcErr *api.RPCError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != api.CodeInvalidRequest {
+		t.Fatalf("shared-window open err = %v, want RPCError{CodeInvalidRequest}", err)
+	}
+
+	// Caller in a different window: guard skipped, open proceeds and streams.
+	if _, err := d.handleTerminalOpen(octx, mustJSON(api.TerminalOpenParams{
+		TermID: "t2", SessionID: sessionID, Cols: 80, Rows: 24, ClientPane: other,
+	})); err != nil {
+		t.Fatalf("different-window open err = %v, want success", err)
+	}
+	select {
+	case <-notif.outputs:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no terminal.output after allowed open")
+	}
+	if _, err := d.handleTerminalClose(octx, mustJSON(api.TerminalCloseParams{TermID: "t2"})); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remote caller (mobile app) sends no pane: guard skipped, open allowed even
+	// though the agent pane trivially shares its own window.
+	if _, err := d.handleTerminalOpen(octx, mustJSON(api.TerminalOpenParams{
+		TermID: "t3", SessionID: sessionID, Cols: 80, Rows: 24, ClientPane: "",
+	})); err != nil {
+		t.Fatalf("empty-ClientPane open err = %v, want success", err)
+	}
+	if _, err := d.handleTerminalClose(octx, mustJSON(api.TerminalCloseParams{TermID: "t3"})); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -281,51 +281,51 @@ func paneFocused(out, paneID string) (bool, error) {
 	return false, nil
 }
 
-// windowVisibleFormat drops pane_active (unlike focusFormat): a side-by-side pane
-// still shares its window's size and zoom, which is what a grouped mirror fights
-// over. session_name lets callers skip their own mirrors, which share the window.
-var windowVisibleFormat = strings.Join([]string{
+// paneWindowFormat pairs each pane with its window id (unique per server). Grouped
+// sessions share window objects, so panes on a shared window report the same id.
+var paneWindowFormat = strings.Join([]string{
 	"#{pane_id}",
-	"#{window_active}",
-	"#{session_attached}",
-	"#{session_name}",
+	"#{window_id}",
 }, fieldSep)
 
-// WindowVisible reports whether paneID's window is the current window of an
-// attached client, skipping sessions for which ignore returns true (a nil ignore
-// counts every session). Empty paneID, or no server, is never visible.
-func (c *Client) WindowVisible(ctx context.Context, paneID string, ignore func(session string) bool) (bool, error) {
-	if paneID == "" {
+// PanesShareWindow reports whether panes a and b are in the same tmux window. A
+// missing pane, an empty id, or no server is never a match.
+func (c *Client) PanesShareWindow(ctx context.Context, a, b string) (bool, error) {
+	if a == "" || b == "" {
 		return false, nil
 	}
-	out, err := c.run(ctx, "list-panes", "-a", "-F", windowVisibleFormat)
+	out, err := c.run(ctx, "list-panes", "-a", "-F", paneWindowFormat)
 	if err != nil {
 		if noServer(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	return windowVisible(out, paneID, ignore)
+	return panesShareWindow(out, a, b)
 }
 
-// windowVisible scans windowVisibleFormat output and reports whether paneID's
-// window is current in a non-ignored attached session. A shared window appears
-// once per grouped session, so any matching line suffices.
-func windowVisible(out, paneID string, ignore func(session string) bool) (bool, error) {
+// panesShareWindow scans paneWindowFormat output and reports whether a and b map to
+// the same, non-empty window id. Panes absent from the output never match.
+func panesShareWindow(out, a, b string) (bool, error) {
+	var winA, winB string
 	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
 		if line == "" {
 			continue
 		}
+		// Normalize tmux's vis-escaped separator before splitting (see parsePane).
 		line = strings.ReplaceAll(line, `\037`, fieldSep)
 		f := strings.Split(line, fieldSep)
-		if len(f) != 4 {
-			return false, fmt.Errorf("tmux: unexpected window-visible format (%d fields): %q", len(f), line)
+		if len(f) != 2 {
+			return false, fmt.Errorf("tmux: unexpected pane-window format (%d fields): %q", len(f), line)
 		}
-		if f[0] == paneID && f[1] == "1" && atoi(f[2]) > 0 && (ignore == nil || !ignore(f[3])) {
-			return true, nil
+		if f[0] == a {
+			winA = f[1]
+		}
+		if f[0] == b {
+			winB = f[1]
 		}
 	}
-	return false, nil
+	return winA != "" && winA == winB, nil
 }
 
 // CaptureOpts controls capture-pane behavior.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -80,62 +80,78 @@ func TestPaneFocusedEscapedSep(t *testing.T) {
 	}
 }
 
-// TestWindowVisible checks the window-current / attached-client logic that decides
-// whether a pane's window is on a user's screen (ignores pane_active).
-func TestWindowVisible(t *testing.T) {
+// TestPanesShareWindow checks the pane→window-id pairing that decides whether two
+// panes sit in the same window (grouped sessions share window ids).
+func TestPanesShareWindow(t *testing.T) {
 	sep := "\x1f"
-	line := func(id, windowActive, attached, session string) string {
-		return strings.Join([]string{id, windowActive, attached, session}, sep)
+	line := func(id, window string) string {
+		return strings.Join([]string{id, window}, sep)
 	}
 	out := strings.Join([]string{
-		line("%1", "1", "1", "origin"),       // visible: current window, attached
-		line("%2", "1", "0", "origin"),       // not visible: no client attached
-		line("%3", "0", "1", "origin"),       // not visible: window not current
-		line("%4", "1", "1", "origin"),       // visible: inactive pane still shares the window
-		line("%5", "1", "2", "origin"),       // visible: two clients attached
-		line("%6", "1", "1", "argus-mirror"), // ignored: our own mirror session
+		line("%1", "@1"), // agent pane
+		line("%2", "@1"), // split sibling on the agent's window
+		line("%3", "@2"), // a different window
+		line("%4", "@1"), // grouped-session pane sharing the agent window
 	}, "\n") + "\n"
 
-	ignore := func(s string) bool { return s == "argus-mirror" }
-	want := map[string]bool{"%1": true, "%2": false, "%3": false, "%4": true, "%5": true, "%6": false, "%absent": false}
-	for id, exp := range want {
-		got, err := windowVisible(out, id, ignore)
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"%2", "%1", true},       // caller split into the agent's window
+		{"%4", "%1", true},       // caller attached to a grouped session on that window
+		{"%3", "%1", false},      // caller in a different window
+		{"%absent", "%1", false}, // caller pane not on this server
+		{"%1", "%absent", false}, // agent pane missing
+	}
+	for _, tc := range cases {
+		got, err := panesShareWindow(out, tc.a, tc.b)
 		if err != nil {
-			t.Fatalf("windowVisible(%q): %v", id, err)
+			t.Fatalf("panesShareWindow(%q,%q): %v", tc.a, tc.b, err)
 		}
-		if got != exp {
-			t.Errorf("windowVisible(%q) = %v, want %v", id, got, exp)
+		if got != tc.want {
+			t.Errorf("panesShareWindow(%q,%q) = %v, want %v", tc.a, tc.b, got, tc.want)
 		}
 	}
 }
 
-// TestWindowVisibleEscapedSep verifies the tmux >=3.4 "\037"-escaped separator is
+// TestPanesShareWindowEscapedSep verifies the tmux >=3.4 "\037"-escaped separator is
 // normalized, matching parsePane's handling.
-func TestWindowVisibleEscapedSep(t *testing.T) {
-	got, err := windowVisible(strings.Join([]string{"%9", "1", "1", "origin"}, `\037`), "%9", nil)
+func TestPanesShareWindowEscapedSep(t *testing.T) {
+	out := strings.Join([]string{
+		strings.Join([]string{"%1", "@1"}, `\037`),
+		strings.Join([]string{"%2", "@1"}, `\037`),
+	}, "\n")
+	got, err := panesShareWindow(out, "%1", "%2")
 	if err != nil {
-		t.Fatalf("windowVisible: %v", err)
+		t.Fatalf("panesShareWindow: %v", err)
 	}
 	if !got {
-		t.Fatal("escaped-separator line not parsed as visible")
+		t.Fatal("escaped-separator lines not parsed as sharing a window")
 	}
 }
 
-// TestWindowVisibleDetached checks a detached pane's window is never reported
-// visible — verifiable headlessly (attaching needs a real terminal).
-func TestWindowVisibleDetached(t *testing.T) {
+// TestPanesShareWindowSingleServer checks two panes in one session's window share a
+// window, while a pane in another window does not — verifiable headlessly.
+func TestPanesShareWindowSingleServer(t *testing.T) {
 	c := testClient(t)
 	ctx := context.Background()
-	pane, err := c.NewSession(ctx, NewSessionOpts{Name: "s1"})
+	p1, err := c.NewSession(ctx, NewSessionOpts{Name: "s1"})
 	if err != nil {
 		t.Fatalf("new session: %v", err)
 	}
-	visible, err := c.WindowVisible(ctx, pane, nil)
+	p2, err := c.NewSession(ctx, NewSessionOpts{Name: "s2"})
 	if err != nil {
-		t.Fatalf("WindowVisible: %v", err)
+		t.Fatalf("new session: %v", err)
 	}
-	if visible {
-		t.Errorf("WindowVisible(%q) = true; want false (no client attached)", pane)
+	if same, err := c.PanesShareWindow(ctx, p1, p1); err != nil || !same {
+		t.Errorf("PanesShareWindow(%q,%q) = %v,%v; want true,nil", p1, p1, same, err)
+	}
+	if same, err := c.PanesShareWindow(ctx, p1, p2); err != nil || same {
+		t.Errorf("PanesShareWindow(%q,%q) = %v,%v; want false,nil", p1, p2, same, err)
+	}
+	if same, err := c.PanesShareWindow(ctx, p1, "%absent"); err != nil || same {
+		t.Errorf("PanesShareWindow(%q,absent) = %v,%v; want false,nil", p1, same, err)
 	}
 }
 

--- a/internal/tui/jump_test.go
+++ b/internal/tui/jump_test.go
@@ -107,6 +107,73 @@ func TestPlanJump(t *testing.T) {
 	}
 }
 
+// TestClientPaneFor: the caller's pane is forwarded only when co-located; every
+// non-co-located case must return "" so the guard never compares across servers.
+func TestClientPaneFor(t *testing.T) {
+	defaultLocal := session.Session{ // same machine (no gateway), default server
+		Tmux: session.TmuxLocation{Server: session.TmuxServerDefault, PaneID: "%3"},
+	}
+	const myPane = "%42"
+	cases := []struct {
+		name     string
+		s        session.Session
+		hostname string
+		tmuxEnv  string
+		tmuxPane string
+		want     string
+	}{
+		{
+			name:     "co-located returns the caller pane",
+			s:        defaultLocal,
+			tmuxEnv:  defaultTmuxEnv,
+			tmuxPane: myPane,
+			want:     myPane,
+		},
+		{
+			name:     "not inside tmux",
+			s:        defaultLocal,
+			tmuxEnv:  "",
+			tmuxPane: myPane,
+			want:     "",
+		},
+		{
+			name:     "caller on a different tmux server",
+			s:        defaultLocal,
+			tmuxEnv:  argusTmuxEnv,
+			tmuxPane: myPane,
+			want:     "",
+		},
+		{
+			name: "session on a different tmux server",
+			s: session.Session{
+				Tmux: session.TmuxLocation{Server: session.TmuxServerArgus, PaneID: "%9"},
+			},
+			tmuxEnv:  defaultTmuxEnv,
+			tmuxPane: myPane,
+			want:     "",
+		},
+		{
+			name: "session on another machine",
+			s: session.Session{
+				NodeID:    "box-2",
+				NodeLabel: "box-2",
+				Tmux:      session.TmuxLocation{Server: session.TmuxServerDefault, PaneID: "%4"},
+			},
+			hostname: "box-1",
+			tmuxEnv:  defaultTmuxEnv,
+			tmuxPane: myPane,
+			want:     "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientPaneFor(tc.s, tc.hostname, tc.tmuxEnv, tc.tmuxPane); got != tc.want {
+				t.Fatalf("clientPaneFor = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPlanJumpPanelessFrontendReason(t *testing.T) {
 	s := session.Session{
 		Frontend: session.FrontendVSCode,

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/base64"
+	"os"
 	"strconv"
 	"strings"
 
@@ -152,7 +153,9 @@ func (m model) enterScreen(id string) (model, tea.Cmd) {
 	m.term = vt.NewEmulator(cols, rows)
 	m.termStop = make(chan struct{})
 	go drainEmulator(m.term, m.termStop)
-	return m, m.termOpenCmd(id, termID, cols, rows)
+	host, _ := os.Hostname()
+	clientPane := clientPaneFor(m.sessions[id], host, os.Getenv("TMUX"), os.Getenv("TMUX_PANE"))
+	return m, m.termOpenCmd(id, termID, cols, rows, clientPane)
 }
 
 // drainEmulator discards the emulator's auto-generated query replies (DA/DSR/
@@ -191,11 +194,11 @@ func (m model) leaveScreen() (model, tea.Cmd) {
 	return m.detachScreen(), m.termCloseCmd(termID)
 }
 
-func (m model) termOpenCmd(id, termID string, cols, rows int) tea.Cmd {
+func (m model) termOpenCmd(id, termID string, cols, rows int, clientPane string) tea.Cmd {
 	client := m.client
 	return func() tea.Msg {
 		err := client.Call(api.MethodTerminalOpen, api.TerminalOpenParams{
-			TermID: termID, SessionID: id, Cols: cols, Rows: rows,
+			TermID: termID, SessionID: id, Cols: cols, Rows: rows, ClientPane: clientPane,
 		}, nil)
 		return termOpenedMsg{termID: termID, err: err}
 	}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -633,6 +633,17 @@ func sameMachine(s session.Session, hostname string) bool {
 	return s.NodeID == "" || s.NodeLabel == hostname || s.NodeID == hostname
 }
 
+// clientPaneFor returns this TUI's own tmux pane ($TMUX_PANE) when co-located with
+// the session (same tmux server, same machine), else "" — a pane id is meaningless
+// on another server, so the guard must not apply.
+func clientPaneFor(s session.Session, hostname, tmuxEnv, tmuxPane string) string {
+	coLocated := session.TmuxServer(tmux.SocketBaseFromEnv(tmuxEnv)) == s.Tmux.Server && sameMachine(s, hostname)
+	if !coLocated {
+		return ""
+	}
+	return tmuxPane
+}
+
 // nodeName picks the human-friendly name for a node: its label, else its id.
 func nodeName(label, id string) string {
 	if label != "" {


### PR DESCRIPTION
The live screen guard refused opens whenever the session's window was attached anywhere on the node's machine, blocking the mobile app.

Now the guard fires only when the caller's own tmux pane shares the agent pane's window. Callers that send no pane (mobile app, remote clients) are always allowed.