### PR TITLE
feat: render skill load as user chunk item

### DIFF
--- a/app/lib/models/chunk.dart
+++ b/app/lib/models/chunk.dart
@@ -170,7 +170,7 @@ class ToolDetail {
       );
 }
 
-enum ChunkKind { user, ai, system, shell, skill, compact, unknown }
+enum ChunkKind { user, ai, system, shell, compact, unknown }
 
 ChunkKind chunkKindFromWire(String? s) {
   switch (s) {
@@ -182,8 +182,6 @@ ChunkKind chunkKindFromWire(String? s) {
       return ChunkKind.system;
     case 'shell':
       return ChunkKind.shell;
-    case 'skill':
-      return ChunkKind.skill;
     case 'compact':
       return ChunkKind.compact;
     default:

--- a/app/lib/ui/chunk_card.dart
+++ b/app/lib/ui/chunk_card.dart
@@ -73,15 +73,17 @@ class _ChunkCardState extends ConsumerState<ChunkCard> {
   Widget build(BuildContext context) {
     switch (widget.chunk.kind) {
       case ChunkKind.user:
-        return _UserBubble(text: widget.chunk.text ?? '');
+        return _UserBubble(
+          text: widget.chunk.text ?? '',
+          items: widget.chunk.items,
+          onDrill: _drill,
+        );
       case ChunkKind.ai:
         return _aiCard(widget.chunk);
       case ChunkKind.system:
         return _SystemCard(chunk: widget.chunk);
       case ChunkKind.shell:
         return _ShellCard(chunk: widget.chunk);
-      case ChunkKind.skill:
-        return _SkillCard(chunk: widget.chunk);
       case ChunkKind.compact:
         return _CompactDivider(summary: widget.chunk.summary);
       case ChunkKind.unknown:
@@ -369,8 +371,10 @@ class _ChunkCardState extends ConsumerState<ChunkCard> {
 }
 
 class _UserBubble extends StatefulWidget {
-  const _UserBubble({required this.text});
+  const _UserBubble({required this.text, this.items = const [], this.onDrill});
   final String text;
+  final List<Item> items;
+  final VoidCallback? Function(Item)? onDrill;
 
   @override
   State<_UserBubble> createState() => _UserBubbleState();
@@ -379,10 +383,12 @@ class _UserBubble extends StatefulWidget {
 class _UserBubbleState extends State<_UserBubble> {
   static const _maxLines = 10;
   bool _expanded = false;
+  bool _itemsExpanded = false;
 
   @override
   Widget build(BuildContext context) {
     final text = widget.text;
+    final hasText = text.trim().isNotEmpty;
     final lineCount = '\n'.allMatches(text).length + 1;
     final long = lineCount > _maxLines || text.length > 600;
 
@@ -421,7 +427,13 @@ class _UserBubbleState extends State<_UserBubble> {
             borderRadius: BorderRadius.circular(6),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: body,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (hasText) body,
+              if (widget.items.isNotEmpty) _items(),
+            ],
+          ),
         ),
       ),
     );
@@ -435,6 +447,35 @@ class _UserBubbleState extends State<_UserBubble> {
               style: _mono.copyWith(color: AppColors.accent, fontSize: 11)),
         ),
       );
+
+  Widget _items() {
+    final items = widget.items;
+    final header = InkWell(
+      onTap: () => setState(() => _itemsExpanded = !_itemsExpanded),
+      child: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(_itemsExpanded ? Icons.expand_more : Icons.chevron_right,
+                size: 14, color: AppColors.dim),
+            const SizedBox(width: 2),
+            Text('${items.length} item${items.length == 1 ? '' : 's'}',
+                style: _monoDim),
+          ],
+        ),
+      ),
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        header,
+        if (_itemsExpanded)
+          for (final it in items)
+            ItemRow(item: it, onTap: widget.onDrill?.call(it)),
+      ],
+    );
+  }
 }
 
 class _SystemCard extends StatefulWidget {
@@ -549,73 +590,6 @@ class _ShellCardState extends State<_ShellCard> {
                     style: _mono.copyWith(color: AppColors.text)),
               ),
               if (hasDetail && _expanded)
-                Padding(
-                  padding: const EdgeInsets.only(top: 6),
-                  child: Text(c.detail!, style: _monoDim),
-                ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _SkillCard extends StatefulWidget {
-  const _SkillCard({required this.chunk});
-  final Chunk chunk;
-
-  @override
-  State<_SkillCard> createState() => _SkillCardState();
-}
-
-class _SkillCardState extends State<_SkillCard> {
-  bool _expanded = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final c = widget.chunk;
-    final hasPath = c.label != null && c.label!.isNotEmpty;
-    final hasBody = c.detail != null && c.detail!.isNotEmpty;
-    final expandable = hasPath || hasBody;
-
-    final header = Row(
-      children: [
-        const Icon(Icons.school_outlined, size: 13, color: AppColors.dim),
-        const SizedBox(width: 6),
-        Text('Skill', style: _mono.copyWith(color: AppColors.secondary)),
-        Text('  ·  ${_clockTime(c.timestamp)}', style: _monoDim),
-      ],
-    );
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: InkWell(
-        onTap: expandable ? () => setState(() => _expanded = !_expanded) : null,
-        borderRadius: BorderRadius.circular(6),
-        child: Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: AppColors.card,
-            border: Border.all(color: AppColors.border),
-            borderRadius: BorderRadius.circular(6),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              header,
-              Padding(
-                padding: const EdgeInsets.only(top: 6),
-                child: Text(c.text ?? '',
-                    style: _mono.copyWith(color: AppColors.text)),
-              ),
-              if (_expanded && hasPath)
-                Padding(
-                  padding: const EdgeInsets.only(top: 6),
-                  child: Text(c.label!, style: _monoDim),
-                ),
-              if (_expanded && hasBody)
                 Padding(
                   padding: const EdgeInsets.only(top: 6),
                   child: Text(c.detail!, style: _monoDim),

--- a/app/lib/ui/tool_registry.dart
+++ b/app/lib/ui/tool_registry.dart
@@ -36,7 +36,7 @@ IconData categoryIcon(ToolCategory c) => switch (c) {
       ToolCategory.glob => Icons.folder_open_outlined,
       ToolCategory.task => Icons.smart_toy_outlined,
       ToolCategory.todo => Icons.checklist,
-      ToolCategory.skill => Icons.build_outlined,
+      ToolCategory.skill => Icons.school_outlined,
       ToolCategory.web => Icons.public,
       ToolCategory.other => Icons.play_arrow,
     };

--- a/app/test/ui/chunk_card_test.dart
+++ b/app/test/ui/chunk_card_test.dart
@@ -18,6 +18,28 @@ void main() {
     expect(find.textContaining('fix the bug'), findsOneWidget);
   });
 
+  testWidgets('user chunk items collapse behind a count, expand on tap',
+      (tester) async {
+    const chunk = Chunk(id: 'c0', kind: ChunkKind.user, text: '/x', items: [
+      Item(
+          id: 'i0',
+          kind: ItemKind.skill,
+          toolName: 'Skill',
+          toolId: 'u-123',
+          inputPreview: 'reviewing-prs-like-munif'),
+    ]);
+    await tester.pumpWidget(_wrap(chunk));
+
+    // Collapsed: only the count is shown, no ItemRow.
+    expect(find.text('1 item'), findsOneWidget);
+    expect(find.text('Skill'), findsNothing);
+
+    await tester.tap(find.text('1 item'));
+    await tester.pump();
+
+    expect(find.text('Skill'), findsOneWidget); // ItemRow label
+  });
+
   testWidgets('shell chunk shows the command, output on expand', (tester) async {
     const c = Chunk(
       id: 'sh',
@@ -32,24 +54,6 @@ void main() {
     await tester.tap(find.text('Shell'));
     await tester.pump();
     expect(find.textContaining('nothing to commit'), findsOneWidget);
-  });
-
-  testWidgets('skill chunk shows the name, path/body on expand', (tester) async {
-    const c = Chunk(
-      id: 'sk',
-      kind: ChunkKind.skill,
-      text: 'superpowers:brainstorming',
-      label: '/path/to/SKILL.md',
-      detail: 'Help turn ideas into designs.',
-    );
-    await tester.pumpWidget(_wrap(c));
-    expect(find.text('Skill'), findsOneWidget);
-    expect(find.textContaining('superpowers:brainstorming'), findsOneWidget);
-    expect(find.textContaining('SKILL.md'), findsNothing);
-    await tester.tap(find.text('Skill'));
-    await tester.pump();
-    expect(find.textContaining('SKILL.md'), findsOneWidget);
-    expect(find.textContaining('Help turn ideas'), findsOneWidget);
   });
 
   testWidgets('long user chunk collapses and expands', (tester) async {

--- a/internal/adapter/claudecode/chunk.go
+++ b/internal/adapter/claudecode/chunk.go
@@ -25,7 +25,6 @@ const (
 	ChunkSystem  = transcript.ChunkSystem
 	ChunkCompact = transcript.ChunkCompact
 	ChunkShell   = transcript.ChunkShell
-	ChunkSkill   = transcript.ChunkSkill
 
 	ItemThinking = transcript.ItemThinking
 	ItemText     = transcript.ItemText

--- a/internal/adapter/claudecode/chunk_test.go
+++ b/internal/adapter/claudecode/chunk_test.go
@@ -81,29 +81,25 @@ func TestReadTranscriptViewSkillChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadTranscriptView: %v", err)
 	}
-	var user, skill *Chunk
-	for i := range view.Chunks {
-		switch view.Chunks[i].Kind {
-		case ChunkUser:
-			user = &view.Chunks[i]
-		case ChunkSkill:
-			skill = &view.Chunks[i]
-		}
+	if len(view.Chunks) != 1 || view.Chunks[0].Kind != ChunkUser {
+		t.Fatalf("want 1 user chunk, got %+v", view.Chunks)
 	}
-	if user == nil || user.Text != "/superpowers:brainstorming" {
-		t.Fatalf("user's slash command should stay its own chunk, got %+v", view.Chunks)
+	user := view.Chunks[0]
+	if user.Text != "/superpowers:brainstorming" {
+		t.Errorf("Text = %q, want the user's slash command", user.Text)
 	}
-	if skill == nil {
-		t.Fatalf("no skill chunk found in %+v", view.Chunks)
+	if len(user.Items) != 1 {
+		t.Fatalf("want 1 skill item in user chunk, got %d items", len(user.Items))
 	}
-	if skill.Text != "superpowers:brainstorming" {
-		t.Errorf("Text = %q, want the skill identifier", skill.Text)
+	it := user.Items[0]
+	if it.Kind != ItemSkill {
+		t.Errorf("Kind = %q, want ItemSkill", it.Kind)
 	}
-	if skill.Label != "/Users/x/.claude/skills/brainstorming" {
-		t.Errorf("Label = %q, want the source path", skill.Label)
+	if it.InputPreview != "superpowers:brainstorming" {
+		t.Errorf("InputPreview = %q, want the skill identifier", it.InputPreview)
 	}
-	if !strings.HasPrefix(skill.Detail, "# Brainstorming Ideas Into Designs") {
-		t.Errorf("Detail = %q, want the skill body", skill.Detail)
+	if !strings.HasPrefix(it.Result, "# Brainstorming Ideas Into Designs") {
+		t.Errorf("Result = %q, want the skill body", it.Result)
 	}
 }
 

--- a/internal/adapter/claudecode/parser/chunk.go
+++ b/internal/adapter/claudecode/parser/chunk.go
@@ -54,7 +54,6 @@ const (
 	SystemChunk
 	CompactChunk // context compression boundary
 	ShellChunk   // user ran `!cmd` directly in the CLI
-	SkillChunk   // a skill file loaded into context
 )
 
 // InferenceCycle is one LLM call plus its dispatched tool calls. A derived
@@ -125,24 +124,28 @@ func BuildChunks(msgs []ClassifiedMsg) []Chunk {
 				Timestamp: m.Timestamp,
 				UserText:  m.Text,
 			}
-			// Skill loads emit a separate SkillChunk; other expanded prompts attach.
+			// Skill loads fold into the user chunk as a Skill item; other expanded prompts attach.
 			if strings.HasPrefix(m.Text, "/") && i+1 < len(msgs) {
 				expanded := extractExpandedPrompt(msgs[i+1])
-				if name, path, body, ok := skillLoad(m.Text, expanded); ok {
-					chunks = append(chunks, c)
-					chunks = append(chunks, Chunk{
-						Type:        SkillChunk,
-						Timestamp:   m.Timestamp,
-						UserText:    name,
-						SystemLabel: path,
-						Output:      body,
+				if name, _, body, ok := skillLoad(m.Text, expanded); ok {
+					input, _ := json.Marshal(map[string]string{"skill": name})
+					c.Items = append(c.Items, DisplayItem{
+						Type:         ItemToolCall,
+						ToolName:     "Skill",
+						ToolID:       m.UUID,
+						ToolInput:    json.RawMessage(input),
+						ToolSummary:  name,
+						ToolResult:   body,
+						ToolCategory: CategorizeToolName("Skill"),
+						TokenCount:   len(body) / 4,
 					})
-					i++ // consume the expanded prompt entry
+					chunks = append(chunks, c)
+					i++
 					continue
 				}
 				if expanded != "" {
 					c.ExpandedPrompt = expanded
-					i++ // consume the expanded prompt entry
+					i++
 				}
 			}
 			chunks = append(chunks, c)

--- a/internal/adapter/claudecode/parser/chunk_test.go
+++ b/internal/adapter/claudecode/parser/chunk_test.go
@@ -31,28 +31,54 @@ func TestBuildChunks_SingleUser(t *testing.T) {
 func TestBuildChunks_SkillLoad(t *testing.T) {
 	t0 := time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC)
 	msgs := []parser.ClassifiedMsg{
-		parser.UserMsg{Timestamp: t0, Text: "/superpowers:brainstorming a new feature"},
+		parser.UserMsg{Timestamp: t0, UUID: "entry-uuid", Text: "/superpowers:brainstorming a new feature"},
 		parser.AIMsg{Timestamp: t0, IsMeta: true, Text: "Base directory for this skill: /p/skills/brainstorming\n\n# Brainstorming\n\nHelp turn ideas into designs."},
 	}
 	chunks := parser.BuildChunks(msgs)
-	if len(chunks) != 2 {
-		t.Fatalf("len(chunks) = %d, want 2 (user command + skill)", len(chunks))
+	if len(chunks) != 1 {
+		t.Fatalf("len(chunks) = %d, want 1 (skill folded into user chunk)", len(chunks))
 	}
-	if chunks[0].Type != parser.UserChunk || chunks[0].UserText != "/superpowers:brainstorming a new feature" {
-		t.Errorf("chunks[0] = %+v, want the user's full slash command", chunks[0])
+	c := chunks[0]
+	if c.Type != parser.UserChunk {
+		t.Errorf("Type = %d, want UserChunk", c.Type)
 	}
-	c := chunks[1]
-	if c.Type != parser.SkillChunk {
-		t.Errorf("Type = %d, want SkillChunk", c.Type)
+	if c.UserText != "/superpowers:brainstorming a new feature" {
+		t.Errorf("UserText = %q, want the user's full slash command", c.UserText)
 	}
-	if c.UserText != "superpowers:brainstorming" {
-		t.Errorf("name = %q, want superpowers:brainstorming (argument excluded)", c.UserText)
+	if len(c.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1 (skill item)", len(c.Items))
 	}
-	if c.SystemLabel != "/p/skills/brainstorming" {
-		t.Errorf("path = %q, want the base directory", c.SystemLabel)
+	it := c.Items[0]
+	if it.Type != parser.ItemToolCall {
+		t.Errorf("Items[0].Type = %d, want ItemToolCall", it.Type)
 	}
-	if c.Output != "# Brainstorming\n\nHelp turn ideas into designs." {
-		t.Errorf("body = %q, want the skill markdown", c.Output)
+	if it.ToolName != "Skill" {
+		t.Errorf("ToolName = %q, want Skill", it.ToolName)
+	}
+	if it.ToolID != "entry-uuid" {
+		t.Errorf("ToolID = %q, want entry-uuid", it.ToolID)
+	}
+	if it.ToolSummary != "superpowers:brainstorming" {
+		t.Errorf("ToolSummary = %q, want superpowers:brainstorming (argument excluded)", it.ToolSummary)
+	}
+	if it.ToolResult != "# Brainstorming\n\nHelp turn ideas into designs." {
+		t.Errorf("ToolResult = %q, want the skill markdown", it.ToolResult)
+	}
+}
+
+func TestBuildChunks_SkillLoadFoldsIntoUserChunkItem(t *testing.T) {
+	msgs := []parser.ClassifiedMsg{
+		parser.UserMsg{UUID: "u-123", Text: "/reviewing-prs-like-munif"},
+		parser.AIMsg{IsMeta: true, Text: "Base directory for this skill: /home/u/.claude/skills/x\n\nDo it."},
+	}
+	chunks := parser.BuildChunks(msgs)
+	u := chunks[0]
+	if u.Type != parser.UserChunk || len(u.Items) != 1 {
+		t.Fatalf("want user chunk w/1 item, got %v/%d", u.Type, len(u.Items))
+	}
+	if it := u.Items[0]; it.ToolName != "Skill" || it.ToolID != "u-123" ||
+		it.ToolResult == "" || len(it.ToolInput) == 0 {
+		t.Fatalf("bad skill item: %+v", it)
 	}
 }
 

--- a/internal/adapter/claudecode/parser/classify.go
+++ b/internal/adapter/claudecode/parser/classify.go
@@ -163,6 +163,7 @@ func Classify(e Entry) (ClassifiedMsg, bool) {
 		if !excluded && hasUserContent(e.Message.Content, contentStr) {
 			return UserMsg{
 				Timestamp:      ts,
+				UUID:           e.UUID,
 				Text:           SanitizeContent(contentStr),
 				PermissionMode: e.PermissionMode,
 			}, true

--- a/internal/adapter/claudecode/parser/message.go
+++ b/internal/adapter/claudecode/parser/message.go
@@ -14,6 +14,7 @@ type ClassifiedMsg interface {
 // UserMsg represents genuine user input that starts a new request cycle.
 type UserMsg struct {
 	Timestamp      time.Time
+	UUID           string // raw entry uuid; stable id for a skill item
 	Text           string // sanitized display text
 	PermissionMode string // "default", "acceptEdits", "bypassPermissions", "plan"; empty if not present
 }

--- a/internal/adapter/claudecode/transcript.go
+++ b/internal/adapter/claudecode/transcript.go
@@ -124,6 +124,7 @@ func foldChunk(pc parser.Chunk, agentRefs map[string]string, traces map[string][
 	case parser.UserChunk:
 		c.Kind = ChunkUser
 		c.Text = pc.UserText
+		c.Items = foldItems(pc.Items, agentRefs, traces)
 	case parser.AIChunk:
 		c.Kind = ChunkAI
 		c.ModelName = modelDisplayName(pc.Model)
@@ -155,11 +156,6 @@ func foldChunk(pc parser.Chunk, agentRefs map[string]string, traces map[string][
 		c.Text = pc.ShellCommand
 		c.Detail = pc.Output
 		c.IsError = pc.IsError
-	case parser.SkillChunk:
-		c.Kind = ChunkSkill
-		c.Text = pc.UserText     // skill identifier
-		c.Label = pc.SystemLabel // source base directory
-		c.Detail = pc.Output     // skill file body
 	default: // SystemChunk
 		c.Kind = ChunkSystem
 		c.Label = pc.SystemLabel // preview after the timestamp (e.g. "Recap"); "" for none

--- a/internal/adapter/claudecode/transcript_test.go
+++ b/internal/adapter/claudecode/transcript_test.go
@@ -1,6 +1,8 @@
 package claudecode
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/MunifTanjim/argus/internal/adapter/claudecode/parser"
@@ -115,5 +117,20 @@ func TestFoldItem_TeammateIdleCarriesFlag(t *testing.T) {
 	}
 	if !it.IsTeammate() || !it.Subagents[0].Idle {
 		t.Errorf("IsTeammate=%v Idle=%v, want true/true", it.IsTeammate(), it.Subagents[0].Idle)
+	}
+}
+
+func TestFindToolDetail_ResolvesUserChunkSkill(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skill-session.jsonl")
+	const skillUUID = "skill-entry-uuid"
+	session := "{\"uuid\":\"skill-entry-uuid\",\"type\":\"user\",\"timestamp\":\"2025-01-15T10:00:00.000Z\",\"isSidechain\":false,\"isMeta\":false,\"message\":{\"role\":\"user\",\"content\":\"/superpowers:systematic-debugging\"}}\n" +
+		"{\"uuid\":\"meta-uuid\",\"type\":\"user\",\"timestamp\":\"2025-01-15T10:00:01.000Z\",\"isSidechain\":false,\"isMeta\":true,\"message\":{\"role\":\"user\",\"content\":\"Base directory for this skill: /p/skills\\n\\n# Systematic Debugging\\n\\nFind root cause first.\"}}\n"
+	if err := os.WriteFile(path, []byte(session), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	td, ok, err := FindToolDetail(path, "", skillUUID)
+	if err != nil || !ok || td.Result == "" {
+		t.Fatalf("want body, got ok=%v err=%v result=%q", ok, err, td.Result)
 	}
 }

--- a/internal/adapter/codex/parse.go
+++ b/internal/adapter/codex/parse.go
@@ -24,6 +24,7 @@ func foldRollout(lines []rolloutLine, models map[string]string) []transcript.Chu
 	model := ""
 	firstCtxTokens := map[*transcript.Chunk]int{}
 	nicknames := map[string]string{} // agent id -> nickname, from each spawn seen so far
+	lastUserTurnID := ""             // turn_id of the trailing user chunk, for skill folding
 
 	flush := func() {
 		if ai != nil {
@@ -81,13 +82,31 @@ func foldRollout(lines []rolloutLine, models map[string]string) []transcript.Chu
 						})
 						continue
 					}
-					if name, path, body, ok := skillLoad(text); ok {
-						out = append(out, transcript.Chunk{
-							Kind: transcript.ChunkSkill, Timestamp: l.Timestamp,
-							Text: name, Label: path, Detail: body,
-						})
+					if name, _, body, ok := skillLoad(text); ok {
+						input, _ := json.Marshal(map[string]string{"skill": name})
+						item := transcript.Item{
+							Kind:         transcript.ItemSkill,
+							ToolName:     "Skill",
+							ToolID:       p.ID,
+							ToolInput:    string(input),
+							InputPreview: name,
+							Result:       body,
+						}
+						// The skill load is a follow-up to the user's invoking message; fold it in
+						// when the trailing chunk is that same-turn user message.
+						turn := p.turnID()
+						if n := len(out); n > 0 && out[n-1].Kind == transcript.ChunkUser && turnsMatch(lastUserTurnID, turn) {
+							out[n-1].Items = append(out[n-1].Items, item)
+						} else {
+							out = append(out, transcript.Chunk{
+								Kind: transcript.ChunkUser, Timestamp: l.Timestamp,
+								Items: []transcript.Item{item},
+							})
+						}
+						lastUserTurnID = turn
 						continue
 					}
+					lastUserTurnID = p.turnID()
 					out = append(out, transcript.Chunk{Kind: transcript.ChunkUser, Timestamp: l.Timestamp, Text: text})
 				case "assistant":
 					c := ensureAI(l.Timestamp)
@@ -181,6 +200,13 @@ func tagContent(s, tag string) string {
 		return ""
 	}
 	return strings.TrimSpace(s[i : i+j])
+}
+
+// turnsMatch reports whether two turn ids are compatible for folding a skill load
+// into the preceding user chunk: a positive mismatch blocks it, a missing id on
+// either side falls back to positional adjacency.
+func turnsMatch(a, b string) bool {
+	return a == "" || b == "" || a == b
 }
 
 func skillLoad(text string) (name, path, body string, ok bool) {
@@ -423,6 +449,9 @@ func stampIDs(chunks []transcript.Chunk) {
 		chunks[i].ID = strconv.Itoa(i)
 		for j := range chunks[i].Items {
 			chunks[i].Items[j].ID = strconv.Itoa(j)
+			if chunks[i].Items[j].Kind == transcript.ItemSkill && chunks[i].Items[j].ToolID == "" {
+				chunks[i].Items[j].ToolID = "skill:" + strconv.Itoa(i) + ":" + strconv.Itoa(j)
+			}
 		}
 	}
 }

--- a/internal/adapter/codex/parse_test.go
+++ b/internal/adapter/codex/parse_test.go
@@ -415,20 +415,33 @@ func TestParseRolloutSkillLoad(t *testing.T) {
 		t.Fatalf("chunks = %d, want 1", len(chunks))
 	}
 	c := chunks[0]
-	if c.Kind != transcript.ChunkSkill {
-		t.Fatalf("kind = %v, want ChunkSkill", c.Kind)
+	if c.Kind != transcript.ChunkUser {
+		t.Fatalf("kind = %v, want ChunkUser", c.Kind)
 	}
-	if c.Text != "superpowers:brainstorming" {
-		t.Fatalf("Text = %q, want skill name", c.Text)
+	if len(c.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(c.Items))
 	}
-	if want := "/Users/muniftanjim/.codex/plugins/cache/openai-curated/superpowers/3fdeeb49/skills/brainstorming/SKILL.md"; c.Label != want {
-		t.Fatalf("Label = %q, want %q", c.Label, want)
+	it := c.Items[0]
+	if it.Kind != transcript.ItemSkill {
+		t.Fatalf("item kind = %v, want ItemSkill", it.Kind)
 	}
-	if strings.Contains(c.Detail, "---") || strings.Contains(c.Detail, "description:") {
-		t.Fatalf("Detail should have frontmatter stripped, got %q", c.Detail)
+	if it.ToolName != "Skill" {
+		t.Fatalf("ToolName = %q, want Skill", it.ToolName)
 	}
-	if !strings.HasPrefix(c.Detail, "# Brainstorming Ideas Into Designs") {
-		t.Fatalf("Detail = %q, want it to start with the body heading", c.Detail)
+	if it.ToolID == "" {
+		t.Fatal("ToolID empty, want stable id from stampIDs")
+	}
+	if it.InputPreview != "superpowers:brainstorming" {
+		t.Fatalf("InputPreview = %q, want skill name", it.InputPreview)
+	}
+	if !strings.Contains(it.ToolInput, `"skill":"superpowers:brainstorming"`) {
+		t.Fatalf("ToolInput = %q, want JSON with skill name", it.ToolInput)
+	}
+	if strings.Contains(it.Result, "---") || strings.Contains(it.Result, "description:") {
+		t.Fatalf("Result should have frontmatter stripped, got %q", it.Result)
+	}
+	if !strings.HasPrefix(it.Result, "# Brainstorming Ideas Into Designs") {
+		t.Fatalf("Result = %q, want it to start with the body heading", it.Result)
 	}
 }
 
@@ -560,3 +573,87 @@ func TestParseRolloutSpawnNickname(t *testing.T) {
 }
 
 func hasPrefix(s, p string) bool { return len(s) >= len(p) && s[:len(p)] == p }
+
+func passthrough(turnID string) *msgPassthrough {
+	if turnID == "" {
+		return nil
+	}
+	return &msgPassthrough{TurnID: turnID}
+}
+
+func skillUserLine(name, path, body, turnID string) rolloutLine {
+	text := "<skill>\n<name>" + name + "</name>\n<path>" + path + "</path>\n" + body + "\n</skill>"
+	return rolloutLine{
+		Timestamp: "2026-07-12T00:00:00.000Z",
+		Type:      "response_item",
+		Payload: rolloutPayload{
+			Type:        "message",
+			Role:        "user",
+			Content:     []rolloutContent{{Type: "input_text", Text: text}},
+			Passthrough: passthrough(turnID),
+		},
+	}
+}
+
+func userMessageLine(text, turnID string) rolloutLine {
+	return rolloutLine{
+		Timestamp: "2026-07-12T00:00:00.000Z",
+		Type:      "response_item",
+		Payload: rolloutPayload{
+			Type:        "message",
+			Role:        "user",
+			Content:     []rolloutContent{{Type: "input_text", Text: text}},
+			Passthrough: passthrough(turnID),
+		},
+	}
+}
+
+func TestFoldRollout_SkillFoldsIntoUserChunkItem(t *testing.T) {
+	lines := []rolloutLine{skillUserLine("reviewing", "/p", "# Body", "")}
+	chunks := foldRollout(lines, nil)
+	u := chunks[0]
+	if u.Kind != transcript.ChunkUser || len(u.Items) != 1 {
+		t.Fatalf("want user chunk w/1 item, got %v/%d", u.Kind, len(u.Items))
+	}
+	it := u.Items[0]
+	if it.Kind != transcript.ItemSkill || it.ToolName != "Skill" ||
+		it.ToolID == "" || it.Result == "" || it.ToolInput == "" {
+		t.Fatalf("bad skill item: %+v", it)
+	}
+}
+
+func TestFoldRollout_SkillMergesIntoInvokingUserChunk(t *testing.T) {
+	lines := []rolloutLine{
+		userMessageLine("$superpowers:brainstorming Hello", "t1"),
+		skillUserLine("superpowers:brainstorming", "/p", "# Body", "t1"),
+	}
+	chunks := foldRollout(lines, nil)
+	if len(chunks) != 1 {
+		t.Fatalf("want 1 merged chunk, got %d", len(chunks))
+	}
+	u := chunks[0]
+	if u.Kind != transcript.ChunkUser || u.Text != "$superpowers:brainstorming Hello" {
+		t.Fatalf("want user chunk carrying invoking text, got %v/%q", u.Kind, u.Text)
+	}
+	if len(u.Items) != 1 || u.Items[0].Kind != transcript.ItemSkill {
+		t.Fatalf("want 1 skill item folded in, got %+v", u.Items)
+	}
+}
+
+func TestFoldRollout_SkillDoesNotMergeOnTurnMismatch(t *testing.T) {
+	lines := []rolloutLine{
+		userMessageLine("earlier message", "t1"),
+		skillUserLine("superpowers:brainstorming", "/p", "# Body", "t2"),
+	}
+	chunks := foldRollout(lines, nil)
+	if len(chunks) != 2 {
+		t.Fatalf("want 2 chunks (turn mismatch blocks fold), got %d", len(chunks))
+	}
+	if len(chunks[0].Items) != 0 {
+		t.Fatalf("invoking chunk should keep no items, got %+v", chunks[0].Items)
+	}
+	if chunks[1].Kind != transcript.ChunkUser || len(chunks[1].Items) != 1 ||
+		chunks[1].Items[0].Kind != transcript.ItemSkill {
+		t.Fatalf("skill should stand alone, got %+v", chunks[1])
+	}
+}

--- a/internal/adapter/codex/rollout.go
+++ b/internal/adapter/codex/rollout.go
@@ -49,6 +49,20 @@ type rolloutPayload struct {
 	DurationMs int64 `json:"duration_ms"`
 	// event_msg agent/user text (unused; response_item is canonical)
 	Message string `json:"message"`
+
+	// response_item/message: per-message turn correlation.
+	Passthrough *msgPassthrough `json:"internal_chat_message_metadata_passthrough"`
+}
+
+type msgPassthrough struct {
+	TurnID string `json:"turn_id"`
+}
+
+func (p rolloutPayload) turnID() string {
+	if p.Passthrough == nil {
+		return ""
+	}
+	return p.Passthrough.TurnID
 }
 
 type rolloutContent struct {

--- a/internal/adapter/codex/transcript.go
+++ b/internal/adapter/codex/transcript.go
@@ -65,7 +65,7 @@ func FindToolDetail(path, agentID, toolID string) (transcript.ToolDetail, bool, 
 	}
 	for _, c := range chunks {
 		for _, it := range c.Items {
-			if (it.Kind == transcript.ItemTool || it.Kind == transcript.ItemSubagent) && it.ToolID == toolID {
+			if (it.Kind == transcript.ItemTool || it.Kind == transcript.ItemSubagent || it.Kind == transcript.ItemSkill) && it.ToolID == toolID {
 				return transcript.ToolDetail{ToolInput: it.ToolInput, Result: it.Result}, true, nil
 			}
 		}

--- a/internal/adapter/codex/transcript_test.go
+++ b/internal/adapter/codex/transcript_test.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -216,5 +217,49 @@ func TestFindToolDetail(t *testing.T) {
 	}
 	if det.Result != "Plan updated" {
 		t.Fatalf("result = %q, want 'Plan updated'", det.Result)
+	}
+}
+
+func TestFindToolDetailSkill(t *testing.T) {
+	dir := t.TempDir()
+	p := dir + "/r.jsonl"
+	text := "<skill>\n<name>test:skill</name>\n<path>/test/path/SKILL.md</path>\n# Skill Body\nSome skill content.\n</skill>"
+	line, err := json.Marshal(map[string]any{
+		"type": "response_item",
+		"payload": map[string]any{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]any{
+				{"type": "input_text", "text": text},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, append(line, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	view, err := ReadTranscriptView(p)
+	if err != nil {
+		t.Fatalf("ReadTranscriptView: %v", err)
+	}
+	var toolID string
+	for _, c := range view.Chunks {
+		for _, it := range c.Items {
+			if it.Kind == transcript.ItemSkill {
+				toolID = it.ToolID
+			}
+		}
+	}
+	if toolID == "" {
+		t.Fatal("no skill item toolID found")
+	}
+	det, ok, err := FindToolDetail(p, "", toolID)
+	if err != nil || !ok {
+		t.Fatalf("FindToolDetail ok=%v err=%v", ok, err)
+	}
+	if det.Result != "# Skill Body\nSome skill content." {
+		t.Fatalf("result = %q, want skill body", det.Result)
 	}
 }

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -30,7 +30,6 @@ const (
 	ChunkSystem  ChunkKind = "system"  // runtime event / meta row
 	ChunkCompact ChunkKind = "compact" // context-compression boundary
 	ChunkShell   ChunkKind = "shell"   // user ran `!cmd` directly in the CLI (codex)
-	ChunkSkill   ChunkKind = "skill"   // a skill file was loaded into context (codex)
 )
 
 type ItemKind string
@@ -93,8 +92,7 @@ type Chunk struct {
 	Kind      ChunkKind `json:"kind"`
 	Timestamp string    `json:"timestamp,omitempty"`
 
-	// User chunk. Also shell chunk: the command run. Also skill chunk: the skill
-	// identifier (e.g. "superpowers:brainstorming").
+	// User chunk. Also shell chunk: the command run.
 	Text string `json:"text,omitempty"`
 
 	// AI chunk.
@@ -113,10 +111,10 @@ type Chunk struct {
 	ContextFirstPct    float64 `json:"contextFirstPct,omitempty"`    // first cycle, 0..100
 	ContextDeltaTokens int     `json:"contextDeltaTokens,omitempty"` // growth, >= 0
 
-	// System / compact / shell / skill chunk.
+	// System / compact / shell chunk.
 	Summary string `json:"summary,omitempty"` // compact: the compression title
-	Label   string `json:"label,omitempty"`   // system: preview after the timestamp (e.g. "Recap"); skill: source file path
-	Detail  string `json:"detail,omitempty"`  // system/shell: detail text (shell: raw result scaffolding); skill: file body (markdown)
+	Label   string `json:"label,omitempty"`   // system: preview after the timestamp (e.g. "Recap")
+	Detail  string `json:"detail,omitempty"`  // system/shell: detail text (shell: raw result scaffolding)
 	IsError bool   `json:"isError,omitempty"` // system: error flag; shell: nonzero exit code
 }
 

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -134,6 +134,13 @@ func (m *model) enterDetail() {
 		}
 		f.items = c.Items
 		f.expandOutputs()
+	} else if c.Kind == transcript.ChunkUser && len(c.Items) > 0 {
+		f.label = "You"
+		if strings.TrimSpace(c.Text) != "" {
+			f.items = append(f.items, transcript.Item{Kind: transcript.ItemPrompt, Text: c.Text})
+		}
+		f.items = append(f.items, c.Items...)
+		f.expandOutputs()
 	} else {
 		f.label = "detail"
 		f.body = m.renderDetail(c)
@@ -185,7 +192,7 @@ func (m model) detailable(c transcript.Chunk) bool {
 	case transcript.ChunkAI:
 		return len(c.Items) > 0
 	case transcript.ChunkUser:
-		return c.Text != ""
+		return c.Text != "" || len(c.Items) > 0
 	default:
 		return c.Detail != ""
 	}
@@ -638,16 +645,6 @@ func (m model) renderDetail(c transcript.Chunk) string {
 				resultLabel = "Error"
 			}
 			body += "\n\n" + sectionLabel(resultLabel, c.IsError) + "\n" + m.execCommandResultBody(c.Detail, width-2)
-		}
-		return head + "\n\n" + body
-	case transcript.ChunkSkill:
-		head := Icon.Skill.Render() + " " + StylePrimaryBold.Render("Skill") + "  " + StyleDim.Render(clockTime(c.Timestamp))
-		body := StyleSecondaryBold.Render(c.Text)
-		if c.Label != "" {
-			body += "\n" + StyleDim.Render(c.Label)
-		}
-		if c.Detail != "" {
-			body += "\n\n" + m.renderMD(c.Detail, width-2)
 		}
 		return head + "\n\n" + body
 	default:

--- a/internal/tui/icons.go
+++ b/internal/tui/icons.go
@@ -148,8 +148,8 @@ func initIcons() {
 			Glob:  StyledIcon{glyphFolderSearch, ColorToolGlob},
 			Task:  StyledIcon{glyphRobot, ColorToolTask},
 			Todo:  StyledIcon{"\U000F0755", ColorToolEdit}, // nf-md-format_list_checks
-			Skill: StyledIcon{glyphWrench, ColorToolSkill},
-			Web:   StyledIcon{"\U000F059F", ColorToolWeb}, // nf-md-web
+			Skill: StyledIcon{"", ColorToolSkill},         // nf-fa-graduation_cap
+			Web:   StyledIcon{"\U000F059F", ColorToolWeb},  // nf-md-web
 			Misc:  StyledIcon{glyphWrench, ColorToolOther},
 		},
 		Task: taskIcons{

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -96,14 +96,15 @@ func (m model) chunkExpandable(c transcript.Chunk) bool {
 	case transcript.ChunkAI:
 		return len(c.Items) > 0
 	case transcript.ChunkUser:
+		if len(c.Items) > 0 {
+			return true
+		}
 		// Count wrapped display lines, not source lines.
 		return len(strings.Split(m.renderMD(c.Text, m.userBubbleInner()), "\n")) > maxCollapsedLines
 	case transcript.ChunkSystem:
 		return c.Detail != ""
 	case transcript.ChunkShell:
 		return c.Detail != "" || strings.Count(c.Text, "\n") >= maxCollapsedLines
-	case transcript.ChunkSkill:
-		return c.Detail != "" || c.Label != ""
 	default:
 		return false
 	}
@@ -237,8 +238,6 @@ func (m model) renderChunk(i int, selected bool) string {
 		return m.renderUserCard(c, selected, accent)
 	case transcript.ChunkShell:
 		return m.renderShellCard(c, selected, accent)
-	case transcript.ChunkSkill:
-		return m.renderSkillCard(c, selected, accent)
 	case transcript.ChunkCompact:
 		return m.renderCompact(c)
 	default:
@@ -465,7 +464,16 @@ func (m model) renderUserCard(c transcript.Chunk, selected, accent bool) string 
 	header := sel + strings.Repeat(" ", gap) + right
 
 	body := m.renderMD(c.Text, m.userBubbleInner())
-	if !expanded {
+	if expanded {
+		for _, it := range c.Items {
+			row := itemRow(it)
+			if body == "" {
+				body = row
+			} else {
+				body += "\n" + row
+			}
+		}
+	} else {
 		// Truncate wrapped display lines so long single lines collapse too.
 		if t, hidden := truncateLines(body, maxCollapsedLines); hidden > 0 {
 			body = t + "\n" + hiddenHint(hidden)
@@ -585,56 +593,6 @@ func (m model) shellBody(c transcript.Chunk, iw int) string {
 		sb.WriteString(m.execCommandResultBody(c.Detail, iw))
 	}
 	return strings.TrimRight(sb.String(), "\n")
-}
-
-func (m model) renderSkillCard(c transcript.Chunk, selected, accent bool) string {
-	container := m.transcriptWidth()
-	fraction := 3 * container / 4
-	if container < maxContentWidth {
-		fraction = 7 * container / 8
-	}
-	cardW := max(fraction-4, 24)
-	iw := max(cardW-4, 10) // card padding(0,2) eats 4 cols
-
-	sel := selIndicator(selected)
-	header := sel + m.skillHeader(c, cardW)
-	body := m.skillBody(c, iw)
-
-	borderColor := ColorBorder
-	if accent {
-		borderColor = ColorAccent
-	}
-	card := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(borderColor).
-		Width(cardW).
-		Padding(0, 2).
-		Render(body)
-
-	return header + "\n" + indentBlock(card, sel)
-}
-
-func (m model) skillHeader(c transcript.Chunk, width int) string {
-	chev := ""
-	if m.chunkExpandable(c) {
-		chev = chevron(m.chunkExpanded(c)) + " "
-	}
-	left := chev + Icon.Skill.Render() + " " + StylePrimaryBold.Render("Skill")
-	return spaceBetween(left, StyleDim.Render(clockTime(c.Timestamp)), width)
-}
-
-func (m model) skillBody(c transcript.Chunk, iw int) string {
-	body := StyleSecondaryBold.Render(c.Text)
-	if !m.chunkExpanded(c) {
-		return body
-	}
-	if c.Label != "" {
-		body += "\n" + StyleDim.Render(c.Label)
-	}
-	if c.Detail != "" {
-		body += "\n\n" + m.renderMD(c.Detail, iw)
-	}
-	return body
 }
 
 func (m model) renderCompact(c transcript.Chunk) string {

--- a/internal/tui/transcript_test.go
+++ b/internal/tui/transcript_test.go
@@ -65,6 +65,107 @@ func loaded() model {
 	return m
 }
 
+// TestUserChunkWithSkillItemExpandableAndDrillable verifies that a user chunk
+// carrying an ItemSkill is marked expandable and its item is reachable in the
+// detail drill-down.
+func TestUserChunkWithSkillItemExpandableAndDrillable(t *testing.T) {
+	m := testModel()
+	m.width = 80
+
+	skillItem := transcript.Item{
+		Kind:         transcript.ItemSkill,
+		ToolName:     "Skill",
+		ToolID:       "sk-001",
+		InputPreview: "superpowers:brainstorming",
+	}
+	c := transcript.Chunk{
+		ID:    "u1",
+		Kind:  transcript.ChunkUser,
+		Text:  "one line",
+		Items: []transcript.Item{skillItem},
+	}
+
+	// The chunk must be expandable even though the text is short.
+	if !m.chunkExpandable(c) {
+		t.Error("user chunk with skill item should be expandable")
+	}
+
+	// When expanded, the rendered card must surface a skill affordance.
+	m.transcript.chunks = []transcript.Chunk{c}
+	m.transcript.expanded[c.ID] = true
+	out := m.renderChunk(0, false)
+	if !strings.Contains(out, "Skill") {
+		t.Errorf("rendered user card should show a Skill affordance:\n%s", out)
+	}
+	if !strings.Contains(out, "superpowers:brainstorming") {
+		t.Errorf("rendered user card should show the skill name:\n%s", out)
+	}
+
+	// The detail frame surfaces the original message as a leading prompt, then the
+	// skill item so it can be drilled by ToolID.
+	dm := detailTestModel(c)
+	f := dm.topFrame()
+	if f == nil || len(f.items) != 2 {
+		t.Fatalf("detail frame should have 2 items, got %d", len(f.items))
+	}
+	if f.items[0].Kind != transcript.ItemPrompt || f.items[0].Text != "one line" {
+		t.Errorf("first detail item should be the original message prompt, got %+v", f.items[0])
+	}
+	if f.items[1].ToolID != "sk-001" {
+		t.Errorf("detail item ToolID = %q, want %q", f.items[1].ToolID, "sk-001")
+	}
+
+	// Drilling into the skill item should focus it (non-drillable leaf).
+	f.cursor = 1
+	dm.drillDetail()
+	if len(dm.transcript.detailStack) != 2 || !dm.topFrame().focused {
+		t.Fatalf("drill should focus the skill item: frames=%d focused=%v",
+			len(dm.transcript.detailStack), dm.topFrame().focused)
+	}
+}
+
+// TestTextlessUserChunkWithSkillItemDrillable verifies that a user chunk carrying an
+// ItemSkill but no Text (codex-style) is detailable and drillable end-to-end.
+func TestTextlessUserChunkWithSkillItemDrillable(t *testing.T) {
+	m := testModel()
+	m.width = 80
+
+	skillItem := transcript.Item{
+		Kind:         transcript.ItemSkill,
+		ToolName:     "Skill",
+		ToolID:       "sk-002",
+		InputPreview: "superpowers:brainstorming",
+	}
+	c := transcript.Chunk{
+		ID:    "u2",
+		Kind:  transcript.ChunkUser,
+		Text:  "", // codex style: no text
+		Items: []transcript.Item{skillItem},
+	}
+
+	// detailable must be true even with empty Text.
+	if !m.detailable(c) {
+		t.Error("text-less user chunk with skill item should be detailable")
+	}
+
+	// The detail frame must expose the item.
+	dm := detailTestModel(c)
+	f := dm.topFrame()
+	if f == nil || len(f.items) != 1 {
+		t.Fatalf("detail frame should have 1 item, got %d", len(f.items))
+	}
+	if f.items[0].ToolID != "sk-002" {
+		t.Errorf("detail item ToolID = %q, want %q", f.items[0].ToolID, "sk-002")
+	}
+
+	// Drilling into the skill item should focus it (non-drillable leaf).
+	dm.drillDetail()
+	if len(dm.transcript.detailStack) != 2 || !dm.topFrame().focused {
+		t.Fatalf("drill should focus the skill item: frames=%d focused=%v",
+			len(dm.transcript.detailStack), dm.topFrame().focused)
+	}
+}
+
 // TestUserChunkExpandableByWrappedLines verifies long-wrapping user chunks are collapsible.
 func TestUserChunkExpandableByWrappedLines(t *testing.T) {
 	m := testModel()
@@ -413,62 +514,6 @@ func TestRenderDetailShell(t *testing.T) {
 	}
 	if !strings.Contains(out, "world") || !strings.Contains(out, "Result") {
 		t.Fatalf("detail should show the labeled output:\n%s", out)
-	}
-}
-
-func TestRenderSkillCard(t *testing.T) {
-	m := testModel()
-	m.width = 160 // wide enough that the source path renders without wrapping
-	c := transcript.Chunk{
-		ID: "sk1", Kind: transcript.ChunkSkill,
-		Text:   "superpowers:brainstorming",
-		Label:  "/Users/muniftanjim/.codex/plugins/cache/openai-curated/superpowers/3fdeeb49/skills/brainstorming/SKILL.md",
-		Detail: "# Brainstorming Ideas Into Designs\n\nHelp turn ideas into fully formed designs.",
-	}
-	m.transcript.chunks = []transcript.Chunk{c}
-	m.transcript.expanded = map[string]bool{}
-
-	collapsed := m.renderChunk(0, false)
-	// AI-card style: the "Skill" header sits above the card border; the name is inside.
-	headerIdx := strings.Index(collapsed, "Skill")
-	borderIdx := strings.Index(collapsed, "╭")
-	if headerIdx < 0 || borderIdx < 0 || headerIdx > borderIdx {
-		t.Fatalf("Skill header should sit above the card border:\n%s", collapsed)
-	}
-	if !strings.Contains(collapsed, "superpowers:brainstorming") {
-		t.Fatalf("collapsed render missing skill name:\n%s", collapsed)
-	}
-	if strings.Contains(collapsed, "SKILL.md") || strings.Contains(collapsed, "Help turn ideas") {
-		t.Fatalf("collapsed render should not show path/body:\n%s", collapsed)
-	}
-
-	m.transcript.expanded["sk1"] = true
-	out := m.renderChunk(0, false)
-	if !strings.Contains(out, "SKILL.md") {
-		t.Fatalf("expanded render missing source path:\n%s", out)
-	}
-	if !strings.Contains(out, "Help turn ideas into fully formed designs.") {
-		t.Fatalf("expanded render missing body:\n%s", out)
-	}
-}
-
-func TestRenderDetailSkill(t *testing.T) {
-	m := testModel()
-	c := transcript.Chunk{
-		ID: "sk1", Kind: transcript.ChunkSkill,
-		Text:   "superpowers:brainstorming",
-		Label:  "/path/to/SKILL.md",
-		Detail: "# Brainstorming\n\nHelp turn ideas into designs.",
-	}
-	out := m.renderDetail(c)
-	if !strings.Contains(out, "Skill") {
-		t.Fatalf("detail should show the Skill header:\n%s", out)
-	}
-	if !strings.Contains(out, "superpowers:brainstorming") {
-		t.Fatalf("detail should show the skill name:\n%s", out)
-	}
-	if !strings.Contains(out, "SKILL.md") || !strings.Contains(out, "Help turn ideas into designs.") {
-		t.Fatalf("detail should show the path and body:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
User-invoked skill loads (Claude Code `/slash-command`, Codex `<skill>` block) now render as a skill item on the user chunk — same row, drilldown, and lazy-fetched markdown body as an assistant skill item — instead of a separate top-level chunk.

- Skill folds into the user turn that triggered it (Codex merges it into the invoking message, gated by a `turn_id` sanity check).
- Drilldown + lazy body fetch reuse the existing assistant-skill machinery.
- Skill icon is now a graduation cap in both TUI and app.
- The obsolete `ChunkSkill` type and its rendering are removed.

Covered by Go and Dart tests; Codex merge verified against a real rollout.
