### PR TITLE
feat(app): support reviewing code changes for a session

### DIFF
--- a/app/lib/models/changes.dart
+++ b/app/lib/models/changes.dart
@@ -1,0 +1,85 @@
+class ChangedFile {
+  const ChangedFile({
+    required this.path,
+    required this.change,
+    this.origPath,
+    this.staged = false,
+    this.unstaged = false,
+  });
+
+  final String path;
+  final String change; // added|modified|deleted|renamed|untracked
+  final String? origPath; // rename source (HEAD-side)
+  final bool staged; // index differs from HEAD
+  final bool unstaged; // working tree differs from index
+
+  factory ChangedFile.fromJson(Map<String, dynamic> j) {
+    final origPath = j['orig_path'] as String?;
+    return ChangedFile(
+      path: j['path'] as String? ?? '',
+      change: j['change'] as String? ?? '',
+      origPath: (origPath != null && origPath.isNotEmpty) ? origPath : null,
+      staged: j['staged'] as bool? ?? false,
+      unstaged: j['unstaged'] as bool? ?? false,
+    );
+  }
+}
+
+class FileDiff {
+  const FileDiff({
+    required this.path,
+    this.oldContent = '',
+    this.newContent = '',
+    this.notShown = false,
+  });
+
+  final String path;
+  final String oldContent;
+  final String newContent;
+  final bool notShown;
+
+  factory FileDiff.fromJson(Map<String, dynamic> j) => FileDiff(
+        path: j['path'] as String? ?? '',
+        oldContent: j['old_content'] as String? ?? '',
+        newContent: j['new_content'] as String? ?? '',
+        notShown: j['not_shown'] as bool? ?? false,
+      );
+}
+
+class Commit {
+  const Commit({
+    required this.sha,
+    required this.short,
+    required this.subject,
+    required this.author,
+    required this.unixSec,
+  });
+
+  final String sha;
+  final String short;
+  final String subject;
+  final String author;
+  final int unixSec; // authored time (epoch seconds)
+
+  factory Commit.fromJson(Map<String, dynamic> j) => Commit(
+        sha: j['sha'] as String? ?? '',
+        short: j['short'] as String? ?? '',
+        subject: j['subject'] as String? ?? '',
+        author: j['author'] as String? ?? '',
+        unixSec: (j['unix_sec'] as num?)?.toInt() ?? 0,
+      );
+}
+
+class CommitList {
+  const CommitList({this.commits = const [], this.unpushed = false});
+
+  final List<Commit> commits;
+  final bool unpushed;
+
+  factory CommitList.fromJson(Map<String, dynamic> j) => CommitList(
+        commits: (j['commits'] as List? ?? const [])
+            .map((e) => Commit.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        unpushed: j['unpushed'] as bool? ?? false,
+      );
+}

--- a/app/lib/state/changes.dart
+++ b/app/lib/state/changes.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/changes.dart';
+import '../transport/rpc_client.dart';
+import 'gateway.dart';
+
+/// Wraps the changed-files RPCs. Resolves the client fresh on each call so
+/// reconnects are transparent; a missing client throws (as does a failed RPC),
+/// surfacing to the caller — a [FutureProvider]'s error state or a screen's
+/// try/catch.
+class ChangesApi {
+  ChangesApi(this._clientOf);
+  final RpcClient? Function() _clientOf;
+
+  RpcClient get _client => _clientOf() ?? (throw StateError('not connected'));
+
+  static List<ChangedFile> _filesOf(Map<String, dynamic> res) =>
+      (res['files'] as List? ?? const [])
+          .map((e) => ChangedFile.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+  Future<List<ChangedFile>> changedFiles(String sessionId) async =>
+      _filesOf(await _client.call('sessions.changedFiles', {
+        'session_id': sessionId,
+      }) as Map<String, dynamic>);
+
+  Future<FileDiff> fileDiff(
+    String sessionId,
+    String path, {
+    String? origPath,
+    String? rev,
+  }) async =>
+      FileDiff.fromJson(await _client.call('sessions.fileDiff', {
+        'session_id': sessionId,
+        'path': path,
+        if ((origPath ?? '').isNotEmpty) 'orig_path': origPath,
+        if ((rev ?? '').isNotEmpty) 'rev': rev,
+      }) as Map<String, dynamic>);
+
+  Future<CommitList> commits(String sessionId) async =>
+      CommitList.fromJson(await _client.call('sessions.commits', {
+        'session_id': sessionId,
+      }) as Map<String, dynamic>);
+
+  Future<List<ChangedFile>> commitFiles(String sessionId, String sha) async =>
+      _filesOf(await _client.call('sessions.commitFiles', {
+        'session_id': sessionId,
+        'sha': sha,
+      }) as Map<String, dynamic>);
+}
+
+final changesApiProvider = Provider<ChangesApi>(
+  (ref) => ChangesApi(() => ref.read(gatewayProvider)?.client),
+);
+
+final changedFilesProvider =
+    FutureProvider.autoDispose.family<List<ChangedFile>, String>(
+  (ref, sessionId) {
+    ref.watch(connStateProvider); // refetch on (re)connect
+    return ref.read(changesApiProvider).changedFiles(sessionId);
+  },
+);
+
+final commitsProvider =
+    FutureProvider.autoDispose.family<CommitList, String>(
+  (ref, sessionId) {
+    ref.watch(connStateProvider);
+    return ref.read(changesApiProvider).commits(sessionId);
+  },
+);
+
+final commitFilesProvider = FutureProvider.autoDispose
+    .family<List<ChangedFile>, (String, String)>(
+  (ref, key) {
+    ref.watch(connStateProvider);
+    return ref.read(changesApiProvider).commitFiles(key.$1, key.$2);
+  },
+);

--- a/app/lib/ui/changed_file_review_screen.dart
+++ b/app/lib/ui/changed_file_review_screen.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/changes.dart';
+import '../state/changes.dart';
+import 'edit_diff.dart';
+import 'responsive.dart';
+import 'theme.dart';
+
+const _mono = TextStyle(fontFamily: 'monospace', fontSize: 12, height: 1.35);
+
+/// Full-screen review of one changed file as a collapsible unified diff.
+class ChangedFileReviewScreen extends ConsumerStatefulWidget {
+  const ChangedFileReviewScreen({
+    super.key,
+    required this.sessionId,
+    required this.file,
+    this.rev,
+  });
+
+  final String sessionId;
+  final ChangedFile file;
+  final String? rev;
+
+  @override
+  ConsumerState<ChangedFileReviewScreen> createState() =>
+      _ChangedFileReviewScreenState();
+}
+
+class _ChangedFileReviewScreenState
+    extends ConsumerState<ChangedFileReviewScreen> {
+  bool _loading = true;
+  FileDiff? _diff;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _fetch());
+  }
+
+  Future<void> _fetch() async {
+    try {
+      final diff = await ref.read(changesApiProvider).fileDiff(
+            widget.sessionId,
+            widget.file.path,
+            origPath: widget.file.origPath,
+            rev: widget.rev,
+          );
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _diff = diff;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = e;
+      });
+    }
+  }
+
+  String get _fileName => widget.file.path.split('/').last;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(_fileName)),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : SafeArea(
+              top: false,
+              child: CenteredBody(
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: _body(),
+                  ),
+                ),
+              ),
+            ),
+    );
+  }
+
+  List<Widget> _body() {
+    final header = widget.file.origPath != null
+        ? '● ${widget.file.origPath} → ${widget.file.path}'
+        : '● ${widget.file.path}';
+    final blocks = <Widget>[
+      Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Text(header, style: _mono.copyWith(color: AppColors.dim)),
+      ),
+    ];
+
+    if (_error != null) {
+      blocks.add(Text('Failed to load: $_error',
+          style: const TextStyle(color: AppColors.dim)));
+      return blocks;
+    }
+    final d = _diff;
+    if (d == null) return blocks;
+    if (d.notShown) {
+      blocks.add(Text('Not shown — binary or too large.',
+          style: _mono.copyWith(color: AppColors.dim)));
+      return blocks;
+    }
+    if (d.oldContent.isEmpty && d.newContent.isEmpty) {
+      blocks.add(Text('Empty file — no content to show.',
+          style: _mono.copyWith(color: AppColors.dim)));
+      return blocks;
+    }
+    // Flexible (not Expanded) so a short diff stays compact under the path
+    // header, while a long one caps at the viewport and scrolls its own content.
+    blocks.add(Flexible(
+        child: collapsibleDiffView(d.oldContent, d.newContent, lang: d.path)));
+    return blocks;
+  }
+}

--- a/app/lib/ui/changed_file_row.dart
+++ b/app/lib/ui/changed_file_row.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import '../models/changes.dart';
+import 'theme.dart';
+
+const _mono = TextStyle(fontFamily: 'monospace', fontSize: 13);
+
+({String letter, Color color}) changeStyle(String change) => switch (change) {
+      'added' => (letter: 'A', color: const Color(0xFFb8bb26)),
+      'modified' => (letter: 'M', color: const Color(0xFFd79921)),
+      'deleted' => (letter: 'D', color: const Color(0xFFfb4934)),
+      'renamed' => (letter: 'R', color: const Color(0xFFd3869b)),
+      'untracked' => (letter: '?', color: const Color(0xFF83a598)),
+      _ => (letter: '•', color: AppColors.dim),
+    };
+
+class _UnstagedBadge extends StatelessWidget {
+  const _UnstagedBadge();
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+        decoration: BoxDecoration(
+          border: Border.all(color: const Color(0xFFd79921)),
+          borderRadius: BorderRadius.circular(3),
+        ),
+        child: const Text('unstaged',
+            style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 10,
+                color: Color(0xFFd79921))),
+      );
+}
+
+class ChangedFileRow extends StatelessWidget {
+  const ChangedFileRow({super.key, required this.file, required this.onTap});
+
+  final ChangedFile file;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = changeStyle(file.change);
+    final label =
+        file.origPath != null ? '${file.origPath} → ${file.path}' : file.path;
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        decoration: BoxDecoration(
+          color: AppColors.card,
+          border: Border.all(color: AppColors.border),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 16,
+              child: Text(s.letter,
+                  style: _mono.copyWith(
+                      color: s.color, fontWeight: FontWeight.w700)),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(label,
+                  style: _mono.copyWith(color: AppColors.text),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis),
+            ),
+            // Grouped under "Staged" by net change; flag the extra unstaged edits.
+            if (file.staged && file.unstaged) ...[
+              const _UnstagedBadge(),
+              const SizedBox(width: 6),
+            ],
+            const Icon(Icons.chevron_right, size: 18, color: AppColors.dim),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/changed_files_screen.dart
+++ b/app/lib/ui/changed_files_screen.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/changes.dart';
+import '../models/session.dart';
+import '../state/changes.dart';
+import 'changed_file_review_screen.dart';
+import 'changed_file_row.dart';
+import 'code_block.dart';
+import 'commit_detail_screen.dart';
+import 'relative_time.dart';
+import 'responsive.dart';
+import 'theme.dart';
+
+const _mono = TextStyle(fontFamily: 'monospace', fontSize: 13);
+
+/// A live session's git status (grouped Staged / Unstaged / Untracked) above its
+/// branch/unpushed commits.
+class ChangedFilesScreen extends ConsumerWidget {
+  const ChangedFilesScreen({super.key, required this.session});
+
+  final Session session;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(changedFilesProvider(session.id));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Changes'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: () {
+              ref.invalidate(changedFilesProvider(session.id));
+              ref.invalidate(commitsProvider(session.id));
+            },
+          ),
+        ],
+      ),
+      body: SafeArea(
+        top: false,
+        child: RefreshIndicator(
+          onRefresh: () async {
+            ref.invalidate(changedFilesProvider(session.id));
+            ref.invalidate(commitsProvider(session.id));
+          },
+          child: async.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => _messageList('Could not load changes:\n$e'),
+            data: (files) => _body(context, ref, files),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _messageList(String text) => ListView(
+        children: [
+          const SizedBox(height: 120),
+          Center(child: Text(text, style: const TextStyle(color: AppColors.dim))),
+        ],
+      );
+
+  Widget _body(BuildContext context, WidgetRef ref, List<ChangedFile> files) {
+    final untracked = files.where((f) => f.change == 'untracked').toList();
+    final staged =
+        files.where((f) => f.change != 'untracked' && f.staged).toList();
+    final unstaged =
+        files.where((f) => f.change != 'untracked' && !f.staged).toList();
+
+    return CenteredBody(
+      child: ListView(
+        padding: const EdgeInsets.all(12),
+        children: [
+          ..._fileSection(context, 'Staged', staged),
+          ..._fileSection(context, 'Unstaged', unstaged),
+          ..._fileSection(context, 'Untracked', untracked),
+          if (files.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: Text('No working-tree changes.',
+                  style: TextStyle(color: AppColors.dim)),
+            ),
+          ..._commitsSection(context, ref),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _fileSection(
+      BuildContext context, String title, List<ChangedFile> files) {
+    if (files.isEmpty) return const [];
+    return [
+      _sectionHeader('${title.toUpperCase()} (${files.length})'),
+      for (final f in files)
+        ChangedFileRow(
+          file: f,
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => ChangedFileReviewScreen(
+                sessionId: session.id,
+                file: f,
+              ),
+            ),
+          ),
+        ),
+      const SizedBox(height: 8),
+    ];
+  }
+
+  List<Widget> _commitsSection(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(commitsProvider(session.id));
+    return async.when(
+      loading: () => [
+        _sectionHeader('COMMITS'),
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      ],
+      error: (e, _) => [
+        _sectionHeader('COMMITS'),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Text('Could not load commits: $e',
+              style: const TextStyle(color: AppColors.dim)),
+        ),
+      ],
+      data: (list) {
+        if (list.commits.isEmpty) return const [];
+        return [
+          _sectionHeader(
+              '${list.unpushed ? 'UNPUSHED' : 'COMMITS'} (${list.commits.length})'),
+          for (final c in list.commits) _CommitRow(session: session, commit: c),
+          const SizedBox(height: 8),
+        ];
+      },
+    );
+  }
+
+  Widget _sectionHeader(String text) => Padding(
+        padding: const EdgeInsets.only(bottom: 8, top: 4),
+        child: Text(
+          '▌ $text',
+          style: const TextStyle(
+            fontFamily: 'monospace',
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            color: AppColors.dim,
+          ),
+        ),
+      );
+}
+
+class _CommitRow extends StatelessWidget {
+  const _CommitRow({required this.session, required this.commit});
+  final Session session;
+  final Commit commit;
+
+  @override
+  Widget build(BuildContext context) {
+    final rel = commit.unixSec == 0
+        ? ''
+        : relativeTimeFrom(
+            DateTime.fromMillisecondsSinceEpoch(commit.unixSec * 1000),
+          );
+    final meta = rel.isEmpty ? commit.author : '${commit.author} · $rel';
+    return InkWell(
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) =>
+              CommitDetailScreen(sessionId: session.id, commit: commit),
+        ),
+      ),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        decoration: BoxDecoration(
+          color: AppColors.card,
+          border: Border.all(color: AppColors.border),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(commit.subject,
+                style: _mono.copyWith(color: AppColors.text),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis),
+            const SizedBox(height: 6),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Expanded(
+                  child: Text(meta,
+                      style: _mono.copyWith(
+                          color: AppColors.dim, fontSize: 11)),
+                ),
+                const SizedBox(width: 8),
+                // Inner InkWell absorbs the tap, so copying the SHA doesn't
+                // trigger the row's navigation.
+                InkWell(
+                  onTap: () => copyToClipboard(context, commit.sha),
+                  borderRadius: BorderRadius.circular(4),
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(commit.short,
+                            style: _mono.copyWith(
+                                color: const Color(0xFFd79921),
+                                fontWeight: FontWeight.w700,
+                                fontSize: 11)),
+                        const SizedBox(width: 4),
+                        const Icon(Icons.copy,
+                            size: 12, color: AppColors.dim),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/code_block.dart
+++ b/app/lib/ui/code_block.dart
@@ -160,7 +160,7 @@ class _CodeBlockState extends State<_CodeBlock> {
       : SingleChildScrollView(
           scrollDirection: Axis.horizontal, child: content);
 
-  Widget _numbered(List<List<_Run>> lines) {
+  Widget _numbered(List<List<CodeRun>> lines) {
     final gutterWidth = lines.length.toString().length * 9.0;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -185,7 +185,7 @@ class _CodeBlockState extends State<_CodeBlock> {
     );
   }
 
-  Widget _lineText(List<_Run> runs) => Text.rich(
+  Widget _lineText(List<CodeRun> runs) => Text.rich(
         TextSpan(
           style: _codeMono,
           // A blank line still needs a glyph so its row keeps the line height.
@@ -239,17 +239,36 @@ class _CodeBlockState extends State<_CodeBlock> {
 }
 
 /// A styled text run within one line, from the flattened highlight tree.
-class _Run {
-  const _Run(this.text, this.style);
+class CodeRun {
+  const CodeRun(this.text, this.style);
   final String text;
   final TextStyle? style;
+}
+
+/// Highlights [source] into per-line styled runs aligned to `source.split('\n')`,
+/// falling back to one unstyled run per line on any highlighter error.
+List<List<CodeRun>> highlightLines(String source, {String? lang}) {
+  List<List<CodeRun>> plain() => [
+        for (final l in source.split('\n')) [if (l.isNotEmpty) CodeRun(l, null)]
+      ];
+  if (source.isEmpty) return const <List<CodeRun>>[];
+  try {
+    final result = _highlight.highlightAuto(source, _candidates(lang));
+    final renderer = TextSpanRenderer(_codeMono, _codeTheme);
+    result.render(renderer);
+    final span = renderer.span;
+    if (span == null) return plain();
+    return _spanLines(span);
+  } catch (_) {
+    return plain();
+  }
 }
 
 /// Flattens a highlighted [span] tree into per-line runs so a line-number gutter
 /// can align to each logical line. Text renders before children within a span,
 /// so the walk order matches on-screen order.
-List<List<_Run>> _spanLines(InlineSpan span) {
-  final lines = <List<_Run>>[<_Run>[]];
+List<List<CodeRun>> _spanLines(InlineSpan span) {
+  final lines = <List<CodeRun>>[<CodeRun>[]];
   void walk(InlineSpan s, TextStyle? inherited) {
     if (s is! TextSpan) return;
     final style = inherited == null ? s.style : inherited.merge(s.style);
@@ -257,8 +276,8 @@ List<List<_Run>> _spanLines(InlineSpan span) {
     if (text != null) {
       final parts = text.split('\n');
       for (var i = 0; i < parts.length; i++) {
-        if (i > 0) lines.add(<_Run>[]);
-        if (parts[i].isNotEmpty) lines.last.add(_Run(parts[i], style));
+        if (i > 0) lines.add(<CodeRun>[]);
+        if (parts[i].isNotEmpty) lines.last.add(CodeRun(parts[i], style));
       }
     }
     for (final c in s.children ?? const <InlineSpan>[]) {
@@ -405,20 +424,76 @@ String? _alias(String? name) {
     case 'zsh':
       return 'bash';
     case 'js':
+    case 'jsx':
+    case 'mjs':
+    case 'cjs':
       return 'javascript';
     case 'ts':
+    case 'tsx':
       return 'typescript';
     case 'yml':
       return 'yaml';
     case 'py':
+    case 'pyi':
       return 'python';
     case 'rs':
       return 'rust';
     case 'md':
+    case 'markdown':
       return 'markdown';
+    case 'toml':
+    case 'cfg':
+      return 'ini';
+    case 'html':
+    case 'htm':
+    case 'svg':
+      return 'xml';
+    case 'kt':
+    case 'kts':
+      return 'kotlin';
+    case 'h':
+      return 'c';
+    case 'cc':
+    case 'cxx':
+    case 'hpp':
+    case 'hh':
+      return 'cpp';
+    case 'cs':
+      return 'csharp';
+    case 'rb':
+      return 'ruby';
+    case 'pl':
+    case 'pm':
+      return 'perl';
+    case 'ex':
+    case 'exs':
+      return 'elixir';
+    case 'erl':
+      return 'erlang';
+    case 'clj':
+      return 'clojure';
+    case 'hs':
+      return 'haskell';
+    case 'ml':
+      return 'ocaml';
+    case 'proto':
+      return 'protobuf';
+    case 'gql':
+      return 'graphql';
     default:
       return n;
   }
+}
+
+/// Highlight grammar for a file [path], keyed on its extension (or the bare
+/// filename for extensionless files like `Dockerfile`). Null when unresolved.
+String? langFromPath(String? path) {
+  final p = path?.trim();
+  if (p == null || p.isEmpty) return null;
+  final base = p.split('/').last.split('\\').last;
+  final dot = base.lastIndexOf('.');
+  final key = dot > 0 ? base.substring(dot + 1) : base;
+  return _alias(key);
 }
 
 /// Returns [body] re-indented as JSON when it parses as a JSON object/array,

--- a/app/lib/ui/commit_detail_screen.dart
+++ b/app/lib/ui/commit_detail_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/changes.dart';
+import '../state/changes.dart';
+import 'changed_file_review_screen.dart';
+import 'changed_file_row.dart';
+import 'responsive.dart';
+import 'theme.dart';
+
+/// Lists the files a commit changed; tap one to review its parent-vs-commit diff.
+class CommitDetailScreen extends ConsumerWidget {
+  const CommitDetailScreen({
+    super.key,
+    required this.sessionId,
+    required this.commit,
+  });
+
+  final String sessionId;
+  final Commit commit;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(commitFilesProvider((sessionId, commit.sha)));
+    return Scaffold(
+      appBar: AppBar(title: Text('${commit.short}  ${commit.subject}')),
+      body: SafeArea(
+        top: false,
+        child: async.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(
+            child: Text('Could not load commit:\n$e',
+                style: const TextStyle(color: AppColors.dim)),
+          ),
+          data: (files) => files.isEmpty
+              ? const Center(
+                  child: Text('No files in this commit.',
+                      style: TextStyle(color: AppColors.dim)))
+              : CenteredBody(
+                  child: ListView(
+                    padding: const EdgeInsets.all(12),
+                    children: [
+                      for (final f in files)
+                        ChangedFileRow(
+                          file: f,
+                          onTap: () => Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => ChangedFileReviewScreen(
+                                sessionId: sessionId,
+                                file: f,
+                                rev: commit.sha,
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/edit_diff.dart
+++ b/app/lib/ui/edit_diff.dart
@@ -10,7 +10,6 @@ const _red = Color(0xFFfb4934);
 const _green = Color(0xFFb8bb26);
 const _mono = TextStyle(fontFamily: 'monospace', fontSize: 12, height: 1.35);
 
-/// Reads a tool-input field as a string, treating non-strings (incl. null) as ''.
 String toolInputStr(Object? v) => v is String ? v : '';
 
 Widget editDiffView(Item item) {
@@ -43,8 +42,9 @@ Widget editDiffView(Item item) {
               style: _mono.copyWith(color: AppColors.dim)),
         ));
       }
-      blocks.add(diffView(
-          toolInputStr(input['old_string']), toolInputStr(input['new_string'])));
+      blocks.add(diffView(toolInputStr(input['old_string']),
+          toolInputStr(input['new_string']),
+          lang: path));
       break;
     case 'MultiEdit':
       final edits = (input['edits'] as List?) ?? const [];
@@ -58,14 +58,15 @@ Widget editDiffView(Item item) {
           ));
         }
         blocks.add(diffView(
-            toolInputStr(e['old_string']), toolInputStr(e['new_string'])));
+            toolInputStr(e['old_string']), toolInputStr(e['new_string']),
+            lang: path));
       }
       break;
     case 'Write':
-      blocks.add(diffView('', toolInputStr(input['content'])));
+      blocks.add(diffView('', toolInputStr(input['content']), lang: path));
       break;
     case 'NotebookEdit':
-      blocks.add(diffView('', toolInputStr(input['new_source'])));
+      blocks.add(diffView('', toolInputStr(input['new_source']), lang: path));
       break;
     default:
       blocks.add(diffView('', item.toolInput ?? ''));
@@ -74,18 +75,333 @@ Widget editDiffView(Item item) {
   return Column(crossAxisAlignment: CrossAxisAlignment.start, children: blocks);
 }
 
+/// Unchanged context kept on each side of a change; longer runs are folded.
+const _ctxLines = 3;
+
+/// Shortest hidden run worth folding — one or two lines behind a bar just adds taps.
+const _foldThreshold = 4;
+
+/// A collapsible unified diff for full-file review (PR style), unchanged runs
+/// folded behind expand bars.
+///
+/// Place it in a bounded-height parent (e.g. a [Flexible]): it sizes to its
+/// content but caps at the granted height, pinning its header and scrolling the
+/// rows on overflow.
+Widget collapsibleDiffView(String oldS, String newS, {String? lang}) =>
+    _CollapsibleDiff(_lineDiff(oldS, newS, lang: langFromPath(lang)));
+
+class _CollapsibleDiff extends StatefulWidget {
+  const _CollapsibleDiff(this.lines);
+  final List<_DLine> lines;
+
+  @override
+  State<_CollapsibleDiff> createState() => _CollapsibleDiffState();
+}
+
+class _CollapsibleDiffState extends State<_CollapsibleDiff> {
+  final Set<int> _expanded = {}; // line indices in fold regions the user opened
+  bool _expandAll = false;
+  bool _wrap = false;
+  bool _highlight = true;
+
+  final _AnchoredScrollController _vScroll = _AnchoredScrollController();
+  // Keys per rendered row and on the content column, so an expand can measure a
+  // boundary row's offset before/after and shift the viewport by the real delta.
+  final Map<int, GlobalKey> _rowKeys = {};
+  final GlobalKey _contentKey = GlobalKey();
+
+  late final List<int> _newNo; // new-side line number per row (0 for deletions)
+  late final List<bool> _keep; // within _ctxLines of a change → never folded
+  late final double _gutterWidth;
+
+  @override
+  void dispose() {
+    _vScroll.dispose();
+    super.dispose();
+  }
+
+  GlobalKey _keyFor(int i) => _rowKeys.putIfAbsent(i, () => GlobalKey());
+
+  // A row's top relative to the content column, independent of scroll; null if
+  // not measurable.
+  double? _rowOffsetInContent(int index) {
+    final row = _rowKeys[index]?.currentContext?.findRenderObject();
+    final content = _contentKey.currentContext?.findRenderObject();
+    if (row is RenderBox && row.attached && content is RenderBox &&
+        content.attached) {
+      return row.localToGlobal(Offset.zero, ancestor: content).dy;
+    }
+    return null;
+  }
+
+  /// Reveals a folded run. A leading run (file head, no row above) fills upward,
+  /// so we hold the row below the bar in place by correcting the scroll during
+  /// layout (before paint, no flicker). Middle/trailing runs fill downward — the
+  /// natural insert — and need no correction.
+  void _expandRegion(int start, int end) {
+    if (start == 0 && end < widget.lines.length && _vScroll.hasClients) {
+      final before = _rowOffsetInContent(end);
+      if (before != null) {
+        // Distance from the viewport top to the boundary row, to be preserved.
+        final keep = before - _vScroll.offset;
+        _vScroll.anchorNextLayout(() {
+          final after = _rowOffsetInContent(end);
+          return after == null ? null : after - keep;
+        });
+      }
+    }
+    setState(() {
+      for (var k = start; k < end; k++) {
+        _expanded.add(k);
+      }
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    final lines = widget.lines;
+    _newNo = List<int>.filled(lines.length, 0);
+    var nn = 0;
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].kind != _DKind.del) _newNo[i] = ++nn;
+    }
+    _gutterWidth = nn.toString().length * 9.0 + 4;
+
+    _keep = List<bool>.filled(lines.length, false);
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].kind != _DKind.context) {
+        for (var k = i - _ctxLines; k <= i + _ctxLines; k++) {
+          if (k >= 0 && k < lines.length) _keep[k] = true;
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lines = widget.lines;
+    if (lines.isEmpty) return const SizedBox.shrink();
+
+    final rows = <Widget>[];
+    var i = 0;
+    while (i < lines.length) {
+      if (!_keep[i] && !_expandAll && !_expanded.contains(i)) {
+        var j = i;
+        while (j < lines.length && !_keep[j] && !_expanded.contains(j)) {
+          j++;
+        }
+        final count = j - i;
+        if (count >= _foldThreshold) {
+          final start = i, end = j;
+          rows.add(_expandBar(start, end, count, () => _expandRegion(start, end)));
+          i = j;
+          continue;
+        }
+      }
+      rows.add(KeyedSubtree(
+        key: _keyFor(i),
+        child: _diffLineRow(lines[i], _newNo[i], _gutterWidth, _wrap, _highlight),
+      ));
+      i++;
+    }
+
+    final content = Column(
+        key: _contentKey,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: rows);
+
+    // Vertical scroll always; horizontal too when not wrapping.
+    final Widget scroller = _wrap
+        ? SingleChildScrollView(controller: _vScroll, child: content)
+        : SingleChildScrollView(
+            controller: _vScroll,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: IntrinsicWidth(child: content),
+            ),
+          );
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 6),
+      decoration: BoxDecoration(
+        color: AppColors.card,
+        border: Border.all(color: AppColors.border),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Column(
+        // min so the box shrinks to its content; the Flexible below caps it.
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            padding: const EdgeInsets.only(left: 8, right: 2),
+            decoration: const BoxDecoration(
+              border: Border(bottom: BorderSide(color: AppColors.border)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text('diff',
+                      style: _mono.copyWith(color: AppColors.dim, fontSize: 11)),
+                ),
+                codeBarButton(
+                  icon: _expandAll ? Icons.unfold_less : Icons.unfold_more,
+                  active: _expandAll,
+                  tooltip: _expandAll ? 'Collapse unchanged' : 'Expand all',
+                  onTap: () => setState(() {
+                    _expandAll = !_expandAll;
+                    if (!_expandAll) _expanded.clear();
+                  }),
+                ),
+                codeBarButton(
+                  icon: Icons.format_color_reset,
+                  active: !_highlight,
+                  tooltip: _highlight ? 'Disable highlight' : 'Enable highlight',
+                  onTap: () => setState(() => _highlight = !_highlight),
+                ),
+                codeBarButton(
+                  icon: Icons.wrap_text,
+                  active: _wrap,
+                  tooltip: _wrap ? 'Disable wrap' : 'Wrap lines',
+                  onTap: () => setState(() => _wrap = !_wrap),
+                ),
+              ],
+            ),
+          ),
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: scroller,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Expand bar for the folded run [start, end): the gutter icon points up at the
+  // file's head, down at its tail, both ways for a run between two changes.
+  Widget _expandBar(int start, int end, int count, VoidCallback onTap) {
+    final IconData icon;
+    if (start == 0) {
+      icon = Icons.keyboard_double_arrow_up;
+    } else if (end == widget.lines.length) {
+      icon = Icons.keyboard_double_arrow_down;
+    } else {
+      icon = Icons.height;
+    }
+    const color = Color(0xFF83a598);
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            SizedBox(
+              width: _gutterWidth,
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Icon(icon, size: 16, color: color),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text('Expand $count unchanged lines',
+                style: _mono.copyWith(color: color)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 enum _DKind { context, add, del }
 
 class _DLine {
-  const _DLine(this.text, this.kind);
+  const _DLine(this.text, this.kind, {this.runs, this.noEol = false});
   final String text;
   final _DKind kind;
+
+  /// Syntax-highlighted runs for [text] (no prefix), or null to render flat.
+  final List<CodeRun>? runs;
+
+  /// The line was the last of its side with no trailing newline; the renderer
+  /// shows a "\ No newline at end of file" marker beneath it.
+  final bool noEol;
 }
 
-/// Empty [oldS] yields an all-additions view.
-Widget diffView(String oldS, String newS) => _DiffBox(_lineDiff(oldS, newS));
+const _noEolLabel = r'\ No newline at end of file';
 
-/// A diff box with a thin header (label + wrap toggle), mirroring code blocks.
+({String prefix, Color color}) _diffLineStyle(_DKind kind) => switch (kind) {
+      _DKind.add => (prefix: '+ ', color: _green),
+      _DKind.del => (prefix: '- ', color: _red),
+      _DKind.context => (prefix: '  ', color: AppColors.text),
+    };
+
+/// Faint background tint marking add/removed lines; null for context.
+Color? _diffLineBg(_DKind kind) => switch (kind) {
+      _DKind.add => _green.withValues(alpha: 0.10),
+      _DKind.del => _red.withValues(alpha: 0.10),
+      _DKind.context => null,
+    };
+
+/// Spans for one diff line: the colored `+`/`-`/space prefix, then either
+/// syntax-highlighted runs or a single flat-colored span.
+List<TextSpan> _diffLineSpans(_DLine l, bool highlight) {
+  final s = _diffLineStyle(l.kind);
+  final runs = l.runs;
+  if (highlight && runs != null) {
+    return [
+      TextSpan(text: s.prefix, style: TextStyle(color: s.color)),
+      for (final r in runs) TextSpan(text: r.text, style: r.style),
+    ];
+  }
+  return [
+    TextSpan(text: '${s.prefix}${l.text}', style: TextStyle(color: s.color)),
+  ];
+}
+
+/// A numbered diff row: new-side line number (blank for deletions) in a
+/// [gutterWidth]-wide gutter, then the styled line text.
+Widget _diffLineRow(
+    _DLine l, int newNo, double gutterWidth, bool wrap, bool highlight) {
+  final text = Text.rich(TextSpan(children: _diffLineSpans(l, highlight)),
+      style: _mono, softWrap: wrap);
+  final row = Row(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      SizedBox(
+        width: gutterWidth,
+        child: Text(l.kind == _DKind.del ? '' : '$newNo',
+            textAlign: TextAlign.right,
+            style: _mono.copyWith(color: AppColors.dim)),
+      ),
+      const SizedBox(width: 8),
+      wrap ? Expanded(child: text) : text,
+    ],
+  );
+  final bg = highlight ? _diffLineBg(l.kind) : null;
+  final styled = bg == null ? row : ColoredBox(color: bg, child: row);
+  if (!l.noEol) return styled;
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [styled, _noEolMarkerRow(gutterWidth)],
+  );
+}
+
+/// The no-newline marker, aligned under the line text and dimmed.
+Widget _noEolMarkerRow(double gutterWidth) => Padding(
+      padding: EdgeInsets.only(left: gutterWidth + 8),
+      child: Text(_noEolLabel,
+          style: _mono.copyWith(
+              color: AppColors.dim, fontStyle: FontStyle.italic)),
+    );
+
+/// Empty [oldS] yields an all-additions view. [lang] hints the highlight grammar.
+Widget diffView(String oldS, String newS, {String? lang}) =>
+    _DiffBox(_lineDiff(oldS, newS, lang: langFromPath(lang)));
+
 /// Copy is intentionally omitted — a diff is for reading, not grabbing text.
 class _DiffBox extends StatefulWidget {
   const _DiffBox(this.lines);
@@ -99,6 +415,7 @@ class _DiffBox extends StatefulWidget {
 class _DiffBoxState extends State<_DiffBox> {
   bool _wrap = false;
   bool _lineNumbers = false;
+  bool _highlight = true;
 
   @override
   Widget build(BuildContext context) {
@@ -135,6 +452,12 @@ class _DiffBoxState extends State<_DiffBox> {
                   onTap: () => setState(() => _lineNumbers = !_lineNumbers),
                 ),
                 codeBarButton(
+                  icon: Icons.format_color_reset,
+                  active: !_highlight,
+                  tooltip: _highlight ? 'Disable highlight' : 'Enable highlight',
+                  onTap: () => setState(() => _highlight = !_highlight),
+                ),
+                codeBarButton(
                   icon: Icons.wrap_text,
                   active: _wrap,
                   tooltip: _wrap ? 'Disable wrap' : 'Wrap lines',
@@ -148,78 +471,89 @@ class _DiffBoxState extends State<_DiffBox> {
             child: _wrap
                 ? content
                 : SingleChildScrollView(
-                    scrollDirection: Axis.horizontal, child: content),
+                    scrollDirection: Axis.horizontal,
+                    child: IntrinsicWidth(child: content)),
           ),
         ],
       ),
     );
   }
 
-  ({String prefix, Color color}) _style(_DKind kind) => switch (kind) {
-        _DKind.add => (prefix: '+ ', color: _green),
-        _DKind.del => (prefix: '- ', color: _red),
-        _DKind.context => (prefix: '  ', color: AppColors.text),
-      };
-
+  // One paragraph of all lines, with a text-background tint (not full-row, which
+  // would need per-row layout) on add/removed lines.
   Widget _plain() {
     final spans = <TextSpan>[];
     for (var i = 0; i < widget.lines.length; i++) {
       final l = widget.lines[i];
-      final s = _style(l.kind);
-      final nl = i == widget.lines.length - 1 ? '' : '\n';
-      spans.add(TextSpan(
-          text: '${s.prefix}${l.text}$nl', style: TextStyle(color: s.color)));
+      final bg = _highlight ? _diffLineBg(l.kind) : null;
+      for (final span in _diffLineSpans(l, _highlight)) {
+        spans.add(bg == null
+            ? span
+            : TextSpan(
+                text: span.text,
+                style: (span.style ?? const TextStyle())
+                    .copyWith(backgroundColor: bg)));
+      }
+      if (l.noEol) {
+        spans.add(const TextSpan(
+            text: '\n$_noEolLabel',
+            style: TextStyle(
+                color: AppColors.dim, fontStyle: FontStyle.italic)));
+      }
+      if (i != widget.lines.length - 1) spans.add(const TextSpan(text: '\n'));
     }
     return Text.rich(TextSpan(children: spans, style: _mono), softWrap: _wrap);
   }
 
-  // Numbers the new-side (context + additions); deletions get a blank gutter.
-  // No file offset is available, so numbering starts at 1.
+  // Numbers the new side; deletions get a blank gutter. Starts at 1 (no offset).
   Widget _numbered() {
-    final newCount =
-        widget.lines.where((l) => l.kind != _DKind.del).length;
+    final newCount = widget.lines.where((l) => l.kind != _DKind.del).length;
     final gutterWidth = newCount.toString().length * 9.0;
     final rows = <Widget>[];
     var newNo = 0;
     for (final l in widget.lines) {
-      final isDel = l.kind == _DKind.del;
-      if (!isDel) newNo++;
-      final s = _style(l.kind);
-      final text = Text('${s.prefix}${l.text}',
-          style: _mono.copyWith(color: s.color), softWrap: _wrap);
-      rows.add(Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: gutterWidth,
-            child: Text(isDel ? '' : '$newNo',
-                textAlign: TextAlign.right,
-                style: _mono.copyWith(color: AppColors.dim)),
-          ),
-          const SizedBox(width: 8),
-          _wrap ? Expanded(child: text) : text,
-        ],
-      ));
+      if (l.kind != _DKind.del) newNo++;
+      rows.add(_diffLineRow(l, newNo, gutterWidth, _wrap, _highlight));
     }
-    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: rows);
+    return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch, children: rows);
   }
 }
 
-/// Line-level LCS diff: context lines are plain, removals red, additions green.
-/// Mirrors the TUI's lineDiff, including the >2000-line block fallback.
-List<_DLine> _lineDiff(String oldS, String newS) {
+/// Line-level LCS diff. Each side is syntax-highlighted once ([lang] hints the
+/// grammar); the per-line runs then attach to their diff line — deletions from
+/// the old side, additions and context from the new side.
+List<_DLine> _lineDiff(String oldS, String newS, {String? lang}) {
+  oldS = _normalizeEol(oldS);
+  newS = _normalizeEol(newS);
   final a = _split(oldS), b = _split(newS);
   final n = a.length, m = b.length;
+
+  // Match on trailing-newline state too, so adding/removing just the final
+  // newline diffs the last line instead of vanishing into context.
+  bool same(_SrcLine x, _SrcLine y) => x.text == y.text && x.eol == y.eol;
+
+  // Large diffs skip the O(n·m) LCS and highlighting (two full-file tokenizer
+  // passes would jank the UI isolate); the renderer falls back to flat color.
   if (n + m > 2000) {
     return [
-      for (final l in a) _DLine(l, _DKind.del),
-      for (final l in b) _DLine(l, _DKind.add),
+      for (var i = 0; i < n; i++)
+        _DLine(a[i].text, _DKind.del, noEol: !a[i].eol),
+      for (var j = 0; j < m; j++)
+        _DLine(b[j].text, _DKind.add, noEol: !b[j].eol),
     ];
   }
+
+  final oldRuns = highlightLines(oldS, lang: lang);
+  final newRuns = highlightLines(newS, lang: lang);
+  // Runs may carry a trailing empty line that _split drops; guard the lookup.
+  List<CodeRun>? runsAt(List<List<CodeRun>> runs, int idx) =>
+      idx >= 0 && idx < runs.length ? runs[idx] : null;
+
   final dp = List.generate(n + 1, (_) => List<int>.filled(m + 1, 0));
   for (var i = n - 1; i >= 0; i--) {
     for (var j = m - 1; j >= 0; j--) {
-      dp[i][j] = a[i] == b[j]
+      dp[i][j] = same(a[i], b[j])
           ? dp[i + 1][j + 1] + 1
           : (dp[i + 1][j] >= dp[i][j + 1] ? dp[i + 1][j] : dp[i][j + 1]);
     }
@@ -227,31 +561,106 @@ List<_DLine> _lineDiff(String oldS, String newS) {
   final out = <_DLine>[];
   var i = 0, j = 0;
   while (i < n && j < m) {
-    if (a[i] == b[j]) {
-      out.add(_DLine(a[i], _DKind.context));
+    if (same(a[i], b[j])) {
+      out.add(_DLine(a[i].text, _DKind.context,
+          runs: runsAt(newRuns, j), noEol: !a[i].eol));
       i++;
       j++;
     } else if (dp[i + 1][j] >= dp[i][j + 1]) {
-      out.add(_DLine(a[i], _DKind.del));
+      out.add(_DLine(a[i].text, _DKind.del,
+          runs: runsAt(oldRuns, i), noEol: !a[i].eol));
       i++;
     } else {
-      out.add(_DLine(b[j], _DKind.add));
+      out.add(_DLine(b[j].text, _DKind.add,
+          runs: runsAt(newRuns, j), noEol: !b[j].eol));
       j++;
     }
   }
   for (; i < n; i++) {
-    out.add(_DLine(a[i], _DKind.del));
+    out.add(_DLine(a[i].text, _DKind.del,
+        runs: runsAt(oldRuns, i), noEol: !a[i].eol));
   }
   for (; j < m; j++) {
-    out.add(_DLine(b[j], _DKind.add));
+    out.add(_DLine(b[j].text, _DKind.add,
+        runs: runsAt(newRuns, j), noEol: !b[j].eol));
   }
   return out;
 }
 
-/// Splits into lines, dropping a single trailing newline. Empty input yields no
-/// lines (so an all-additions block has no spurious blank context line).
-List<String> _split(String s) {
+/// One source line plus whether it was newline-terminated — carried so the diff
+/// can surface an otherwise-invisible trailing-newline-only change.
+class _SrcLine {
+  const _SrcLine(this.text, {required this.eol});
+  final String text;
+  final bool eol;
+}
+
+/// Collapses CRLF to LF so line endings never render as stray carriage returns
+/// and a pure LF↔CRLF change doesn't diff every line.
+String _normalizeEol(String s) => s.replaceAll('\r\n', '\n');
+
+/// Splits into lines, dropping a single trailing newline but recording whether
+/// it was present. Empty input yields no lines (no spurious blank context line).
+List<_SrcLine> _split(String s) {
   if (s.isEmpty) return const [];
-  final t = s.endsWith('\n') ? s.substring(0, s.length - 1) : s;
-  return t.split('\n');
+  final hasTrailing = s.endsWith('\n');
+  final body = hasTrailing ? s.substring(0, s.length - 1) : s;
+  final parts = body.split('\n');
+  return [
+    for (var k = 0; k < parts.length; k++)
+      _SrcLine(parts[k], eol: k < parts.length - 1 || hasTrailing),
+  ];
+}
+
+/// A scroll controller that applies a one-shot offset correction during the next
+/// layout, before paint — so inserting rows above the viewport keeps the visible
+/// content put without the one-frame flicker a post-frame `jumpTo` would cause.
+class _AnchoredScrollController extends ScrollController {
+  double? Function()? _pending;
+
+  void anchorNextLayout(double? Function() computeTarget) =>
+      _pending = computeTarget;
+
+  double? Function()? _takePending() {
+    final p = _pending;
+    _pending = null;
+    return p;
+  }
+
+  @override
+  ScrollPosition createScrollPosition(ScrollPhysics physics,
+          ScrollContext context, ScrollPosition? oldPosition) =>
+      _AnchoredScrollPosition(
+        physics: physics,
+        context: context,
+        oldPosition: oldPosition,
+        takePending: _takePending,
+      );
+}
+
+class _AnchoredScrollPosition extends ScrollPositionWithSingleContext {
+  _AnchoredScrollPosition({
+    required super.physics,
+    required super.context,
+    super.oldPosition,
+    required this.takePending,
+  });
+
+  final double? Function()? Function() takePending;
+
+  @override
+  bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
+    final applied =
+        super.applyContentDimensions(minScrollExtent, maxScrollExtent);
+    final compute = takePending();
+    final target = compute?.call();
+    if (target != null) {
+      final clamped = target.clamp(minScrollExtent, maxScrollExtent);
+      if ((clamped - pixels).abs() > 0.5) {
+        correctPixels(clamped);
+        return false; // re-layout with the corrected offset before painting
+      }
+    }
+    return applied;
+  }
 }

--- a/app/lib/ui/relative_time.dart
+++ b/app/lib/ui/relative_time.dart
@@ -7,6 +7,11 @@ String relativeTime(String? iso, [DateTime? now]) {
   if (iso == null || iso.isEmpty) return '';
   final then = DateTime.tryParse(iso);
   if (then == null) return '';
+  return relativeTimeFrom(then, now);
+}
+
+/// Like [relativeTime] but from an already-parsed [then].
+String relativeTimeFrom(DateTime then, [DateTime? now]) {
   final secs = ((now ?? DateTime.now()).difference(then).inMilliseconds / 1000)
       .clamp(0, double.infinity);
   const units = [

--- a/app/lib/ui/session_detail_screen.dart
+++ b/app/lib/ui/session_detail_screen.dart
@@ -14,6 +14,7 @@ import '../state/sessions.dart';
 import '../state/tool_detail.dart';
 import '../state/transcript_controller.dart';
 import '../transport/connection.dart';
+import 'changed_files_screen.dart';
 import 'interaction_bar.dart';
 import 'live_screen_screen.dart';
 import 'respond_sheet.dart';
@@ -189,6 +190,15 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen>
           ],
         ),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.difference),
+            tooltip: 'Changes',
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => ChangedFilesScreen(session: live),
+              ),
+            ),
+          ),
           IconButton(
             icon: const Icon(Icons.terminal),
             tooltip: 'Live screen',

--- a/app/lib/ui/tool_detail.dart
+++ b/app/lib/ui/tool_detail.dart
@@ -221,82 +221,9 @@ Widget _read(Item it) {
     // Read output is already `cat -n` numbered — no need for our own gutter.
     if ((it.result ?? '').isNotEmpty)
       codeBlock(it.result!,
-          lang: _langFromPath(path), lineNumberToggle: false),
+          lang: langFromPath(path), lineNumberToggle: false),
   ]);
 }
-
-/// Maps a file path's extension (or bare name) to a re_highlight grammar, or
-/// null when unknown so the highlighter auto-detects instead.
-String? _langFromPath(String path) {
-  final slash = path.lastIndexOf('/');
-  final name = (slash >= 0 ? path.substring(slash + 1) : path).toLowerCase();
-  final dot = name.lastIndexOf('.');
-  final key = dot > 0 ? name.substring(dot + 1) : name;
-  return _extLang[key];
-}
-
-const _extLang = <String, String>{
-  'dart': 'dart',
-  'go': 'go',
-  'py': 'python',
-  'pyi': 'python',
-  'js': 'javascript',
-  'mjs': 'javascript',
-  'cjs': 'javascript',
-  'jsx': 'javascript',
-  'ts': 'typescript',
-  'tsx': 'typescript',
-  'json': 'json',
-  'yaml': 'yaml',
-  'yml': 'yaml',
-  'toml': 'ini',
-  'ini': 'ini',
-  'cfg': 'ini',
-  'sh': 'bash',
-  'bash': 'bash',
-  'zsh': 'bash',
-  'rs': 'rust',
-  'md': 'markdown',
-  'markdown': 'markdown',
-  'html': 'xml',
-  'htm': 'xml',
-  'xml': 'xml',
-  'svg': 'xml',
-  'css': 'css',
-  'scss': 'scss',
-  'less': 'less',
-  'java': 'java',
-  'kt': 'kotlin',
-  'kts': 'kotlin',
-  'swift': 'swift',
-  'c': 'c',
-  'h': 'c',
-  'cpp': 'cpp',
-  'cc': 'cpp',
-  'cxx': 'cpp',
-  'hpp': 'cpp',
-  'hh': 'cpp',
-  'cs': 'csharp',
-  'rb': 'ruby',
-  'php': 'php',
-  'sql': 'sql',
-  'lua': 'lua',
-  'r': 'r',
-  'scala': 'scala',
-  'pl': 'perl',
-  'pm': 'perl',
-  'ex': 'elixir',
-  'exs': 'elixir',
-  'erl': 'erlang',
-  'clj': 'clojure',
-  'hs': 'haskell',
-  'ml': 'ocaml',
-  'proto': 'protobuf',
-  'graphql': 'graphql',
-  'gql': 'graphql',
-  'makefile': 'makefile',
-  'dockerfile': 'dockerfile',
-};
 
 Widget _grep(Item it) {
   final m = _input(it);

--- a/app/lib/ui/tool_detail_antigravity.dart
+++ b/app/lib/ui/tool_detail_antigravity.dart
@@ -343,7 +343,7 @@ Widget agyWriteToFileDetail(Item it) {
       Text('● $path${overwrite ? '  (overwrite)' : ''}',
           style: _mono.copyWith(color: AppColors.dim)),
     if (code.isNotEmpty)
-      diffView('', code)
+      diffView('', code, lang: path)
     else if ((it.toolInput ?? '').isNotEmpty)
       codeBlock(it.toolInput!),
   ];
@@ -379,7 +379,8 @@ Widget _replaceDetail(Item it, {required bool multi}) {
             style: _mono.copyWith(color: AppColors.dim)),
       ));
       children.add(diffView(toolInputStr(c['TargetContent']),
-          toolInputStr(c['ReplacementContent'])));
+          toolInputStr(c['ReplacementContent']),
+          lang: path));
     }
     if (chunks.isEmpty && (it.toolInput ?? '').isNotEmpty) {
       children.add(codeBlock(it.toolInput!));
@@ -394,7 +395,7 @@ Widget _replaceDetail(Item it, {required bool multi}) {
     final target = toolInputStr(m['TargetContent']);
     final replacement = toolInputStr(m['ReplacementContent']);
     if (target.isNotEmpty || replacement.isNotEmpty) {
-      children.add(diffView(target, replacement));
+      children.add(diffView(target, replacement, lang: path));
     } else if ((it.toolInput ?? '').isNotEmpty) {
       children.add(codeBlock(it.toolInput!));
     }

--- a/app/test/models/changes_test.dart
+++ b/app/test/models/changes_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:argus/models/changes.dart';
+
+void main() {
+  test('CommitList.fromJson parses commits and unpushed flag', () {
+    final list = CommitList.fromJson({
+      'unpushed': true,
+      'commits': [
+        {
+          'sha': 'abc123',
+          'short': 'abc123',
+          'subject': 'do a thing',
+          'author': 'Munif',
+          'unix_sec': 1700000000,
+        },
+      ],
+    });
+    expect(list.unpushed, isTrue);
+    expect(list.commits, hasLength(1));
+    expect(list.commits.first.subject, 'do a thing');
+    expect(list.commits.first.unixSec, 1700000000);
+  });
+
+  test('CommitList.fromJson tolerates missing fields', () {
+    final list = CommitList.fromJson({'commits': []});
+    expect(list.unpushed, isFalse);
+    expect(list.commits, isEmpty);
+  });
+}

--- a/app/test/ui/collapsible_diff_test.dart
+++ b/app/test/ui/collapsible_diff_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:argus/ui/edit_diff.dart';
+
+// The diff scrolls its own content and pins its header, so it needs a
+// bounded-height parent (the Scaffold body) rather than an outer scroll view.
+Widget _wrap(String oldS, String newS) => MaterialApp(
+      home: Scaffold(body: collapsibleDiffView(oldS, newS)),
+    );
+
+// Mirrors the review screen: a static line above a Flexible diff, so a short
+// diff stays compact and a long one caps at the viewport.
+Widget _screen(String oldS, String newS) => MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            const Text('header'),
+            Flexible(child: collapsibleDiffView(oldS, newS)),
+          ],
+        ),
+      ),
+    );
+
+// Height of the outer vertical scroller wrapping the diff rows.
+double _scrollerHeight(WidgetTester tester) =>
+    tester.getSize(find.byType(SingleChildScrollView).first).height;
+
+void main() {
+  testWidgets('folds far context, shows the change, expands on demand',
+      (tester) async {
+    // 20 unchanged lines, then a one-line change at the bottom.
+    final ctx = List.generate(20, (i) => 'l$i').join('\n');
+    await tester.pumpWidget(_wrap('$ctx\nold\n', '$ctx\nnew\n'));
+
+    // The change and its nearby context are visible…
+    expect(find.textContaining('- old'), findsOneWidget);
+    expect(find.textContaining('+ new'), findsOneWidget);
+    expect(find.textContaining('l19'), findsOneWidget); // within 3 of change
+    // …while far context is folded behind an expand bar.
+    expect(find.textContaining('Expand'), findsOneWidget);
+    expect(find.textContaining('l0\n'), findsNothing);
+    expect(find.text('  l0'), findsNothing);
+
+    // Expand all reveals the whole file.
+    await tester.tap(find.byIcon(Icons.unfold_more));
+    await tester.pump();
+    expect(find.textContaining('l0'), findsWidgets);
+    expect(find.textContaining('Expand'), findsNothing);
+  });
+
+  testWidgets('tapping an expand bar reveals the whole folded run',
+      (tester) async {
+    final ctx = List.generate(20, (i) => 'l$i').join('\n');
+    await tester.pumpWidget(_wrap('$ctx\nold\n', '$ctx\nnew\n'));
+
+    // 17 lines (l0..l16) are folded; l17..l19 stay as context near the change.
+    expect(find.textContaining('Expand 17 unchanged lines'), findsOneWidget);
+
+    await tester.tap(find.textContaining('Expand'));
+    await tester.pump();
+
+    // One tap reveals the entire run, not a single line, and leaves no bar.
+    expect(find.text('  l0'), findsOneWidget);
+    expect(find.text('  l16'), findsOneWidget);
+    expect(find.textContaining('Expand'), findsNothing);
+  });
+
+  testWidgets('empty old side renders an all-additions view', (tester) async {
+    await tester.pumpWidget(_wrap('', 'a\nb\nc\n'));
+    expect(find.textContaining('+ a'), findsOneWidget);
+    expect(find.textContaining('+ b'), findsOneWidget);
+    expect(find.textContaining('+ c'), findsOneWidget);
+    expect(find.textContaining('Expand'), findsNothing);
+  });
+
+  testWidgets('empty new side renders an all-deletions view', (tester) async {
+    await tester.pumpWidget(_wrap('x\ny\n', ''));
+    expect(find.textContaining('- x'), findsOneWidget);
+    expect(find.textContaining('- y'), findsOneWidget);
+  });
+
+  testWidgets('a short diff stays compact instead of filling the viewport',
+      (tester) async {
+    // Two rows in an 800×600 test surface: the scroller hugs its content.
+    await tester.pumpWidget(_screen('a', 'b'));
+    expect(_scrollerHeight(tester), lessThan(200));
+  });
+
+  testWidgets('a tall diff caps at the viewport and scrolls', (tester) async {
+    final many = List.generate(200, (i) => 'x$i').join('\n');
+    await tester.pumpWidget(_screen('', '$many\n'));
+    // Capped near the available height rather than the ~3000px of content.
+    expect(_scrollerHeight(tester), greaterThan(300));
+    expect(_scrollerHeight(tester), lessThan(600));
+  });
+
+  testWidgets('a leading fold (change at the bottom) points up', (tester) async {
+    final ctx = List.generate(20, (i) => 'l$i').join('\n');
+    await tester.pumpWidget(_wrap('$ctx\nold\n', '$ctx\nnew\n'));
+    expect(find.byIcon(Icons.keyboard_double_arrow_up), findsOneWidget);
+    expect(find.byIcon(Icons.keyboard_double_arrow_down), findsNothing);
+    expect(find.byIcon(Icons.height), findsNothing);
+  });
+
+  testWidgets('a trailing fold (change at the top) points down', (tester) async {
+    final ctx = List.generate(20, (i) => 'l$i').join('\n');
+    await tester.pumpWidget(_wrap('old\n$ctx\n', 'new\n$ctx\n'));
+    expect(find.byIcon(Icons.keyboard_double_arrow_down), findsOneWidget);
+    expect(find.byIcon(Icons.keyboard_double_arrow_up), findsNothing);
+    expect(find.byIcon(Icons.height), findsNothing);
+  });
+
+  testWidgets('a fold between two changes points both ways', (tester) async {
+    final mid = List.generate(20, (i) => 'm$i').join('\n');
+    await tester.pumpWidget(_wrap(
+      'a\nb\nc\nold1\n$mid\nold2\nx\ny\nz\n',
+      'a\nb\nc\nnew1\n$mid\nnew2\nx\ny\nz\n',
+    ));
+    expect(find.byIcon(Icons.height), findsOneWidget);
+    expect(find.byIcon(Icons.keyboard_double_arrow_up), findsNothing);
+    expect(find.byIcon(Icons.keyboard_double_arrow_down), findsNothing);
+  });
+
+  testWidgets('a middle fold anchors the row above it (fills downward)',
+      (tester) async {
+    final mid =
+        List.generate(25, (i) => 'mid${i.toString().padLeft(2, '0')}').join('\n');
+    // Tail changes keep the content overflowing so scrolling actually matters.
+    final tailOld = List.generate(40, (i) => 'ta$i').join('\n');
+    final tailNew = List.generate(40, (i) => 'tb$i').join('\n');
+    await tester.pumpWidget(_screen(
+      'a\nb\nc\nold1\n$mid\nold2\n$tailOld\n',
+      'a\nb\nc\nnew1\n$mid\nnew2\n$tailNew\n',
+    ));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.height), findsOneWidget);
+    final before = tester.getTopLeft(find.textContaining('mid02')).dy;
+
+    await tester.tap(find.byIcon(Icons.height));
+    await tester.pumpAndSettle();
+
+    // The row above the fold stays put; the revealed lines fill downward.
+    final after = tester.getTopLeft(find.textContaining('mid02')).dy;
+    expect(after, closeTo(before, 2.0));
+  });
+
+  testWidgets('expanding an upward run anchors the viewport, not the file top',
+      (tester) async {
+    final before = List.generate(40, (i) => 'c$i').join('\n');
+    final after = List.generate(10, (i) => 't$i').join('\n');
+    await tester.pumpWidget(
+        _screen('$before\nold\n$after\n', '$before\nnew\n$after\n'));
+    await tester.pump();
+
+    double offset() =>
+        tester.state<ScrollableState>(find.byType(Scrollable).first)
+            .position
+            .pixels;
+
+    // The change is visible and the top run is folded; nothing has scrolled.
+    expect(offset(), 0);
+    expect(find.textContaining('+ new'), findsOneWidget);
+
+    // Reveal the folded lines above the change (the first of the two fold bars).
+    await tester.tap(find.textContaining('Expand').first);
+    await tester.pumpAndSettle();
+
+    // We scrolled down to keep the change in view instead of snapping to c0.
+    expect(offset(), greaterThan(0));
+    expect(find.textContaining('+ new'), findsOneWidget);
+  });
+
+  testWidgets('expand-to-top keeps the row below the bar exactly in place',
+      (tester) async {
+    // A foldable head, then enough changed lines to fill (and overflow) the
+    // viewport, so the top fold bar sits at the very top with l17 just below it.
+    final lead = List.generate(20, (i) => 'l$i').join('\n');
+    final olds = List.generate(60, (i) => 'old$i').join('\n');
+    final news = List.generate(60, (i) => 'new$i').join('\n');
+    await tester.pumpWidget(_screen('$lead\n$olds\n', '$lead\n$news\n'));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.keyboard_double_arrow_up), findsOneWidget);
+    final before = tester.getTopLeft(find.textContaining('l17')).dy;
+
+    await tester.tap(find.byIcon(Icons.keyboard_double_arrow_up));
+    await tester.pumpAndSettle();
+
+    // l17 must not shift: the revealed lines fill upward into the bar's slot,
+    // rather than l17 jumping up to where the bar was.
+    final after = tester.getTopLeft(find.textContaining('l17')).dy;
+    expect(after, closeTo(before, 2.0));
+  });
+}

--- a/app/test/ui/commits_section_test.dart
+++ b/app/test/ui/commits_section_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:argus/models/changes.dart';
+import 'package:argus/models/session.dart';
+import 'package:argus/state/changes.dart';
+import 'package:argus/ui/changed_files_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Session _session() => Session.fromJson(
+      jsonDecode(jsonEncode({
+        'id': 'n1:s1',
+        'agent': 'claude',
+        'status': 'active',
+        'source': 'hooked',
+        'repo': 'my-repo',
+        'tmux': {
+          'server': 'argus',
+          'pane_id': '%1',
+          'session_name': 's',
+          'window_index': 0,
+          'current_path': '/p',
+        },
+      })) as Map<String, dynamic>,
+    );
+
+void main() {
+  testWidgets('renders the unpushed commits section and taps into a commit',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          changedFilesProvider(_session().id)
+              .overrideWith((ref) async => <ChangedFile>[]),
+          commitsProvider(_session().id).overrideWith(
+            (ref) async => const CommitList(
+              unpushed: true,
+              commits: [
+                Commit(
+                  sha: 'deadbeef',
+                  short: 'deadbee',
+                  subject: 'add commit browser',
+                  author: 'Munif',
+                  unixSec: 1700000000,
+                ),
+              ],
+            ),
+          ),
+          commitFilesProvider((_session().id, 'deadbeef'))
+              .overrideWith((ref) async => <ChangedFile>[]),
+        ],
+        child: MaterialApp(home: ChangedFilesScreen(session: _session())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('UNPUSHED'), findsOneWidget);
+    expect(find.text('deadbee'), findsOneWidget);
+    expect(find.text('add commit browser'), findsOneWidget);
+
+    await tester.tap(find.text('add commit browser'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('deadbee  add commit browser'), findsOneWidget);
+    expect(find.text('No files in this commit.'), findsOneWidget);
+  });
+
+  testWidgets('tapping the hash copies the full SHA instead of navigating',
+      (tester) async {
+    final clipboard = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboard.add((call.arguments as Map)['text'] as String);
+        }
+        return null;
+      },
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          changedFilesProvider(_session().id)
+              .overrideWith((ref) async => <ChangedFile>[]),
+          commitsProvider(_session().id).overrideWith(
+            (ref) async => const CommitList(
+              unpushed: true,
+              commits: [
+                Commit(
+                  sha: 'deadbeefcafe',
+                  short: 'deadbee',
+                  subject: 'add commit browser',
+                  author: 'Munif',
+                  unixSec: 1700000000,
+                ),
+              ],
+            ),
+          ),
+        ],
+        child: MaterialApp(home: ChangedFilesScreen(session: _session())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.copy));
+    await tester.pumpAndSettle();
+
+    // Copied the full SHA, and stayed on the list (no navigation to detail).
+    expect(clipboard, ['deadbeefcafe']);
+    expect(find.text('add commit browser'), findsOneWidget);
+    expect(find.text('No files in this commit.'), findsNothing);
+  });
+}

--- a/app/test/ui/edit_diff_test.dart
+++ b/app/test/ui/edit_diff_test.dart
@@ -5,6 +5,10 @@ import 'package:argus/ui/edit_diff.dart';
 
 Widget _wrap(Item i) => MaterialApp(home: Scaffold(body: editDiffView(i)));
 
+Widget _wrapDiff(String oldS, String newS) => MaterialApp(
+    home: Scaffold(
+        body: SingleChildScrollView(child: diffView(oldS, newS))));
+
 void main() {
   testWidgets('Edit shows path, old and new', (tester) async {
     await tester.pumpWidget(_wrap(const Item(
@@ -83,5 +87,75 @@ void main() {
     expect(find.text('1'), findsOneWidget);
     expect(find.text('2'), findsOneWidget);
     expect(find.text('3'), findsOneWidget);
+  });
+
+  // The faint per-row tints marking add/removed lines.
+  final greenTint = const Color(0xFFb8bb26).withValues(alpha: 0.10);
+  final redTint = const Color(0xFFfb4934).withValues(alpha: 0.10);
+  Finder tinted(Color c) =>
+      find.byWidgetPredicate((w) => w is ColoredBox && w.color == c);
+
+  testWidgets('highlighted rows carry a green/red tint by add/del',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const Item(
+        id: 'i',
+        kind: ItemKind.tool,
+        toolName: 'Edit',
+        toolInput:
+            '{"file_path":"/a.dart","old_string":"x","new_string":"y"}')));
+    // Line-number view lays each row out with a full-width tinted background.
+    await tester.tap(find.byIcon(Icons.format_list_numbered));
+    await tester.pump();
+    expect(tinted(redTint), findsOneWidget); // "- x"
+    expect(tinted(greenTint), findsOneWidget); // "+ y"
+  });
+
+  testWidgets('disabling highlight drops the row tints', (tester) async {
+    await tester.pumpWidget(_wrap(const Item(
+        id: 'i',
+        kind: ItemKind.tool,
+        toolName: 'Edit',
+        toolInput:
+            '{"file_path":"/a.dart","old_string":"x","new_string":"y"}')));
+    await tester.tap(find.byIcon(Icons.format_list_numbered));
+    await tester.pump();
+    expect(tinted(redTint), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.format_color_reset));
+    await tester.pump();
+    expect(tinted(redTint), findsNothing);
+    expect(tinted(greenTint), findsNothing);
+  });
+
+  group('trailing newline and CRLF fidelity', () {
+    testWidgets('removing the final newline is shown, not swallowed',
+        (tester) async {
+      await tester.pumpWidget(_wrapDiff('foo\n', 'foo'));
+      // The change is now visible (last line re-diffed) with git's marker.
+      expect(find.textContaining('No newline at end of file'), findsOneWidget);
+      expect(find.textContaining('- foo'), findsOneWidget);
+      expect(find.textContaining('+ foo'), findsOneWidget);
+    });
+
+    testWidgets('adding a final newline is shown', (tester) async {
+      await tester.pumpWidget(_wrapDiff('foo', 'foo\n'));
+      expect(find.textContaining('No newline at end of file'), findsOneWidget);
+    });
+
+    testWidgets('a trailing-newline change touches only the last line',
+        (tester) async {
+      await tester.pumpWidget(_wrapDiff('a\nb', 'a\nb\n'));
+      // "a" stays shared context; only "b" is re-diffed for its newline.
+      expect(find.textContaining('- b'), findsOneWidget);
+      expect(find.textContaining('+ b'), findsOneWidget);
+      expect(find.textContaining('- a'), findsNothing);
+    });
+
+    testWidgets('CRLF vs LF with identical content shows no changes',
+        (tester) async {
+      await tester.pumpWidget(_wrapDiff('a\nb\n', 'a\r\nb\r\n'));
+      expect(find.textContaining('- '), findsNothing);
+      expect(find.textContaining('+ '), findsNothing);
+      expect(find.textContaining('No newline at end of file'), findsNothing);
+    });
   });
 }

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -74,7 +74,67 @@ const (
 	MethodPushVAPIDKey  = "push.vapidKey"         // request: no params; result: PushVAPIDKey
 	MethodPushDesktop   = "push.desktop"          // request: push.Notification; result: nil (render on node if opted in)
 	MethodSessionExport = "sessions.exportBundle" // request: ExportBundleParams; result: ExportBundleResult
+	// Changed-files review for a live session's working directory (vs HEAD).
+	MethodSessionChangedFiles = "sessions.changedFiles" // request: SessionRef; result: ChangedFilesResult
+	MethodSessionFileDiff     = "sessions.fileDiff"     // request: FileDiffParams; result: FileDiffResult
+	MethodSessionCommits      = "sessions.commits"      // request: SessionRef; result: CommitsResult
+	MethodSessionCommitFiles  = "sessions.commitFiles"  // request: CommitFilesParams; result: ChangedFilesResult
 )
+
+// ChangedFile is one entry in a session working directory's git status.
+type ChangedFile struct {
+	Path     string `json:"path"`                // current (working-tree) path
+	OrigPath string `json:"orig_path,omitempty"` // rename source (HEAD-side), else ""
+	Change   string `json:"change"`              // added|modified|deleted|renamed|untracked
+	Staged   bool   `json:"staged"`              // index differs from HEAD
+	Unstaged bool   `json:"unstaged,omitempty"`  // working tree differs from index
+}
+
+// ChangedFilesResult lists everything git status reports for the session's repo.
+type ChangedFilesResult struct {
+	Root  string        `json:"root,omitempty"` // repo top-level (for display)
+	Files []ChangedFile `json:"files"`
+}
+
+// Commit is one entry in a session's branch/unpushed commit log.
+type Commit struct {
+	SHA     string `json:"sha"`
+	Short   string `json:"short"`
+	Subject string `json:"subject"`
+	Author  string `json:"author"`
+	UnixSec int64  `json:"unix_sec"` // authored time; client formats
+}
+
+// CommitsResult carries the commit list. Unpushed is true when the scope is
+// unpushed-vs-remote.
+type CommitsResult struct {
+	Commits  []Commit `json:"commits"`
+	Unpushed bool     `json:"unpushed,omitempty"`
+}
+
+// CommitFilesParams selects one commit in a session's repo.
+type CommitFilesParams struct {
+	SessionID string `json:"session_id"`
+	SHA       string `json:"sha"`
+}
+
+// FileDiffParams selects one changed file in a session's working directory.
+type FileDiffParams struct {
+	SessionID string `json:"session_id"`
+	Path      string `json:"path"`
+	OrigPath  string `json:"orig_path,omitempty"` // rename source, so the old side resolves
+	Rev       string `json:"rev,omitempty"`       // commit sha; empty = HEAD vs worktree
+}
+
+// FileDiffResult carries a changed file's HEAD (old) and working-tree (new)
+// content. Either side is "" when absent; NotShown (both empty) marks binary or
+// oversized files.
+type FileDiffResult struct {
+	Path       string `json:"path"`
+	OldContent string `json:"old_content,omitempty"`
+	NewContent string `json:"new_content,omitempty"`
+	NotShown   bool   `json:"not_shown,omitempty"`
+}
 
 // ExportBundleParams selects a session to export. Metadata is supplied by the
 // client (what it already displays) and written verbatim into the manifest.

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -30,6 +30,10 @@ var clientRoutedMethods = []string{
 	api.MethodSessionKey,
 	api.MethodSessionRespond,
 	api.MethodSessionKill,
+	api.MethodSessionChangedFiles,
+	api.MethodSessionFileDiff,
+	api.MethodSessionCommits,
+	api.MethodSessionCommitFiles,
 }
 
 // subEntry records a client's transcript subscription for routing delta notifications.

--- a/internal/gitstatus/gitstatus.go
+++ b/internal/gitstatus/gitstatus.go
@@ -1,0 +1,401 @@
+// Package gitstatus reports a working tree's changes against HEAD and fetches a
+// single changed file's HEAD and working-tree content for review from the app.
+package gitstatus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/MunifTanjim/argus/internal/shell"
+)
+
+// maxContentBytes caps each side of a file returned for review; larger files are
+// reported as not-shown rather than shipped over the wire.
+const maxContentBytes = 1 << 20 // 1 MiB
+
+// ChangeType is the net change of a file relative to HEAD.
+type ChangeType string
+
+const (
+	ChangeAdded     ChangeType = "added"
+	ChangeModified  ChangeType = "modified"
+	ChangeDeleted   ChangeType = "deleted"
+	ChangeRenamed   ChangeType = "renamed"
+	ChangeUntracked ChangeType = "untracked"
+)
+
+// ChangedFile is one entry from `git status`.
+type ChangedFile struct {
+	Path     string     // current (working-tree) path
+	OrigPath string     // rename/copy source (HEAD-side path), else ""
+	Change   ChangeType // net change vs HEAD
+	Staged   bool       // true when the index differs from HEAD for this path (X)
+	Unstaged bool       // true when the working tree differs from the index (Y)
+}
+
+// ChangedFiles returns the repo root containing dir and every file that differs
+// from HEAD — staged, unstaged, or untracked. It errors when dir is empty or not
+// inside a git repository.
+func ChangedFiles(ctx context.Context, dir string) (root string, files []ChangedFile, err error) {
+	root, err = repoRoot(ctx, dir)
+	if err != nil {
+		return "", nil, err
+	}
+	// -z: NUL-terminated records with no path quoting (safe for spaces/unicode).
+	// --untracked-files=all: list individual untracked files, not just their dir.
+	cmd := shell.NewCommandContext(ctx, "git", "-C", root,
+		"status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err := cmd.Run(); err != nil {
+		return "", nil, fmt.Errorf("gitstatus: git status failed in %s: %w", root, err)
+	}
+	return root, parsePorcelainZ(cmd.StdOut().String()), nil
+}
+
+// parsePorcelainZ parses the NUL-separated output of `git status --porcelain=v1 -z`.
+// Each record is "XY PATH"; rename/copy records (X == 'R'/'C') are followed by a
+// second token holding the original (HEAD-side) path.
+func parsePorcelainZ(out string) []ChangedFile {
+	tokens := strings.Split(out, "\x00")
+	var files []ChangedFile
+	for i := 0; i < len(tokens); i++ {
+		rec := tokens[i]
+		if len(rec) < 4 { // need at least "XY " + 1-char path; trailing "" is skipped
+			continue
+		}
+		x, y := rec[0], rec[1]
+		cf := ChangedFile{
+			Path:     rec[3:],
+			Staged:   x != ' ' && x != '?',
+			Unstaged: y != ' ' && y != '?', // worktree differs from index
+		}
+		switch {
+		case x == '?' && y == '?':
+			cf.Change = ChangeUntracked
+		case x == 'R' || x == 'C':
+			cf.Change = ChangeRenamed
+			// The destination path is in this record; the original is the next token.
+			if i+1 < len(tokens) {
+				cf.OrigPath = tokens[i+1]
+				i++
+			}
+		case x == 'D' || y == 'D':
+			cf.Change = ChangeDeleted
+		case x == 'A' || y == 'A':
+			cf.Change = ChangeAdded
+		default:
+			cf.Change = ChangeModified
+		}
+		files = append(files, cf)
+	}
+	return files
+}
+
+// FileContents returns the HEAD version (old) and working-tree version (new) of a
+// changed file for rendering a diff. Either side is "" when it does not exist:
+// untracked/added → old ""; deleted → new ""; empty repo (no HEAD) → old "".
+// notShown is true when either side is binary (contains a NUL byte) or exceeds the
+// size cap, in which case both contents are returned empty.
+func FileContents(ctx context.Context, dir, path, origPath string) (old, new string, notShown bool, err error) {
+	root, err := repoRoot(ctx, dir)
+	if err != nil {
+		return "", "", false, err
+	}
+	headPath := path
+	if origPath != "" {
+		headPath = origPath // rename: HEAD holds the source path
+	}
+	workPath, err := repoRelPath(root, path)
+	if err != nil {
+		return "", "", false, err
+	}
+	// Lstat, not Stat: a changed file may be a symlink. repoRelPath only checks the
+	// path lexically, so following a symlink here (via Stat/ReadFile) could read a
+	// file outside the repo. Match git instead — a symlink's blob is its target
+	// text — by reading the link itself.
+	fi, serr := os.Lstat(workPath)
+	symlink := serr == nil && fi.Mode()&os.ModeSymlink != 0
+	if serr == nil && !symlink && fi.Size() > maxContentBytes {
+		return "", "", true, nil // skip reading an oversized working file into memory
+	}
+	old, oversize, err := gitShowRev(ctx, root, "HEAD", headPath)
+	if err != nil {
+		return "", "", false, err
+	}
+	if oversize {
+		return "", "", true, nil
+	}
+	if symlink {
+		if target, lerr := os.Readlink(workPath); lerr == nil {
+			new = target
+		}
+	} else if b, rerr := os.ReadFile(workPath); rerr == nil {
+		new = string(b)
+	}
+	if isBinary(old) || isBinary(new) || len(new) > maxContentBytes {
+		return "", "", true, nil
+	}
+	return old, new, false, nil
+}
+
+// gitShowRev returns the content of a repo-relative path at a git rev. content is
+// "" when the path is absent at that rev (or the rev/parent does not exist);
+// oversize is true when the blob exceeds the size cap, so it is never read into
+// memory. A context error (cancellation/timeout) is surfaced rather than masked as
+// an absent path.
+func gitShowRev(ctx context.Context, root, rev, path string) (content string, oversize bool, err error) {
+	spec := rev + ":" + path
+	sz := shell.NewCommandContext(ctx, "git", "-C", root, "cat-file", "-s", spec)
+	if err := sz.Run(); err != nil {
+		if ctx.Err() != nil {
+			return "", false, ctx.Err()
+		}
+		return "", false, nil // absent at rev
+	}
+	if n, perr := strconv.ParseInt(sz.StdOut().TrimSpace().String(), 10, 64); perr == nil && n > maxContentBytes {
+		return "", true, nil
+	}
+	cmd := shell.NewCommandContext(ctx, "git", "-C", root, "show", spec)
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return "", false, ctx.Err()
+		}
+		return "", false, nil
+	}
+	return cmd.StdOut().String(), false, nil
+}
+
+// repoRelPath joins a client-supplied repo-relative path onto root, rejecting any
+// path that escapes the repo (e.g. via "..").
+func repoRelPath(root, path string) (string, error) {
+	full := filepath.Join(root, filepath.FromSlash(path))
+	rel, err := filepath.Rel(root, full)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("gitstatus: path escapes repo: %s", path)
+	}
+	return full, nil
+}
+
+// repoRoot resolves the top-level directory of the repo containing dir so every
+// git command and working-file read uses consistent repo-root-relative paths.
+func repoRoot(ctx context.Context, dir string) (string, error) {
+	if dir == "" {
+		return "", errors.New("gitstatus: empty working directory")
+	}
+	cmd := shell.NewCommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel")
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gitstatus: not a git repository: %s", dir)
+	}
+	return cmd.StdOut().TrimSpace().String(), nil
+}
+
+// isBinary uses git's own heuristic: a NUL byte means treat as binary.
+func isBinary(s string) bool {
+	return strings.IndexByte(s, 0) >= 0
+}
+
+// isHexSHA reports whether s is a plausible git object name: 4–64 hex digits.
+// Client-supplied revs are checked against this before reaching git so they can
+// never be parsed as options (e.g. "--output=FILE").
+func isHexSHA(s string) bool {
+	if len(s) < 4 || len(s) > 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+// Commit is one entry in the branch/unpushed commit log.
+type Commit struct {
+	SHA     string
+	Short   string
+	Subject string
+	Author  string
+	UnixSec int64 // authored time
+}
+
+// CommitLog is the commit list plus whether its scope is unpushed-vs-remote.
+type CommitLog struct {
+	Commits  []Commit
+	Unpushed bool
+}
+
+// Commits lists commits reachable from HEAD but not from the base ref, newest
+// first, excluding merges. The base prefers the remote default branch (so the list
+// is "work not yet on the remote"), falling back to a local main/master. Unpushed
+// is true when a remote base ref was used. An empty range yields no commits, no
+// error.
+func Commits(ctx context.Context, dir string) (CommitLog, error) {
+	root, err := repoRoot(ctx, dir)
+	if err != nil {
+		return CommitLog{}, err
+	}
+	base, unpushed := baseRef(ctx, root)
+	if base == "" {
+		return CommitLog{}, nil
+	}
+	mb := mergeBase(ctx, root, base)
+	if mb == "" {
+		return CommitLog{}, nil
+	}
+	const sep = "\x1f"
+	format := strings.Join([]string{"%H", "%h", "%s", "%an", "%at"}, sep)
+	cmd := shell.NewCommandContext(ctx, "git", "-C", root,
+		"log", "--no-merges", "--format="+format, mb+"..HEAD")
+	if err := cmd.Run(); err != nil {
+		return CommitLog{}, fmt.Errorf("gitstatus: git log failed in %s: %w", root, err)
+	}
+	return CommitLog{Commits: parseCommitLog(cmd.StdOut().String(), sep), Unpushed: unpushed}, nil
+}
+
+func parseCommitLog(out, sep string) []Commit {
+	var commits []Commit
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		f := strings.Split(line, sep)
+		if len(f) != 5 {
+			continue
+		}
+		unix, _ := strconv.ParseInt(f[4], 10, 64)
+		commits = append(commits, Commit{
+			SHA: f[0], Short: f[1], Subject: f[2], Author: f[3], UnixSec: unix,
+		})
+	}
+	return commits
+}
+
+// baseRef resolves the ref to compare HEAD against and whether it is a remote ref
+// (remote → the commit list represents unpushed work).
+func baseRef(ctx context.Context, root string) (ref string, remote bool) {
+	for _, r := range []string{"origin/HEAD", "origin/main", "origin/master"} {
+		if revExists(ctx, root, r) {
+			return r, true
+		}
+	}
+	for _, r := range []string{"main", "master"} {
+		if revExists(ctx, root, r) {
+			return r, false
+		}
+	}
+	return "", false
+}
+
+func revExists(ctx context.Context, root, ref string) bool {
+	cmd := shell.NewCommandContext(ctx, "git", "-C", root,
+		"rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	return cmd.Run() == nil
+}
+
+func mergeBase(ctx context.Context, root, base string) string {
+	cmd := shell.NewCommandContext(ctx, "git", "-C", root, "merge-base", base, "HEAD")
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return cmd.StdOut().TrimSpace().String()
+}
+
+// CommitFiles lists the files a commit changed relative to its first parent, or —
+// for the root commit — everything it introduced.
+func CommitFiles(ctx context.Context, dir, sha string) ([]ChangedFile, error) {
+	if !isHexSHA(sha) {
+		return nil, fmt.Errorf("gitstatus: invalid commit sha: %q", sha)
+	}
+	root, err := repoRoot(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	// isHexSHA above guarantees sha is pure hex, so it can never be read as an
+	// option (e.g. "--output=FILE") — no --end-of-options guard needed.
+	cmd := shell.NewCommandContext(ctx, "git", "-C", root,
+		"diff-tree", "--no-commit-id", "--name-status", "-r", "-M", "--root", "-z", sha)
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gitstatus: git diff-tree failed: %w", err)
+	}
+	return parseNameStatusZ(cmd.StdOut().String()), nil
+}
+
+// parseNameStatusZ parses NUL-separated `git diff-tree --name-status -z` records.
+// A record is "STATUS\0PATH"; a rename/copy (R/C) is "STATUS\0SRC\0DST".
+func parseNameStatusZ(out string) []ChangedFile {
+	tokens := strings.Split(out, "\x00")
+	var files []ChangedFile
+	for i := 0; i+1 < len(tokens); {
+		status := tokens[i]
+		if status == "" {
+			i++
+			continue
+		}
+		if c := status[0]; c == 'R' || c == 'C' {
+			if i+2 >= len(tokens) {
+				break
+			}
+			files = append(files, ChangedFile{
+				Change:   ChangeRenamed,
+				OrigPath: tokens[i+1],
+				Path:     tokens[i+2],
+			})
+			i += 3
+			continue
+		}
+		files = append(files, ChangedFile{
+			Change: changeFromCode(status[0]),
+			Path:   tokens[i+1],
+		})
+		i += 2
+	}
+	return files
+}
+
+func changeFromCode(c byte) ChangeType {
+	switch c {
+	case 'A':
+		return ChangeAdded
+	case 'D':
+		return ChangeDeleted
+	default:
+		return ChangeModified
+	}
+}
+
+// CommitFileContents returns a file's content before (parent) and after a commit,
+// for rendering that commit's diff. old is "" for an added file or the root
+// commit; new is "" for a deleted file; notShown marks binary or oversized files.
+func CommitFileContents(ctx context.Context, dir, sha, path, origPath string) (old, new string, notShown bool, err error) {
+	if !isHexSHA(sha) {
+		return "", "", false, fmt.Errorf("gitstatus: invalid commit sha: %q", sha)
+	}
+	root, err := repoRoot(ctx, dir)
+	if err != nil {
+		return "", "", false, err
+	}
+	oldPath := path
+	if origPath != "" {
+		oldPath = origPath
+	}
+	var oversize bool
+	if old, oversize, err = gitShowRev(ctx, root, sha+"^", oldPath); err != nil {
+		return "", "", false, err
+	} else if oversize {
+		return "", "", true, nil
+	}
+	if new, oversize, err = gitShowRev(ctx, root, sha, path); err != nil {
+		return "", "", false, err
+	} else if oversize {
+		return "", "", true, nil
+	}
+	if isBinary(old) || isBinary(new) {
+		return "", "", true, nil
+	}
+	return old, new, false, nil
+}

--- a/internal/gitstatus/gitstatus_test.go
+++ b/internal/gitstatus/gitstatus_test.go
@@ -1,0 +1,588 @@
+package gitstatus
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- pure parser unit test (deterministic, no git) ---
+
+func TestParsePorcelainZ(t *testing.T) {
+	// A rename record ("R  <dest>") is followed by a NUL token with the source.
+	// Then an unstaged modify, a staged add, an AM (staged add + later modify),
+	// an untracked file, and a path containing a space.
+	out := "R  dst name\x00src name\x00 M mod.txt\x00A  added.go\x00AM both.go\x00?? unt.txt\x00?? with space.txt\x00"
+	files := parsePorcelainZ(out)
+
+	byPath := map[string]ChangedFile{}
+	for _, f := range files {
+		byPath[f.Path] = f
+	}
+	if len(files) != 6 {
+		t.Fatalf("got %d files, want 6: %+v", len(files), files)
+	}
+
+	if f := byPath["dst name"]; f.Change != ChangeRenamed || f.OrigPath != "src name" || !f.Staged {
+		t.Errorf("rename: got %+v", f)
+	}
+	if f := byPath["mod.txt"]; f.Change != ChangeModified || f.Staged || !f.Unstaged {
+		t.Errorf("unstaged modify: got %+v", f)
+	}
+	if f := byPath["added.go"]; f.Change != ChangeAdded || !f.Staged || f.Unstaged {
+		t.Errorf("staged add: got %+v", f)
+	}
+	if f := byPath["both.go"]; f.Change != ChangeAdded || !f.Staged || !f.Unstaged {
+		t.Errorf("AM (staged + unstaged): got %+v", f)
+	}
+	if f := byPath["unt.txt"]; f.Change != ChangeUntracked || f.Staged {
+		t.Errorf("untracked: got %+v", f)
+	}
+	if f := byPath["with space.txt"]; f.Change != ChangeUntracked {
+		t.Errorf("space path: got %+v", f)
+	}
+}
+
+// --- integration tests over real temp repos ---
+
+func gitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	p := filepath.Join(dir, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func headSHA(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestChangedFilesIntegration(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+
+	// Committed baseline.
+	write(t, dir, "mod.txt", "one\n")
+	write(t, dir, "del.txt", "gone\n")
+	write(t, dir, "ren_src.txt", "moved\n")
+	write(t, dir, "staged_mod.txt", "base\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	// Working-tree mutations.
+	write(t, dir, "mod.txt", "one\ntwo\n")             // " M" unstaged modify
+	os.Remove(filepath.Join(dir, "del.txt"))           // " D" unstaged delete
+	gitCmd(t, dir, "mv", "ren_src.txt", "ren_dst.txt") // "R " staged rename
+	write(t, dir, "staged_mod.txt", "changed\n")
+	gitCmd(t, dir, "add", "staged_mod.txt") // "M " staged modify
+	write(t, dir, "added.txt", "new\n")
+	gitCmd(t, dir, "add", "added.txt")  // "A " staged add
+	write(t, dir, "unt.txt", "loose\n") // "??" untracked
+
+	root, files, err := ChangedFiles(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root == "" {
+		t.Error("empty root")
+	}
+	byPath := map[string]ChangedFile{}
+	for _, f := range files {
+		byPath[f.Path] = f
+	}
+
+	checks := map[string]ChangeType{
+		"mod.txt":        ChangeModified,
+		"del.txt":        ChangeDeleted,
+		"ren_dst.txt":    ChangeRenamed,
+		"staged_mod.txt": ChangeModified,
+		"added.txt":      ChangeAdded,
+		"unt.txt":        ChangeUntracked,
+	}
+	for path, want := range checks {
+		f, ok := byPath[path]
+		if !ok {
+			t.Errorf("%s missing from status", path)
+			continue
+		}
+		if f.Change != want {
+			t.Errorf("%s: change=%q want %q", path, f.Change, want)
+		}
+	}
+	if f := byPath["ren_dst.txt"]; f.OrigPath != "ren_src.txt" {
+		t.Errorf("rename orig path = %q, want ren_src.txt", f.OrigPath)
+	}
+	if !byPath["staged_mod.txt"].Staged {
+		t.Error("staged_mod.txt should be staged")
+	}
+	if byPath["mod.txt"].Staged {
+		t.Error("mod.txt should not be staged")
+	}
+}
+
+func TestFileContents(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "mod.txt", "one\n")
+	write(t, dir, "del.txt", "gone\n")
+	write(t, dir, "bin.dat", "safe\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	write(t, dir, "mod.txt", "one\ntwo\n")
+	os.Remove(filepath.Join(dir, "del.txt"))
+	write(t, dir, "unt.txt", "loose\n")
+	write(t, dir, "bin.dat", "x\x00y\n") // now contains a NUL
+
+	ctx := context.Background()
+
+	t.Run("modified", func(t *testing.T) {
+		old, nw, ns, err := FileContents(ctx, dir, "mod.txt", "")
+		if err != nil || ns {
+			t.Fatalf("err=%v notShown=%v", err, ns)
+		}
+		if old != "one\n" || nw != "one\ntwo\n" {
+			t.Errorf("old=%q new=%q", old, nw)
+		}
+	})
+	t.Run("untracked", func(t *testing.T) {
+		old, nw, _, err := FileContents(ctx, dir, "unt.txt", "")
+		if err != nil || old != "" || nw != "loose\n" {
+			t.Errorf("old=%q new=%q err=%v", old, nw, err)
+		}
+	})
+	t.Run("deleted", func(t *testing.T) {
+		old, nw, _, err := FileContents(ctx, dir, "del.txt", "")
+		if err != nil || old != "gone\n" || nw != "" {
+			t.Errorf("old=%q new=%q err=%v", old, nw, err)
+		}
+	})
+	t.Run("binary not shown", func(t *testing.T) {
+		old, nw, ns, err := FileContents(ctx, dir, "bin.dat", "")
+		if err != nil || !ns || old != "" || nw != "" {
+			t.Errorf("old=%q new=%q notShown=%v err=%v", old, nw, ns, err)
+		}
+	})
+}
+
+func TestFileContentsRenamed(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "ren_src.txt", "moved\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+	gitCmd(t, dir, "mv", "ren_src.txt", "ren_dst.txt")
+	write(t, dir, "ren_dst.txt", "moved\nmore\n")
+
+	old, nw, ns, err := FileContents(context.Background(), dir, "ren_dst.txt", "ren_src.txt")
+	if err != nil || ns {
+		t.Fatalf("err=%v notShown=%v", err, ns)
+	}
+	if old != "moved\n" || nw != "moved\nmore\n" {
+		t.Errorf("old=%q new=%q", old, nw)
+	}
+}
+
+func TestFileContentsOversized(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	big := strings.Repeat("x", maxContentBytes+1)
+	write(t, dir, "head_big.txt", big)
+	write(t, dir, "work_big.txt", "small\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	write(t, dir, "head_big.txt", "small\n") // HEAD oversized, working small
+	write(t, dir, "work_big.txt", big)       // working oversized
+
+	t.Run("head side oversized", func(t *testing.T) {
+		old, nw, ns, err := FileContents(context.Background(), dir, "head_big.txt", "")
+		if err != nil || !ns || old != "" || nw != "" {
+			t.Errorf("old=%q new=%q notShown=%v err=%v", old, nw, ns, err)
+		}
+	})
+	t.Run("working side oversized", func(t *testing.T) {
+		_, _, ns, err := FileContents(context.Background(), dir, "work_big.txt", "")
+		if err != nil || !ns {
+			t.Errorf("notShown=%v err=%v", ns, err)
+		}
+	})
+}
+
+func TestFileContentsPathEscape(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "hi\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	if _, _, _, err := FileContents(context.Background(), dir, "../escape.txt", ""); err == nil {
+		t.Error("expected error for path escaping repo root")
+	}
+}
+
+func TestCommitsBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "1\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+	gitCmd(t, dir, "checkout", "-b", "feat")
+	write(t, dir, "a.txt", "1\n2\n")
+	gitCmd(t, dir, "commit", "-am", "second")
+	write(t, dir, "b.txt", "x\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "third")
+
+	log, err := Commits(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(log.Commits) != 2 {
+		t.Fatalf("got %d commits, want 2: %+v", len(log.Commits), log.Commits)
+	}
+	if log.Commits[0].Subject != "third" || log.Commits[1].Subject != "second" {
+		t.Errorf("order/subjects: %+v", log.Commits)
+	}
+	if log.Commits[0].Short == "" || log.Commits[0].SHA == "" || log.Commits[0].UnixSec == 0 {
+		t.Errorf("missing fields: %+v", log.Commits[0])
+	}
+	if log.Unpushed {
+		t.Error("no remote configured; Unpushed should be false")
+	}
+}
+
+func TestCommitsInSyncEmpty(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "1\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	log, err := Commits(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(log.Commits) != 0 {
+		t.Fatalf("on base branch with no divergence, want 0 commits: %+v", log.Commits)
+	}
+}
+
+func TestCommitsSkipsMerges(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "1\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+	gitCmd(t, dir, "checkout", "-b", "feat")
+	write(t, dir, "a.txt", "1\n2\n")
+	gitCmd(t, dir, "commit", "-am", "feat work")
+	gitCmd(t, dir, "checkout", "main")
+	write(t, dir, "c.txt", "c\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "main work")
+	gitCmd(t, dir, "checkout", "feat")
+	gitCmd(t, dir, "merge", "--no-ff", "-m", "merge main", "main")
+
+	log, err := Commits(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range log.Commits {
+		if c.Subject == "merge main" {
+			t.Errorf("merge commit should be skipped: %+v", log.Commits)
+		}
+	}
+}
+
+func TestNotARepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if _, _, err := ChangedFiles(context.Background(), t.TempDir()); err == nil {
+		t.Error("expected error for non-repo directory")
+	}
+}
+
+func TestEmptyRepoNoHEAD(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "hello\n")
+
+	_, files, err := ChangedFiles(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0].Change != ChangeUntracked {
+		t.Fatalf("got %+v", files)
+	}
+	// No HEAD yet: old side must be empty, new side the working content.
+	old, nw, _, err := FileContents(context.Background(), dir, "a.txt", "")
+	if err != nil || old != "" || nw != "hello\n" {
+		t.Errorf("old=%q new=%q err=%v", old, nw, err)
+	}
+}
+
+func TestCommitFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "keep.txt", "k\n")
+	write(t, dir, "gone.txt", "g\n")
+	write(t, dir, "ren_src.txt", "same content here\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	write(t, dir, "keep.txt", "k\nk2\n")               // modified
+	os.Remove(filepath.Join(dir, "gone.txt"))          // deleted
+	gitCmd(t, dir, "mv", "ren_src.txt", "ren_dst.txt") // renamed
+	write(t, dir, "added.txt", "n\n")                  // added
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "changes")
+
+	sha := headSHA(t, dir)
+	files, err := CommitFiles(context.Background(), dir, sha)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := map[string]ChangedFile{}
+	for _, f := range files {
+		byPath[f.Path] = f
+	}
+	if byPath["keep.txt"].Change != ChangeModified {
+		t.Errorf("keep.txt: %+v", byPath["keep.txt"])
+	}
+	if byPath["gone.txt"].Change != ChangeDeleted {
+		t.Errorf("gone.txt: %+v", byPath["gone.txt"])
+	}
+	if byPath["added.txt"].Change != ChangeAdded {
+		t.Errorf("added.txt: %+v", byPath["added.txt"])
+	}
+	if f := byPath["ren_dst.txt"]; f.Change != ChangeRenamed || f.OrigPath != "ren_src.txt" {
+		t.Errorf("rename: %+v", f)
+	}
+}
+
+func TestCommitFilesRootCommit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "1\n")
+	write(t, dir, "b.txt", "2\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "root")
+
+	files, err := CommitFiles(context.Background(), dir, headSHA(t, dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("root commit should list all files, got %+v", files)
+	}
+	for _, f := range files {
+		if f.Change != ChangeAdded {
+			t.Errorf("root commit files should be added: %+v", f)
+		}
+	}
+}
+
+func TestIsHexSHA(t *testing.T) {
+	ok := []string{
+		"abcd", "0000", "DEADBEEF",
+		"9714570255b0e9e81fe6dde43f192861bce35c9a", // sha-1
+		strings.Repeat("a", 64),                    // sha-256 length
+	}
+	for _, s := range ok {
+		if !isHexSHA(s) {
+			t.Errorf("isHexSHA(%q) = false, want true", s)
+		}
+	}
+	bad := []string{
+		"", "abc", // too short
+		strings.Repeat("a", 65), // too long
+		"--output=/tmp/pwned",   // option injection
+		"HEAD", "main",          // refs, not object names
+		"abc g", "abcz", // non-hex
+		"abc\n123", // embedded newline
+	}
+	for _, s := range bad {
+		if isHexSHA(s) {
+			t.Errorf("isHexSHA(%q) = true, want false", s)
+		}
+	}
+}
+
+// A crafted sha must never be parsed as a git option: "--output=FILE" would
+// otherwise make diff-tree write to an arbitrary path.
+func TestCommitFilesRejectsInjection(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "1\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	victim := filepath.Join(dir, "PWNED.txt")
+	_, err := CommitFiles(context.Background(), dir, "--output="+victim)
+	if err == nil {
+		t.Error("expected error for option-like sha")
+	}
+	if _, serr := os.Stat(victim); serr == nil {
+		t.Fatalf("argument injection wrote %s", victim)
+	}
+}
+
+func TestCommitFileContentsRejectsInvalidSHA(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "a.txt", "1\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	if _, _, _, err := CommitFileContents(context.Background(), dir, "--output=x", "a.txt", ""); err == nil {
+		t.Error("expected error for option-like sha")
+	}
+}
+
+// A changed symlink must yield its target text (as git stores it), never the
+// content of the file it points to — even when that file is outside the repo.
+func TestFileContentsSymlink(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	if err := os.Symlink("target_a.txt", filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	write(t, dir, "target_a.txt", "A\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	// Repoint the symlink at a secret file outside the repo.
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("SECRET\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	old, nw, ns, err := FileContents(context.Background(), dir, "link", "")
+	if err != nil || ns {
+		t.Fatalf("err=%v notShown=%v", err, ns)
+	}
+	if strings.Contains(nw, "SECRET") {
+		t.Errorf("symlink content disclosure: new=%q leaked the target file's content", nw)
+	}
+	if nw != outside {
+		t.Errorf("new = %q, want the link target path %q", nw, outside)
+	}
+	if old != "target_a.txt" {
+		t.Errorf("old = %q, want the HEAD link target %q", old, "target_a.txt")
+	}
+}
+
+func TestCommitFileContents(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-b", "main")
+	write(t, dir, "mod.txt", "one\n")
+	write(t, dir, "del.txt", "bye\n")
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-m", "base")
+
+	write(t, dir, "mod.txt", "one\ntwo\n")
+	os.Remove(filepath.Join(dir, "del.txt"))
+	write(t, dir, "add.txt", "fresh\n")
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "changes")
+	sha := headSHA(t, dir)
+
+	t.Run("modified", func(t *testing.T) {
+		old, nw, ns, err := CommitFileContents(context.Background(), dir, sha, "mod.txt", "")
+		if err != nil || ns || old != "one\n" || nw != "one\ntwo\n" {
+			t.Errorf("old=%q new=%q ns=%v err=%v", old, nw, ns, err)
+		}
+	})
+	t.Run("added", func(t *testing.T) {
+		old, nw, _, err := CommitFileContents(context.Background(), dir, sha, "add.txt", "")
+		if err != nil || old != "" || nw != "fresh\n" {
+			t.Errorf("old=%q new=%q err=%v", old, nw, err)
+		}
+	})
+	t.Run("deleted", func(t *testing.T) {
+		old, nw, _, err := CommitFileContents(context.Background(), dir, sha, "del.txt", "")
+		if err != nil || old != "bye\n" || nw != "" {
+			t.Errorf("old=%q new=%q err=%v", old, nw, err)
+		}
+	})
+}

--- a/internal/node/handlers.go
+++ b/internal/node/handlers.go
@@ -39,4 +39,8 @@ func (d *Node) registerHandlers(srv *api.Server) {
 	srv.Handle(api.MethodTerminalResize, d.handleTerminalResize)
 	srv.Handle(api.MethodTerminalClose, d.handleTerminalClose)
 	srv.Handle(api.MethodSessionExport, d.handleExportBundle)
+	srv.Handle(api.MethodSessionChangedFiles, d.handleChangedFiles)
+	srv.Handle(api.MethodSessionFileDiff, d.handleFileDiff)
+	srv.Handle(api.MethodSessionCommits, d.handleCommits)
+	srv.Handle(api.MethodSessionCommitFiles, d.handleCommitFiles)
 }

--- a/internal/node/handlers_changes.go
+++ b/internal/node/handlers_changes.go
@@ -1,0 +1,148 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/gitstatus"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// Changed-files review handlers: report a session working directory's git status
+// (vs HEAD) and fetch one changed file's HEAD + working-tree content.
+
+// handleChangedFiles lists every file git status reports for the session's repo.
+func (d *Node) handleChangedFiles(ctx context.Context, params json.RawMessage) (any, error) {
+	p, err := api.Decode[api.SessionRef](params)
+	if err != nil {
+		return nil, err
+	}
+	s, ok := d.reg.Get(p.SessionID)
+	if !ok {
+		return nil, fmt.Errorf("unknown session: %s", p.SessionID)
+	}
+	dir := sessionDir(s)
+	if dir == "" {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session working directory unknown"}
+	}
+	root, files, err := gitstatus.ChangedFiles(ctx, dir)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: err.Error()}
+	}
+	out := make([]api.ChangedFile, len(files))
+	for i, f := range files {
+		out[i] = api.ChangedFile{
+			Path:     f.Path,
+			OrigPath: f.OrigPath,
+			Change:   string(f.Change),
+			Staged:   f.Staged,
+			Unstaged: f.Unstaged,
+		}
+	}
+	return api.ChangedFilesResult{Root: root, Files: out}, nil
+}
+
+// handleFileDiff returns one changed file's HEAD (old) and working-tree (new)
+// content for rendering a diff and the full file.
+func (d *Node) handleFileDiff(ctx context.Context, params json.RawMessage) (any, error) {
+	p, err := api.Decode[api.FileDiffParams](params)
+	if err != nil {
+		return nil, err
+	}
+	if p.Path == "" {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "path is required"}
+	}
+	s, ok := d.reg.Get(p.SessionID)
+	if !ok {
+		return nil, fmt.Errorf("unknown session: %s", p.SessionID)
+	}
+	dir := sessionDir(s)
+	if dir == "" {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session working directory unknown"}
+	}
+	var (
+		old, nw  string
+		notShown bool
+	)
+	if p.Rev != "" {
+		old, nw, notShown, err = gitstatus.CommitFileContents(ctx, dir, p.Rev, p.Path, p.OrigPath)
+	} else {
+		old, nw, notShown, err = gitstatus.FileContents(ctx, dir, p.Path, p.OrigPath)
+	}
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: err.Error()}
+	}
+	return api.FileDiffResult{
+		Path:       p.Path,
+		OldContent: old,
+		NewContent: nw,
+		NotShown:   notShown,
+	}, nil
+}
+
+func (d *Node) handleCommits(ctx context.Context, params json.RawMessage) (any, error) {
+	p, err := api.Decode[api.SessionRef](params)
+	if err != nil {
+		return nil, err
+	}
+	s, ok := d.reg.Get(p.SessionID)
+	if !ok {
+		return nil, fmt.Errorf("unknown session: %s", p.SessionID)
+	}
+	dir := sessionDir(s)
+	if dir == "" {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session working directory unknown"}
+	}
+	log, err := gitstatus.Commits(ctx, dir)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: err.Error()}
+	}
+	out := make([]api.Commit, len(log.Commits))
+	for i, c := range log.Commits {
+		out[i] = api.Commit{
+			SHA: c.SHA, Short: c.Short, Subject: c.Subject,
+			Author: c.Author, UnixSec: c.UnixSec,
+		}
+	}
+	return api.CommitsResult{Commits: out, Unpushed: log.Unpushed}, nil
+}
+
+func (d *Node) handleCommitFiles(ctx context.Context, params json.RawMessage) (any, error) {
+	p, err := api.Decode[api.CommitFilesParams](params)
+	if err != nil {
+		return nil, err
+	}
+	if p.SHA == "" {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "sha is required"}
+	}
+	s, ok := d.reg.Get(p.SessionID)
+	if !ok {
+		return nil, fmt.Errorf("unknown session: %s", p.SessionID)
+	}
+	dir := sessionDir(s)
+	if dir == "" {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "session working directory unknown"}
+	}
+	files, err := gitstatus.CommitFiles(ctx, dir, p.SHA)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: err.Error()}
+	}
+	out := make([]api.ChangedFile, len(files))
+	for i, f := range files {
+		out[i] = api.ChangedFile{
+			Path: f.Path, OrigPath: f.OrigPath, Change: string(f.Change), Staged: f.Staged,
+		}
+	}
+	return api.ChangedFilesResult{Files: out}, nil
+}
+
+// sessionDir is the working directory to run git in: the hook-reported Cwd when
+// known, else the live tmux pane's current path.
+func sessionDir(s session.Session) string {
+	if s.Cwd != "" {
+		return s.Cwd
+	}
+	return s.Tmux.CurrentPath
+}

--- a/internal/node/handlers_changes_test.go
+++ b/internal/node/handlers_changes_test.go
@@ -1,0 +1,290 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/registry"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// nodeNoDirSession registers a session whose working directory is unknown (no
+// hook Cwd, no tmux pane path), so sessionDir() returns "".
+func nodeNoDirSession(t *testing.T) (*Node, string) {
+	t.Helper()
+	d := newTestNode(t)
+	d.reg.ReconcileSessions("claude", []registry.DiscoveredSession{{
+		AgentSessionID: "s1", Frontend: session.FrontendTmux,
+	}})
+	var id string
+	for _, s := range d.reg.Snapshot() {
+		id = s.ID
+	}
+	if id == "" {
+		t.Fatal("session not registered")
+	}
+	return d, id
+}
+
+// rpcCode returns the RPCError code from err, or 0 if err is not an *api.RPCError.
+func rpcCode(err error) int {
+	var re *api.RPCError
+	if errors.As(err, &re) {
+		return re.Code
+	}
+	return 0
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func nodeWithGitSession(t *testing.T) (*Node, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "base")
+	runGit(t, dir, "checkout", "-b", "feat")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1\n2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "second")
+
+	d := newTestNode(t)
+	d.reg.ReconcileSessions("claude", []registry.DiscoveredSession{{
+		AgentSessionID: "s1", Cwd: dir, Frontend: session.FrontendTmux,
+	}})
+	var id string
+	for _, s := range d.reg.Snapshot() {
+		id = s.ID
+	}
+	if id == "" {
+		t.Fatal("session not registered")
+	}
+	return d, id, dir
+}
+
+func TestHandleCommits(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	d, id, _ := nodeWithGitSession(t)
+	params, _ := json.Marshal(api.SessionRef{SessionID: id})
+	raw, err := d.handleCommits(context.Background(), params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := raw.(api.CommitsResult)
+	if len(res.Commits) != 1 || res.Commits[0].Subject != "second" {
+		t.Fatalf("commits = %+v", res.Commits)
+	}
+	if res.Commits[0].Short == "" || res.Commits[0].SHA == "" {
+		t.Errorf("commit missing sha fields: %+v", res.Commits[0])
+	}
+}
+
+func TestHandleCommitFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	d, id, dir := nodeWithGitSession(t)
+	shaCmd := exec.Command("git", "rev-parse", "HEAD")
+	shaCmd.Dir = dir
+	shaOut, err := shaCmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sha := string(shaOut[:len(shaOut)-1]) // drop trailing newline
+
+	params, _ := json.Marshal(api.CommitFilesParams{SessionID: id, SHA: sha})
+	raw, err := d.handleCommitFiles(context.Background(), params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := raw.(api.ChangedFilesResult)
+	if len(res.Files) != 1 || res.Files[0].Path != "a.txt" || res.Files[0].Change != "modified" {
+		t.Fatalf("files = %+v", res.Files)
+	}
+}
+
+func TestHandleChangedFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	d, id, dir := nodeWithGitSession(t)
+	// An unstaged edit on top of the committed history so status has an entry.
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1\n2\n3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	params, _ := json.Marshal(api.SessionRef{SessionID: id})
+	raw, err := d.handleChangedFiles(context.Background(), params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := raw.(api.ChangedFilesResult)
+	if res.Root == "" {
+		t.Error("empty root")
+	}
+	var found bool
+	for _, f := range res.Files {
+		if f.Path == "a.txt" {
+			found = true
+			if f.Change != "modified" || f.Staged || !f.Unstaged {
+				t.Errorf("a.txt: %+v", f)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("a.txt missing from status: %+v", res.Files)
+	}
+}
+
+func TestHandleChangedFilesErrors(t *testing.T) {
+	t.Run("unknown session", func(t *testing.T) {
+		d := newTestNode(t)
+		params, _ := json.Marshal(api.SessionRef{SessionID: "nope"})
+		if _, err := d.handleChangedFiles(context.Background(), params); err == nil {
+			t.Error("expected error for unknown session")
+		}
+	})
+	t.Run("unknown working directory", func(t *testing.T) {
+		d, id := nodeNoDirSession(t)
+		params, _ := json.Marshal(api.SessionRef{SessionID: id})
+		_, err := d.handleChangedFiles(context.Background(), params)
+		if rpcCode(err) != api.CodeInvalidRequest {
+			t.Fatalf("err=%v, want InvalidRequest RPCError", err)
+		}
+	})
+}
+
+func TestHandleFileDiff(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	d, id, dir := nodeWithGitSession(t)
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1\n2\n3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("working tree diff", func(t *testing.T) {
+		params, _ := json.Marshal(api.FileDiffParams{SessionID: id, Path: "a.txt"})
+		raw, err := d.handleFileDiff(context.Background(), params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res := raw.(api.FileDiffResult)
+		if res.OldContent != "1\n2\n" || res.NewContent != "1\n2\n3\n" {
+			t.Errorf("old=%q new=%q", res.OldContent, res.NewContent)
+		}
+	})
+
+	t.Run("path required", func(t *testing.T) {
+		params, _ := json.Marshal(api.FileDiffParams{SessionID: id})
+		_, err := d.handleFileDiff(context.Background(), params)
+		if rpcCode(err) != api.CodeInvalidRequest {
+			t.Fatalf("err=%v, want InvalidRequest RPCError", err)
+		}
+	})
+
+	t.Run("unknown session", func(t *testing.T) {
+		params, _ := json.Marshal(api.FileDiffParams{SessionID: "nope", Path: "a.txt"})
+		if _, err := d.handleFileDiff(context.Background(), params); err == nil {
+			t.Error("expected error for unknown session")
+		}
+	})
+
+	t.Run("path escaping repo is rejected", func(t *testing.T) {
+		params, _ := json.Marshal(api.FileDiffParams{SessionID: id, Path: "../escape.txt"})
+		_, err := d.handleFileDiff(context.Background(), params)
+		if rpcCode(err) != api.CodeInvalidRequest {
+			t.Fatalf("err=%v, want InvalidRequest RPCError", err)
+		}
+	})
+}
+
+func TestHandleCommitFilesErrors(t *testing.T) {
+	t.Run("sha required", func(t *testing.T) {
+		d, id := nodeNoDirSession(t)
+		params, _ := json.Marshal(api.CommitFilesParams{SessionID: id})
+		_, err := d.handleCommitFiles(context.Background(), params)
+		if rpcCode(err) != api.CodeInvalidRequest {
+			t.Fatalf("err=%v, want InvalidRequest RPCError", err)
+		}
+	})
+
+	t.Run("unknown session", func(t *testing.T) {
+		d := newTestNode(t)
+		params, _ := json.Marshal(api.CommitFilesParams{SessionID: "nope", SHA: "abcdef1"})
+		if _, err := d.handleCommitFiles(context.Background(), params); err == nil {
+			t.Error("expected error for unknown session")
+		}
+	})
+
+	// An option-like sha must be rejected and must not write a file.
+	t.Run("argument injection blocked", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not available")
+		}
+		d, id, dir := nodeWithGitSession(t)
+		victim := filepath.Join(dir, "PWNED.txt")
+		params, _ := json.Marshal(api.CommitFilesParams{SessionID: id, SHA: "--output=" + victim})
+		if _, err := d.handleCommitFiles(context.Background(), params); err == nil {
+			t.Error("expected error for option-like sha")
+		}
+		if _, serr := os.Stat(victim); serr == nil {
+			t.Fatalf("argument injection wrote %s", victim)
+		}
+	})
+}
+
+func TestSessionDir(t *testing.T) {
+	tests := []struct {
+		name string
+		s    session.Session
+		want string
+	}{
+		{
+			name: "cwd wins",
+			s:    session.Session{Cwd: "/repo/from/hook", Tmux: session.TmuxLocation{CurrentPath: "/pane/path"}},
+			want: "/repo/from/hook",
+		},
+		{
+			name: "falls back to pane path",
+			s:    session.Session{Tmux: session.TmuxLocation{CurrentPath: "/pane/path"}},
+			want: "/pane/path",
+		},
+		{
+			name: "empty when neither known",
+			s:    session.Session{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sessionDir(tt.s); got != tt.want {
+				t.Errorf("sessionDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

A per-session **changed-files review** in the mobile app — a PR-review-style view of everything `git status` reports for a session's working directory, from your phone.

- **Entry point:** diff icon in the session screen's app bar.
- **List:** changed files grouped Staged / Unstaged / Untracked with git-style `M A D ?` letters.
- **Review:** tap a file for a GitHub-mobile-style inline-expand diff — only changed hunks show, with `⋯ Expand N lines` bars and an expand-all toggle. Baseline is working-tree vs HEAD.

## Notes

- v1 scope: no +/− counts, no staged/unstaged toggle (baseline fixed at working-tree vs HEAD).

## Testing

- `go test ./...`, `flutter test`, `flutter analyze` — all green.
- Not yet run against a live node+gateway+device.