### PR TITLE
fix: fail fast if cloudflare tunnel creds missing

### DIFF
--- a/cmd/argus/tunnel.go
+++ b/cmd/argus/tunnel.go
@@ -103,12 +103,22 @@ func resolveTunnel(o tunnelOptions) (tunnel.Provider, string, error) {
 		if cfMode == "quick" && cfLog != "debug" {
 			cfLog = "info"
 		}
+		// <UUID>.json creds live in the same dir as the origin cert.
+		var credsDir string
+		if cfMode == "local" {
+			cert, _, err := cloudflareCertPath()
+			if err != nil {
+				return nil, "", err
+			}
+			credsDir = filepath.Dir(cert)
+		}
 		return tunnel.Cloudflare{
 			Bin:      bin,
 			Token:    o.cfToken,
 			Tunnel:   name,
 			Hostname: o.cfHostname,
 			LogLevel: cfLog,
+			CredsDir: credsDir,
 		}, origin, nil
 	default:
 		// unreachable: providerBinary already gated unknown names

--- a/internal/tunnel/cloudflare.go
+++ b/internal/tunnel/cloudflare.go
@@ -6,10 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/MunifTanjim/argus/internal/shell"
+	"github.com/MunifTanjim/argus/internal/util"
 )
 
 // quickURLRe matches the public URL cloudflared prints for a quick tunnel.
@@ -29,6 +32,7 @@ type Cloudflare struct {
 	Tunnel   string // locally-managed tunnel name (selects local mode)
 	Hostname string // public hostname argus routes to the locally-managed tunnel
 	LogLevel string // cloudflared --loglevel (debug/info/warn/error/fatal); "" omits it
+	CredsDir string // dir cloudflared reads <UUID>.json creds from; "" skips the local-creds check
 
 	runner cmdRunner // nil => defaultRunner (real exec); overridable in tests
 }
@@ -98,7 +102,7 @@ func (c Cloudflare) Prepare(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
-	exists, err := c.tunnelExists(ctx)
+	exists, id, err := c.tunnelExists(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -106,6 +110,8 @@ func (c Cloudflare) Prepare(ctx context.Context) (string, error) {
 		if _, stderr, err := c.exec(ctx, c.tunnelArgs("create", c.Tunnel)...); err != nil {
 			return "", fmt.Errorf("create tunnel %q: %w: %s", c.Tunnel, err, bytes.TrimSpace(stderr))
 		}
+	} else if err := c.checkCredentials(id); err != nil {
+		return "", err
 	}
 
 	// --overwrite-dns makes the route idempotent across restarts.
@@ -116,25 +122,76 @@ func (c Cloudflare) Prepare(ctx context.Context) (string, error) {
 	return "https://" + c.Hostname, nil
 }
 
-// tunnelExists reports whether a tunnel named c.Tunnel exists, by parsing
-// `cloudflared tunnel list --output json`.
-func (c Cloudflare) tunnelExists(ctx context.Context) (bool, error) {
+// tunnelExists reports whether a tunnel named c.Tunnel exists, returning its UUID when it does.
+func (c Cloudflare) tunnelExists(ctx context.Context) (bool, string, error) {
 	stdout, stderr, err := c.exec(ctx, c.tunnelArgs("list", "--output", "json")...)
 	if err != nil {
-		return false, fmt.Errorf("list tunnels: %w: %s", err, bytes.TrimSpace(stderr))
+		return false, "", fmt.Errorf("list tunnels: %w: %s", err, bytes.TrimSpace(stderr))
 	}
 	var tunnels []struct {
+		ID   string `json:"id"`
 		Name string `json:"name"`
 	}
 	if err := json.Unmarshal(stdout, &tunnels); err != nil {
-		return false, fmt.Errorf("parse tunnel list: %w", err)
+		return false, "", fmt.Errorf("parse tunnel list: %w", err)
 	}
 	for _, t := range tunnels {
 		if t.Name == c.Tunnel {
-			return true, nil
+			return true, t.ID, nil
 		}
 	}
-	return false, nil
+	return false, "", nil
+}
+
+// checkCredentials fails fast when the tunnel exists on the account but its
+// credentials file is absent here — otherwise cloudflared restart-loops on
+// "credentials file not found".
+func (c Cloudflare) checkCredentials(id string) error {
+	if c.CredsDir == "" || id == "" {
+		return nil
+	}
+	if os.Getenv("TUNNEL_CRED_CONTENTS") != "" {
+		return nil // inline creds; no file to check
+	}
+	path := os.Getenv("TUNNEL_CRED_FILE")
+	if path == "" {
+		path = cloudflaredCredentialsFile(c.CredsDir)
+	}
+	if path == "" {
+		path = filepath.Join(c.CredsDir, id+".json")
+	} else if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = filepath.Join(home, path[2:])
+		}
+	}
+	if exists, err := util.FileExists(path); err != nil {
+		return fmt.Errorf("stat cloudflared credentials %s: %w", path, err)
+	} else if exists {
+		return nil
+	}
+	return fmt.Errorf(
+		"cloudflare tunnel %q (UUID %s) is registered on the account but its credentials file %s is missing on this machine. "+
+			"Copy the credentials JSON from the machine that originally ran `cloudflared tunnel create`, "+
+			"or run `cloudflared tunnel delete %s` and restart argus to recreate it",
+		c.Tunnel, id, path, c.Tunnel,
+	)
+}
+
+// cloudflaredCredentialsFile returns the credentials-file path from cloudflared's
+// config in dir, or "" if unset. Line scan, not a full YAML parse.
+func cloudflaredCredentialsFile(dir string) string {
+	for _, name := range []string{"config.yml", "config.yaml"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if v, ok := strings.CutPrefix(strings.TrimSpace(line), "credentials-file:"); ok {
+				return strings.Trim(strings.TrimSpace(v), `"'`)
+			}
+		}
+	}
+	return ""
 }
 
 // tunnelArgs builds args for a `cloudflared tunnel <sub...>` call. cloudflared

--- a/internal/tunnel/cloudflare_test.go
+++ b/internal/tunnel/cloudflare_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -223,6 +225,124 @@ func TestCloudflarePrepareReusesWhenPresent(t *testing.T) {
 	}
 	if !rr.called("route") {
 		t.Error("must still route dns when reusing")
+	}
+}
+
+func TestCloudflarePrepareFailsWhenLocalCredentialsMissing(t *testing.T) {
+	// List returns a UUID but the <UUID>.json is absent: fail fast rather than
+	// defer to cloudflared's restart loop.
+	rr := &recordingRunner{replies: map[string]runnerReply{
+		"list": {stdout: []byte(`[{"id":"622328ce-e5f8-4e65-b156-7293d4744e74","name":"argus"}]`)},
+	}}
+	dir := t.TempDir()
+	t.Setenv("TUNNEL_CRED_FILE", "") // ensure default path resolution
+	c := Cloudflare{
+		Bin: "cloudflared", Tunnel: "argus", Hostname: "argus.example.com",
+		CredsDir: dir, runner: rr.run,
+	}
+
+	_, err := c.Prepare(context.Background())
+	if err == nil {
+		t.Fatal("Prepare must fail when credentials JSON is missing")
+	}
+	for _, want := range []string{"622328ce-e5f8-4e65-b156-7293d4744e74", "cloudflared tunnel delete argus", "missing"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+	if rr.called("create") || rr.called("route") {
+		t.Error("must not create or route DNS when credentials are missing")
+	}
+}
+
+func TestCloudflarePrepareAcceptsLocalCredentialsFile(t *testing.T) {
+	dir := t.TempDir()
+	id := "622328ce-e5f8-4e65-b156-7293d4744e74"
+	if err := os.WriteFile(filepath.Join(dir, id+".json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("seed credentials: %v", err)
+	}
+	rr := &recordingRunner{replies: map[string]runnerReply{
+		"list":  {stdout: []byte(`[{"id":"` + id + `","name":"argus"}]`)},
+		"route": {},
+	}}
+	c := Cloudflare{
+		Bin: "cloudflared", Tunnel: "argus", Hostname: "argus.example.com",
+		CredsDir: dir, runner: rr.run,
+	}
+
+	if _, err := c.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if rr.called("create") {
+		t.Error("must not create when the tunnel already exists with local credentials")
+	}
+	if !rr.called("route") {
+		t.Error("must still route dns when reusing")
+	}
+}
+
+func TestCloudflarePrepareHonorsTunnelCredFileEnv(t *testing.T) {
+	dir := t.TempDir()
+	credFile := filepath.Join(dir, "custom-creds.json")
+	if err := os.WriteFile(credFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("seed credentials: %v", err)
+	}
+	t.Setenv("TUNNEL_CRED_FILE", credFile)
+	rr := &recordingRunner{replies: map[string]runnerReply{
+		"list":  {stdout: []byte(`[{"id":"deadbeef","name":"argus"}]`)},
+		"route": {},
+	}}
+	c := Cloudflare{
+		Bin: "cloudflared", Tunnel: "argus", Hostname: "argus.example.com",
+		CredsDir: t.TempDir(), runner: rr.run, // deliberately empty dir
+	}
+	if _, err := c.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+}
+
+func TestCloudflarePrepareHonorsTunnelCredContentsEnv(t *testing.T) {
+	// Inline creds mean no file is read, so an absent <UUID>.json must not trip the check.
+	t.Setenv("TUNNEL_CRED_FILE", "")
+	t.Setenv("TUNNEL_CRED_CONTENTS", "{}")
+	rr := &recordingRunner{replies: map[string]runnerReply{
+		"list":  {stdout: []byte(`[{"id":"deadbeef","name":"argus"}]`)},
+		"route": {},
+	}}
+	c := Cloudflare{
+		Bin: "cloudflared", Tunnel: "argus", Hostname: "argus.example.com",
+		CredsDir: t.TempDir(), runner: rr.run, // deliberately empty dir
+	}
+	if _, err := c.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if !rr.called("route") {
+		t.Error("must still route dns when credentials are supplied inline")
+	}
+}
+
+func TestCloudflarePrepareHonorsConfigCredentialsFile(t *testing.T) {
+	// config.yml's credentials-file: points creds outside the default <UUID>.json,
+	// so an existing file there satisfies the check.
+	dir := t.TempDir()
+	credFile := filepath.Join(dir, "custom-creds.json")
+	if err := os.WriteFile(credFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("seed credentials: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte("credentials-file: "+credFile+"\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	t.Setenv("TUNNEL_CRED_FILE", "")
+	rr := &recordingRunner{replies: map[string]runnerReply{
+		"list":  {stdout: []byte(`[{"id":"deadbeef","name":"argus"}]`)},
+		"route": {},
+	}}
+	c := Cloudflare{
+		Bin: "cloudflared", Tunnel: "argus", Hostname: "argus.example.com",
+		CredsDir: dir, runner: rr.run,
+	}
+	if _, err := c.Prepare(context.Background()); err != nil {
+		t.Fatalf("Prepare: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
When a locally-managed cloudflare tunnel is already registered on the account but its `<UUID>.json` credentials file is absent on this machine, argus skipped `tunnel create` and let cloudflared restart-loop forever on `tunnel credentials file not found`. This detects the orphan state in `Prepare` and returns an actionable error instead.

- `tunnelExists` now also returns the tunnel UUID (parsed from the same `tunnel list --output json` call).
- New `checkCredentials` mirrors cloudflared's own resolution — `$TUNNEL_CRED_FILE` if set, else `<CredsDir>/<UUID>.json` — and stats the path.
- `cmd/argus/tunnel.go` populates `CredsDir` from the same cert-path logic used for `ensureCloudflareLogin` (local mode only), so no new user-facing config surface.

## Repro
```
./bin/argus start --tunnel cloudflare:local --cloudflare-hostname <host>
```
on a machine where the tunnel exists on the CF account (e.g. created on another host) but `~/.cloudflared/<UUID>.json` was never copied over. Previously: exponential backoff loop of `tunnel credentials file not found`. Now:
```
cloudflare tunnel "argus" (UUID …) is registered on the account but its credentials file …json is missing on this machine. Copy the credentials JSON from the machine that originally ran `cloudflared tunnel create`, or run `cloudflared tunnel delete argus` and restart argus to recreate it
```

## Test plan
- [x] `make check` (fmt-check, vet, all tests) passes
- [x] New tests: missing creds → fail-fast with UUID + remediation; creds present → reuse without recreate; `TUNNEL_CRED_FILE` env honored
- [x] Existing `TestCloudflarePrepareReusesWhenPresent` / `TestCloudflarePrepareCreatesWhenAbsent` unchanged and still pass