### PR TITLE
feat(app): add --mode flag for standalone gateway

### DIFF
--- a/cmd/argus/config.go
+++ b/cmd/argus/config.go
@@ -40,6 +40,7 @@ var flagKeys = map[string]string{
 	"gateway":                "gateway.url",
 	"token":                  "token",
 	"listen-addr":            "gateway.listen-addr",
+	"mode":                   "mode",
 	"id":                     "node.id",
 	"label":                  "node.label",
 	"log-level":              "log.level",

--- a/cmd/argus/gateway_serve_test.go
+++ b/cmd/argus/gateway_serve_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MunifTanjim/argus/internal/logbuf"
 	"github.com/MunifTanjim/argus/internal/logger"
 	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/session"
 	"github.com/MunifTanjim/argus/internal/tunnel"
 )
 
@@ -47,6 +48,55 @@ func TestServeGatewayEnforcesToken(t *testing.T) {
 		t.Fatalf("gateway must accept the right token: %v", err)
 	}
 	conn.Close()
+}
+
+// A standalone gateway (nil node) must serve /client without crashing and report an
+// empty view until remote nodes dial in.
+func TestServeGatewayStandaloneNoNode(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	httpSrv := serveGateway(ctx, gatewayServeOpts{
+		node:     nil, // standalone: no local node
+		token:    "secret",
+		listener: ln,
+		log:      logger.NewBufferLogger(logbuf.New(50)),
+		version:  "test",
+	})
+	t.Cleanup(func() {
+		sctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		_ = httpSrv.Shutdown(sctx)
+	})
+
+	conn, err := api.DialWSConn(ctx, "ws://"+ln.Addr().String()+"/client", "secret", nil)
+	if err != nil {
+		t.Fatalf("dial /client: %v", err)
+	}
+	defer conn.Close()
+
+	client := api.NewClient(conn)
+	defer client.Close()
+
+	var info api.ServerInfo
+	if err := client.Call(api.MethodServerInfo, nil, &info); err != nil {
+		t.Fatalf("server.info: %v", err)
+	}
+	if len(info.Nodes) != 0 {
+		t.Errorf("standalone gateway must report no nodes, got %d", len(info.Nodes))
+	}
+
+	var sessions []session.Session
+	if err := client.Call(api.MethodSessionsList, nil, &sessions); err != nil {
+		t.Fatalf("sessions.list: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("standalone gateway must have no sessions, got %d", len(sessions))
+	}
 }
 
 // failingTunnel's Command errors immediately, so Supervisor.Run returns without a

--- a/cmd/argus/start.go
+++ b/cmd/argus/start.go
@@ -26,15 +26,179 @@ import (
 	"github.com/MunifTanjim/argus/internal/tunnel"
 )
 
-// uplinkMode reports whether this node dials an upstream gateway (then it doesn't
-// listen). gatewayMode reports whether it serves as a gateway (no upstream, a token to
-// require). Neither = a local node (unix socket only).
-func uplinkMode(cfg *config.Config) bool  { return cfg.Gateway.URL != "" }
-func gatewayMode(cfg *config.Config) bool { return cfg.Gateway.URL == "" && cfg.Token != "" }
+// Run topology. --mode is authoritative when set; an empty --mode infers from
+// URL/token: a gateway when a token is set with no upstream, otherwise a node.
+func runLocalNode(cfg *config.Config) bool { return cfg.Mode != "gateway" }
+func serveGatewayMode(cfg *config.Config) bool {
+	if cfg.Mode == "gateway" {
+		return true
+	}
+	return cfg.Mode == "" && cfg.Gateway.URL == "" && cfg.Token != ""
+}
+func uplinkMode(cfg *config.Config) bool { return cfg.Gateway.URL != "" }
+
+func validateMode(cfg *config.Config) error {
+	switch cfg.Mode {
+	case "":
+		return nil
+	case "node":
+		if cfg.Token != "" && cfg.Gateway.URL == "" {
+			return fmt.Errorf("--token in --mode node is for connecting to a gateway; add --gateway, or use --mode gateway to run one")
+		}
+		return nil
+	case "gateway":
+		if cfg.Token == "" {
+			return fmt.Errorf("--mode gateway requires --token")
+		}
+		if cfg.Gateway.URL != "" {
+			return fmt.Errorf("--mode gateway does not connect upstream; remove --gateway")
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid --mode %q (use 'node' or 'gateway')", cfg.Mode)
+	}
+}
+
+// runStart is split from the cobra RunE so tests can drive the node/gateway wiring
+// with a cancellable context instead of a real signal.
+func runStart(ctx context.Context, stop context.CancelFunc, cmd *cobra.Command, cfg *config.Config, version string) error {
+	if err := validateMode(cfg); err != nil {
+		return fail(cmd, err)
+	}
+	if err := setupLogger(cfg); err != nil {
+		return fail(cmd, err)
+	}
+	local := runLocalNode(cfg)
+	serveGW := serveGatewayMode(cfg)
+	onTTY := isatty.IsTerminal(os.Stdin.Fd())
+	if local {
+		logger.Scoped("node").Info("starting argus node", "version", version)
+	} else {
+		logger.Scoped("gateway").Info("starting argus standalone gateway", "version", version)
+	}
+	if config.RuntimeDirIsFallback {
+		logger.Scoped("config").Warn("XDG runtime dir unavailable; using fallback", "dir", config.RuntimeDir)
+	}
+
+	tun, tunOrigin, err := resolveTunnel(tunnelOptions{
+		provider:     cfg.Tunnel.Provider,
+		cfToken:      cfg.Tunnel.Cloudflare.Token,
+		cfTunnelName: cfg.Tunnel.Cloudflare.TunnelName,
+		cfHostname:   cfg.Tunnel.Cloudflare.Hostname,
+		externalURL:  cfg.Tunnel.External.URL,
+		zrokName:     cfg.Tunnel.Zrok.Name,
+		ngrokDomain:  cfg.Tunnel.Ngrok.Domain,
+		runGateway:   serveGW,
+		listenAddr:   cfg.Gateway.ListenAddr,
+		logLevel:     config.LogLevel.Level(),
+	})
+	if err != nil {
+		return fail(cmd, err)
+	}
+
+	// nil in a standalone gateway: no local node, discovery, or socket API.
+	var d *node.Node
+	if local {
+		d = node.New()
+		d.SetIdentity(cfg.Node.ID, cfg.Node.Label)
+		d.SetVersion(version)
+		d.SetMirrorAffixes(cfg.Tmux.MirrorSessionPrefix, cfg.Tmux.MirrorSessionSuffix)
+		// Standalone node logs to the configured logger (the embedded node, sharing a
+		// TUI's terminal, stays at its discard default).
+		d.SetLogger(logger.Scoped("node").L)
+		clickCmd := desktopClickCmd(cfg) // shared by the node's desktop notifier and the local Watch below
+		d.SetDesktopNotify(cfg.Push.Desktop.Enabled, clickCmd)
+	}
+
+	// A locally-managed Cloudflare tunnel needs an origin cert: run interactive
+	// `cloudflared tunnel login` when on a terminal, else fail fast. No-op
+	// otherwise.
+	if cf, ok := tun.(tunnel.Cloudflare); ok {
+		if err := ensureCloudflareLogin(ctx, cf, onTTY); err != nil {
+			return fail(cmd, err)
+		}
+	}
+	// A zrok share needs an enabled environment: prompt for an account token to
+	// enable it when on a terminal, else fail fast.
+	if z, ok := tun.(*tunnel.Zrok); ok {
+		if err := ensureZrokEnabled(ctx, z.Bin, onTTY); err != nil {
+			return fail(cmd, err)
+		}
+	}
+	// An ngrok tunnel needs an authtoken: prompt at a terminal, else fail fast.
+	if n, ok := tun.(tunnel.Ngrok); ok {
+		if err := ensureNgrokAuth(ctx, n.Bin, onTTY); err != nil {
+			return fail(cmd, err)
+		}
+	}
+
+	if local {
+		reconcileInstalledHooks()
+		if err := connectGateway(ctx, cfg, d); err != nil {
+			return fail(cmd, err)
+		}
+	}
+
+	// Set when a background subsystem fails fatally; read after the blocking
+	// wait so the process exits non-zero.
+	var nodeFailed atomic.Bool
+	var httpSrv *http.Server
+	if serveGW {
+		ln, err := net.Listen("tcp", cfg.Gateway.ListenAddr)
+		if err != nil {
+			return fail(cmd, err)
+		}
+		httpSrv = serveGateway(ctx, gatewayServeOpts{
+			node:          d,
+			token:         cfg.Token,
+			listener:      ln,
+			log:           logger.New(context.Background()).L,
+			onFatal:       func() { nodeFailed.Store(true); stop() },
+			version:       version,
+			publicURL:     gatewayBaseURL(cfg),
+			enablePairing: true,
+			enablePush:    true,
+			pushDelay:     cfg.Push.Mobile.Delay,
+			tunnel:        tun,
+			tunnelOrigin:  tunOrigin,
+		})
+	}
+
+	// Plain local node: nothing upstream drives desktop notifications, so run a
+	// local Watch over our own registry. (Gateway mode reaches the node via
+	// Fanout; uplink mode via the gateway's push.desktop RPC.)
+	if local && cfg.Push.Desktop.Enabled && !uplinkMode(cfg) && !serveGW {
+		events, cancel := d.Registry().Subscribe()
+		// Focus-aware sink: suppresses alerts for a session already on screen.
+		go func() {
+			defer cancel()
+			push.Watch(ctx, events, push.Sinks{Immediate: []push.Sink{d.DesktopSink()}}, logger.Scoped("push").L)
+		}()
+	}
+
+	if d != nil {
+		err = d.Run(ctx, cfg.Socket) // blocks until the signal cancels ctx
+	} else {
+		<-ctx.Done() // standalone gateway: block on the signal (no node to run)
+	}
+
+	if httpSrv != nil {
+		sctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(sctx)
+	}
+	if err != nil {
+		return fail(cmd, err)
+	}
+	if nodeFailed.Load() {
+		return errSilent // a background subsystem already printed the cause
+	}
+	return nil
+}
 
 // newStartCmd builds `argus start`: runs the local node (discovery + tmux control + the
 // unix-socket API), and optionally serves as a gateway (no --gateway + token set) or
-// connects to one (--gateway).
+// connects to one (--gateway). See --mode to force a standalone gateway or node-only.
 func newStartCmd(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "start",
@@ -47,122 +211,9 @@ func newStartCmd(version string) *cobra.Command {
 			if err != nil {
 				return fail(cmd, err)
 			}
-			if err := setupLogger(cfg); err != nil {
-				return fail(cmd, err)
-			}
-			logger.Scoped("node").Info("starting argus node", "version", version)
-			if config.RuntimeDirIsFallback {
-				logger.Scoped("config").Warn("XDG runtime dir unavailable; using fallback", "dir", config.RuntimeDir)
-			}
-
-			tun, tunOrigin, err := resolveTunnel(tunnelOptions{
-				provider:     cfg.Tunnel.Provider,
-				cfToken:      cfg.Tunnel.Cloudflare.Token,
-				cfTunnelName: cfg.Tunnel.Cloudflare.TunnelName,
-				cfHostname:   cfg.Tunnel.Cloudflare.Hostname,
-				externalURL:  cfg.Tunnel.External.URL,
-				zrokName:     cfg.Tunnel.Zrok.Name,
-				ngrokDomain:  cfg.Tunnel.Ngrok.Domain,
-				runGateway:   gatewayMode(cfg),
-				listenAddr:   cfg.Gateway.ListenAddr,
-				logLevel:     config.LogLevel.Level(),
-			})
-			if err != nil {
-				return fail(cmd, err)
-			}
-
-			d := node.New()
-			d.SetIdentity(cfg.Node.ID, cfg.Node.Label)
-			d.SetVersion(version)
-			d.SetMirrorAffixes(cfg.Tmux.MirrorSessionPrefix, cfg.Tmux.MirrorSessionSuffix)
-			// Standalone node logs to the configured logger (the embedded node, sharing a
-			// TUI's terminal, stays at its discard default).
-			d.SetLogger(logger.Scoped("node").L)
-			clickCmd := desktopClickCmd(cfg) // shared by the node's desktop notifier and the local Watch below
-			d.SetDesktopNotify(cfg.Push.Desktop.Enabled, clickCmd)
-
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
-
-			// A locally-managed Cloudflare tunnel needs an origin cert: run interactive
-			// `cloudflared tunnel login` when on a terminal, else fail fast. No-op
-			// otherwise.
-			if cf, ok := tun.(tunnel.Cloudflare); ok {
-				if err := ensureCloudflareLogin(ctx, cf, isatty.IsTerminal(os.Stdin.Fd())); err != nil {
-					return fail(cmd, err)
-				}
-			}
-			// A zrok share needs an enabled environment: prompt for an account token to
-			// enable it when on a terminal, else fail fast.
-			if z, ok := tun.(*tunnel.Zrok); ok {
-				if err := ensureZrokEnabled(ctx, z.Bin, isatty.IsTerminal(os.Stdin.Fd())); err != nil {
-					return fail(cmd, err)
-				}
-			}
-			// An ngrok tunnel needs an authtoken: prompt at a terminal, else fail fast.
-			if n, ok := tun.(tunnel.Ngrok); ok {
-				if err := ensureNgrokAuth(ctx, n.Bin, isatty.IsTerminal(os.Stdin.Fd())); err != nil {
-					return fail(cmd, err)
-				}
-			}
-
-			reconcileInstalledHooks()
-
-			if err := connectGateway(ctx, cfg, d); err != nil {
-				return fail(cmd, err)
-			}
-
-			// Set when a background subsystem fails fatally; read after d.Run so the
-			// process exits non-zero.
-			var nodeFailed atomic.Bool
-			var httpSrv *http.Server
-			if gatewayMode(cfg) {
-				ln, err := net.Listen("tcp", cfg.Gateway.ListenAddr)
-				if err != nil {
-					return fail(cmd, err)
-				}
-				httpSrv = serveGateway(ctx, gatewayServeOpts{
-					node:          d,
-					token:         cfg.Token,
-					listener:      ln,
-					log:           logger.New(context.Background()).L,
-					onFatal:       func() { nodeFailed.Store(true); stop() },
-					version:       version,
-					publicURL:     gatewayBaseURL(cfg),
-					enablePairing: true,
-					enablePush:    true,
-					pushDelay:     cfg.Push.Mobile.Delay,
-					tunnel:        tun,
-					tunnelOrigin:  tunOrigin,
-				})
-			}
-
-			// Plain local node: nothing upstream drives desktop notifications, so run a
-			// local Watch over our own registry. (Gateway mode reaches the node via
-			// Fanout; uplink mode via the gateway's push.desktop RPC.)
-			if cfg.Push.Desktop.Enabled && !uplinkMode(cfg) && !gatewayMode(cfg) {
-				events, cancel := d.Registry().Subscribe()
-				// Focus-aware sink: suppresses alerts for a session already on screen.
-				go func() {
-					defer cancel()
-					push.Watch(ctx, events, push.Sinks{Immediate: []push.Sink{d.DesktopSink()}}, logger.Scoped("push").L)
-				}()
-			}
-
-			err = d.Run(ctx, cfg.Socket) // blocks until the signal cancels ctx
-
-			if httpSrv != nil {
-				sctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-				defer cancel()
-				_ = httpSrv.Shutdown(sctx)
-			}
-			if err != nil {
-				return fail(cmd, err)
-			}
-			if nodeFailed.Load() {
-				return errSilent // a background subsystem already printed the cause
-			}
-			return nil
+			return runStart(ctx, stop, cmd, cfg, version)
 		},
 	}
 
@@ -173,7 +224,9 @@ func newStartCmd(version string) *cobra.Command {
 	f.String("id", "", "stable node id announced to a gateway (default: hostname)")
 	f.String("label", "", "human-friendly node name shown in clients (default: hostname)")
 
-	f.String("listen-addr", "", "address for the gateway's WebSocket listener when this node is a gateway (default :8443; terminate TLS via a tunnel, ssh, or a reverse proxy)")
+	f.String("mode", "", "run mode: 'node' (local node) or 'gateway' (standalone gateway, no local node); default: inferred from --token/--gateway [$ARGUS_MODE]")
+
+	f.String("listen-addr", "", "address for the gateway's WebSocket listener when serving as a gateway (see --mode) (default :8443; terminate TLS via a tunnel, ssh, or a reverse proxy)")
 
 	f.String("gateway", "", "connect to a gateway (the /node route is implicit): ws(s)://host, or ssh://[user@]host[:ssh-port][?port=N] to tunnel over SSH [$ARGUS_GATEWAY_URL]")
 	f.String("token", "", "gateway token: required from incoming clients/nodes when this node is a gateway, and presented to the --gateway it connects to (empty: allow all) [$ARGUS_TOKEN]")
@@ -191,6 +244,9 @@ func newStartCmd(version string) *cobra.Command {
 
 	_ = cmd.RegisterFlagCompletionFunc("tunnel", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return tunnelFlagCompletions(), cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("mode", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{"node", "gateway"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	return cmd
@@ -285,7 +341,7 @@ func connectGateway(ctx context.Context, cfg *config.Config, d *node.Node) error
 // the gateway/tunnel/push scopes from it — injected so the embedded caller can
 // route to the TUI's log buffer instead of stderr.
 type gatewayServeOpts struct {
-	node          *node.Node
+	node          *node.Node // in-process source; nil for a standalone gateway (relay only)
 	token         string
 	listener      net.Listener
 	log           *slog.Logger
@@ -304,9 +360,11 @@ type gatewayServeOpts struct {
 // client-token pairing, mobile push, and a tunnel. Returns the *http.Server to
 // shut down.
 func serveGateway(ctx context.Context, o gatewayServeOpts) *http.Server {
-	d := o.node
 	agg := gateway.New(0)
-	agg.AddSource(gateway.NewInProcessSource(d.ID(), d.Label(), d.Version(), d.Capabilities(), d.Registry(), d.DispatchFunc()))
+	// A standalone gateway (nil node) seeds no in-process source: remote nodes only.
+	if d := o.node; d != nil {
+		agg.AddSource(gateway.NewInProcessSource(d.ID(), d.Label(), d.Version(), d.Capabilities(), d.Registry(), d.DispatchFunc()))
+	}
 
 	var store *clienttoken.Store
 	if o.enablePairing {

--- a/cmd/argus/start_test.go
+++ b/cmd/argus/start_test.go
@@ -1,15 +1,25 @@
 package main
 
 import (
+	"context"
 	"log/slog"
+	"net"
 	"testing"
+	"time"
 
+	"github.com/MunifTanjim/argus/internal/api"
 	"github.com/MunifTanjim/argus/internal/config"
 )
 
 func cfgWith(url, token string) *config.Config {
 	c := &config.Config{Token: token}
 	c.Gateway.URL = url
+	return c
+}
+
+func cfgWithMode(mode, url, token string) *config.Config {
+	c := cfgWith(url, token)
+	c.Mode = mode
 	return c
 }
 
@@ -29,26 +39,131 @@ func TestApplyLogLevelSetsConfiguredLevel(t *testing.T) {
 
 func TestRoleGates(t *testing.T) {
 	cases := []struct {
-		name        string
-		url, token  string
-		wantUplink  bool
-		wantGateway bool
+		name             string
+		mode, url, token string
+		wantUplink       bool
+		wantGateway      bool
+		wantNode         bool
 	}{
-		{"connected node", "wss://h", "tok", true, false},
-		{"connected no token", "wss://h", "", true, false},
-		{"gateway node", "", "tok", false, true},
-		{"local node", "", "", false, false},
-		{"url+token does not listen", "wss://h", "tok", true, false},
+		// Inference path (--mode unset): unchanged behavior.
+		{"connected node", "", "wss://h", "tok", true, false, true},
+		{"connected no token", "", "wss://h", "", true, false, true},
+		{"co-located gateway", "", "", "tok", false, true, true},
+		{"local node", "", "", "", false, false, true},
+		// Explicit --mode node: always runs a node, never serves a gateway.
+		{"mode node", "node", "", "tok", false, false, true},
+		{"mode node uplink", "node", "wss://h", "tok", true, false, true},
+		// Explicit --mode gateway: standalone gateway, no local node.
+		{"mode gateway", "gateway", "", "tok", false, true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := cfgWith(tc.url, tc.token)
+			cfg := cfgWithMode(tc.mode, tc.url, tc.token)
 			if got := uplinkMode(cfg); got != tc.wantUplink {
 				t.Errorf("uplinkMode = %v, want %v", got, tc.wantUplink)
 			}
-			if got := gatewayMode(cfg); got != tc.wantGateway {
-				t.Errorf("gatewayMode = %v, want %v", got, tc.wantGateway)
+			if got := serveGatewayMode(cfg); got != tc.wantGateway {
+				t.Errorf("serveGatewayMode = %v, want %v", got, tc.wantGateway)
+			}
+			if got := runLocalNode(cfg); got != tc.wantNode {
+				t.Errorf("runLocalNode = %v, want %v", got, tc.wantNode)
 			}
 		})
+	}
+}
+
+func TestValidateMode(t *testing.T) {
+	cases := []struct {
+		name             string
+		mode, url, token string
+		wantErr          bool
+	}{
+		{"unset", "", "", "", false},
+		{"unset with token infers co-located gateway", "", "", "tok", false},
+		{"node", "node", "", "", false},
+		{"node with uplink", "node", "wss://h", "", false},
+		{"node with uplink and token", "node", "wss://h", "tok", false},
+		{"node with token but no upstream", "node", "", "tok", true},
+		{"gateway with token", "gateway", "", "tok", false},
+		{"gateway without token", "gateway", "", "", true},
+		{"gateway with upstream", "gateway", "wss://h", "tok", true},
+		{"unknown mode", "relay", "", "tok", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMode(cfgWithMode(tc.mode, tc.url, tc.token))
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateMode err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// freeAddr returns an ephemeral loopback address. (Small reuse race, fine for a test.)
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return addr
+}
+
+// TestStartStandaloneGatewayServes drives `argus start --mode gateway` through
+// runStart: the gateway serves (reporting no nodes) and cancelling ctx returns cleanly.
+func TestStartStandaloneGatewayServes(t *testing.T) {
+	t.Cleanup(func() { config.LogLevel.Set(slog.LevelInfo) })
+
+	addr := freeAddr(t)
+	cfg := cfgWithMode("gateway", "", "secret")
+	cfg.Gateway.ListenAddr = addr
+	cfg.Log.Level = "error" // keep the run quiet
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- runStart(ctx, cancel, newStartCmd("test"), cfg, "test") }()
+
+	// serveGateway starts its listener asynchronously; poll until /client accepts.
+	url := "ws://" + addr + "/client"
+	deadline := time.Now().Add(3 * time.Second)
+	var client *api.Client
+	for client == nil {
+		if time.Now().After(deadline) {
+			t.Fatalf("gateway did not come up on %s", addr)
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("runStart returned before serving: %v", err)
+		default:
+		}
+		conn, derr := api.DialWSConn(ctx, url, "secret", nil)
+		if derr != nil {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		client = api.NewClient(conn)
+		defer conn.Close()
+		defer client.Close()
+	}
+
+	var info api.ServerInfo
+	if err := client.Call(api.MethodServerInfo, nil, &info); err != nil {
+		t.Fatalf("server.info: %v", err)
+	}
+	if len(info.Nodes) != 0 {
+		t.Errorf("standalone gateway must report no nodes, got %d", len(info.Nodes))
+	}
+
+	cancel() // simulate SIGINT/SIGTERM
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("runStart returned %v, want nil on clean shutdown", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("runStart did not return after ctx cancel")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,10 @@ import (
 
 // Config is the resolved argus configuration. Precedence: flags > env > file > defaults.
 type Config struct {
-	Socket  string
-	Token   string // shared gateway token: presented by clients/nodes, required by the gateway
+	Socket string
+	Token  string // shared gateway token: presented by clients/nodes, required by the gateway
+	// Mode selects the run topology: "node", "gateway", or empty to infer from URL/token.
+	Mode    string
 	Gateway GatewayConfig
 	Node    NodeConfig
 	Push    PushConfig
@@ -93,6 +95,7 @@ var defaults = map[string]any{
 	"token":                         "",
 	"gateway.url":                   "",
 	"gateway.listen-addr":           ":8443",
+	"mode":                          "",
 	"node.id":                       "",
 	"node.label":                    "",
 	"push.desktop.enabled":          false,
@@ -176,6 +179,7 @@ func FromViper(v *viper.Viper) Config {
 	return Config{
 		Socket: v.GetString("socket"),
 		Token:  v.GetString("token"),
+		Mode:   v.GetString("mode"),
 		Gateway: GatewayConfig{
 			URL:        v.GetString("gateway.url"),
 			ListenAddr: v.GetString("gateway.listen-addr"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,6 +111,35 @@ func TestArgusGatewayEnv(t *testing.T) {
 	}
 }
 
+func TestModeRoundTrips(t *testing.T) {
+	isolateConfigDir(t)
+	if got := load(t, "").Mode; got != "" {
+		t.Errorf("default mode = %q, want empty", got)
+	}
+
+	path := writeConfig(t, "mode: gateway\n")
+	if got := load(t, path).Mode; got != "gateway" {
+		t.Errorf("file mode = %q, want gateway", got)
+	}
+
+	t.Setenv("ARGUS_MODE", "node")
+	if got := load(t, "").Mode; got != "node" {
+		t.Errorf("ARGUS_MODE should map to mode, got %q", got)
+	}
+
+	v := viper.New()
+	if err := config.Load(v, path, false); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	fs := pflag.NewFlagSet("t", pflag.ContinueOnError)
+	fs.String("mode", "", "")
+	_ = fs.Set("mode", "node")
+	_ = v.BindPFlag("mode", fs.Lookup("mode"))
+	if got := config.FromViper(v).Mode; got != "node" {
+		t.Errorf("mode = %q, want flag 'node' to override file", got)
+	}
+}
+
 func TestFlagOverridesEnv(t *testing.T) {
 	t.Setenv("ARGUS_GATEWAY_LISTEN_ADDR", ":9999")
 	v := viper.New()


### PR DESCRIPTION
## Summary

Adds a `--mode` flag (env `ARGUS_MODE`) to `argus start` for explicit run-topology selection:

- `--mode node` — always runs the local node; never serves a gateway.
- `--mode gateway` — **standalone gateway**: no local node, a pure relay aggregating remote nodes that dial in over `/node`.

Empty `--mode` preserves the existing inference from `--gateway`/`--token`.

## Notes

- `validateMode` rejects unusable combos up front: `--mode gateway` requires `--token` and no upstream `--gateway`; `--mode node` with a token but no `--gateway` errors (token has nowhere to go).
- `serveGateway` tolerates `node == nil`; `runStart` is extracted from `RunE` so startup wiring is testable with a cancellable context.
- Tests cover the full mode × url × token matrix, config default/file/env/flag precedence, and the nil-node serve path end-to-end.