### PR TITLE
fix: report public url for cloudflare remote tunnel

### DIFF
--- a/cmd/argus/gateway_serve_test.go
+++ b/cmd/argus/gateway_serve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,6 +109,101 @@ func (failingTunnel) Command(string) (tunnel.CommandSpec, error) {
 	return tunnel.CommandSpec{}, errors.New("boom")
 }
 func (failingTunnel) ExtractURL(string) (string, bool) { return "", false }
+
+// silentTunnel's child never prints a URL — a remotely-managed tunnel whose ingress
+// argus can't parse. reportURL makes it print one line ExtractURL accepts, for the
+// suppression case.
+type silentTunnel struct{ reportURL string }
+
+func (silentTunnel) Name() string { return "silent" }
+func (p silentTunnel) Command(string) (tunnel.CommandSpec, error) {
+	script := "sleep 30"
+	if p.reportURL != "" {
+		script = "echo " + p.reportURL + "; sleep 30"
+	}
+	return tunnel.CommandSpec{Path: "/bin/sh", Args: []string{"-c", script}}, nil
+}
+
+func (p silentTunnel) ExtractURL(line string) (string, bool) {
+	if p.reportURL != "" && strings.Contains(line, p.reportURL) {
+		return p.reportURL, true
+	}
+	return "", false
+}
+
+// A tunnel that comes up but never reports a public URL must be fatal: pairing would
+// otherwise hand out the LAN URL and encode an unreachable address in the QR.
+func TestServeGatewayOnFatalWhenTunnelReportsNoURL(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orig := tunnelURLTimeout
+	tunnelURLTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { tunnelURLTimeout = orig })
+
+	fatal := make(chan struct{}, 1)
+	httpSrv := serveGateway(ctx, gatewayServeOpts{
+		node:         node.New(),
+		listener:     ln,
+		log:          logger.NewBufferLogger(logbuf.New(50)),
+		onFatal:      func() { fatal <- struct{}{} },
+		version:      "test",
+		tunnel:       silentTunnel{},
+		tunnelOrigin: "http://127.0.0.1:0",
+	})
+	t.Cleanup(func() {
+		sctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		_ = httpSrv.Shutdown(sctx)
+	})
+
+	select {
+	case <-fatal:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onFatal not called after the tunnel reported no public URL")
+	}
+}
+
+// The converse: a tunnel that does report a URL must never trip the timeout, or every
+// healthy tunnel dies a minute after start.
+func TestServeGatewayReportedURLSuppressesTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orig := tunnelURLTimeout
+	tunnelURLTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { tunnelURLTimeout = orig })
+
+	fatal := make(chan struct{}, 1)
+	httpSrv := serveGateway(ctx, gatewayServeOpts{
+		node:         node.New(),
+		listener:     ln,
+		log:          logger.NewBufferLogger(logbuf.New(50)),
+		onFatal:      func() { fatal <- struct{}{} },
+		version:      "test",
+		tunnel:       silentTunnel{reportURL: "https://argus.example.com"},
+		tunnelOrigin: "http://127.0.0.1:0",
+	})
+	t.Cleanup(func() {
+		sctx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		_ = httpSrv.Shutdown(sctx)
+	})
+
+	select {
+	case <-fatal:
+		t.Fatal("onFatal called despite the tunnel reporting a public URL")
+	case <-time.After(500 * time.Millisecond): // 10x the timeout
+	}
+}
 
 // A listener that dies after startup must invoke onFatal so `argus start` can exit
 // non-zero (and the embedded gateway can tear its stack down).

--- a/cmd/argus/start.go
+++ b/cmd/argus/start.go
@@ -334,6 +334,11 @@ func connectGateway(ctx context.Context, cfg *config.Config, d *node.Node) error
 	return nil
 }
 
+// tunnelURLTimeout: a tunnel running this long without reporting a public URL is
+// treated as fatal. Long enough for a slow first connect, short enough to beat a
+// pairing attempt. A var so tests can shrink it.
+var tunnelURLTimeout = 60 * time.Second
+
 // gatewayServeOpts configures serveGateway. Each capability is guarded by its own
 // flag so `argus start` (all on) and the embedded TUI gateway (tunnel off) share
 // one code path. The listener is pre-bound by the caller so bind errors surface
@@ -404,8 +409,27 @@ func serveGateway(ctx context.Context, o gatewayServeOpts) *http.Server {
 		tunLog := o.log.With("scope", "tunnel")
 		sup := tunnel.Supervisor{Logger: tunLog}
 		tunLog.Info("opening tunnel", "provider", o.tunnel.Name(), "origin", o.tunnelOrigin)
+		// If no URL arrives, pairing would silently hand out the LAN URL from
+		// gatewayBaseURL — fail instead of serving a wrong QR. Also catches a child the
+		// supervisor crash-restarts forever.
+		var gotURL atomic.Bool
+		urlTimer := time.AfterFunc(tunnelURLTimeout, func() {
+			// CAS, not Load: Stop() loses to a timer already firing, so a URL landing at
+			// exactly t=timeout would otherwise be both published and declared missing.
+			if !gotURL.CompareAndSwap(false, true) || ctx.Err() != nil {
+				return
+			}
+			tunLog.Error("tunnel opened but reported no public URL; pairing would use the local URL",
+				"provider", o.tunnel.Name(), "timeout", tunnelURLTimeout)
+			if o.onFatal != nil {
+				o.onFatal()
+			}
+		})
 		go func() {
+			defer urlTimer.Stop()
 			rerr := sup.Run(ctx, o.tunnel, o.tunnelOrigin, func(u string) {
+				gotURL.Store(true)
+				urlTimer.Stop()
 				hsrv.SetPublicURL(u)
 				tunLog.Info("tunnel public URL; run `argus pair` to add a device", "url", u)
 			})

--- a/cmd/argus/tunnel.go
+++ b/cmd/argus/tunnel.go
@@ -96,13 +96,9 @@ func resolveTunnel(o tunnelOptions) (tunnel.Provider, string, error) {
 		if cfMode == "local" && name == "" {
 			name = "argus" // default name for the tunnel argus creates and owns
 		}
+		// Cloudflare.Command floors the level for the modes that scrape their URL from
+		// output; which those are is the provider's business, not the CLI's.
 		cfLog := cloudflaredLogLevel(o.logLevel)
-		// A quick tunnel's public URL is only emitted by cloudflared at info or
-		// below, but argus's default (info -> warn) would suppress it — so floor
-		// quick mode at info. The INFO noise stays below the fold via ClassifyLine.
-		if cfMode == "quick" && cfLog != "debug" {
-			cfLog = "info"
-		}
 		// <UUID>.json creds live in the same dir as the origin cert.
 		var credsDir string
 		if cfMode == "local" {

--- a/cmd/argus/tunnel_test.go
+++ b/cmd/argus/tunnel_test.go
@@ -578,44 +578,61 @@ func TestCloudflaredLogLevel(t *testing.T) {
 	}
 }
 
-func TestResolveTunnelSetsCloudflaredLogLevel(t *testing.T) {
-	o := baseOpts()
-	o.provider = "cloudflare:remote" // remote keeps the plain info->warn offset
-	o.cfToken = "tok"
-	o.logLevel = slog.LevelInfo
-	p, _, err := resolveTunnel(o)
-	if err != nil {
-		t.Fatalf("resolve: %v", err)
-	}
-	cf, ok := p.(tunnel.Cloudflare)
-	if !ok {
-		t.Fatalf("provider type = %T", p)
-	}
-	if cf.LogLevel != "warn" {
-		t.Errorf("cf.LogLevel = %q, want warn (offset from info)", cf.LogLevel)
-	}
-}
-
-// A quick tunnel must run cloudflared at info (or below) or its public-URL banner
-// is never printed; the info->warn offset that suits other modes would hide it.
-func TestResolveTunnelQuickFloorsLogLevel(t *testing.T) {
-	cases := map[slog.Level]string{
+// The level cloudflared runs at is the argus level (via cloudflaredLogLevel) floored by
+// Cloudflare.Command for the scrape modes. Assert on the argv, since that is what
+// reaches the child.
+func TestResolveTunnelCloudflaredLogLevel(t *testing.T) {
+	scraped := map[slog.Level]string{
 		slog.Level(-8):  "debug", // trace: stays at debug (URL still emitted)
 		slog.LevelDebug: "debug",
 		slog.LevelInfo:  "info", // would be warn without the floor
 		slog.LevelWarn:  "info",
 		slog.LevelError: "info",
 	}
-	for in, want := range cases {
-		o := baseOpts() // no --cloudflare-* flags => quick mode
-		o.logLevel = in
-		p, _, err := resolveTunnel(o)
-		if err != nil {
-			t.Fatalf("resolve(%v): %v", in, err)
-		}
-		cf := p.(tunnel.Cloudflare)
-		if cf.LogLevel != want {
-			t.Errorf("quick LogLevel at argus %v = %q, want %q", in, cf.LogLevel, want)
+	local := map[slog.Level]string{
+		slog.Level(-8):  "debug",
+		slog.LevelDebug: "debug",
+		slog.LevelInfo:  "warn", // no floor: Prepare reports local's hostname
+		slog.LevelWarn:  "warn",
+		slog.LevelError: "error",
+	}
+	modes := []struct {
+		name  string
+		setup func(*tunnelOptions)
+		want  map[slog.Level]string
+	}{
+		{"quick", func(*tunnelOptions) {}, scraped}, // no --cloudflare-* flags => quick
+		{"remote", func(o *tunnelOptions) { o.provider = "cloudflare:remote"; o.cfToken = "tok" }, scraped},
+		{"local", func(o *tunnelOptions) { o.provider = "cloudflare:local"; o.cfHostname = "argus.example.com" }, local},
+	}
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			for in, want := range m.want {
+				o := baseOpts()
+				m.setup(&o)
+				o.logLevel = in
+				p, origin, err := resolveTunnel(o)
+				if err != nil {
+					t.Fatalf("resolve(%v): %v", in, err)
+				}
+				spec, err := p.Command(origin)
+				if err != nil {
+					t.Fatalf("Command(%v): %v", in, err)
+				}
+				if got := argValue(spec.Args, "--loglevel"); got != want {
+					t.Errorf("%s --loglevel at argus %v = %q, want %q", m.name, in, got, want)
+				}
+			}
+		})
+	}
+}
+
+// argValue returns the argument following flag, or "" if flag is absent or last.
+func argValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
 		}
 	}
+	return ""
 }

--- a/docs/guide/gateway-tunnel.md
+++ b/docs/guide/gateway-tunnel.md
@@ -13,6 +13,10 @@ with `--tunnel`; plain `--tunnel cloudflare` infers it from the `--cloudflare-*`
 flags. The tunnel edge terminates TLS; if it dies, Argus retries with backoff and
 keeps serving on your LAN.
 
+Whichever provider you pick, a tunnel that comes up but reports no public URL within
+a minute is fatal: Argus exits instead of handing out pairing QRs that encode the LAN
+address.
+
 ### Quick
 
 An ephemeral URL that changes on each run — fine for a quick pairing test.
@@ -29,6 +33,16 @@ its token:
 ```sh
 argus start --tunnel cloudflare:remote --cloudflare-token <CLOUDFLARE_TOKEN> --token <TOKEN>
 ```
+
+- Argus reads the public hostname from the tunnel's **remotely-managed ingress**, which
+  `cloudflared` reports once it connects — nothing to pass on the command line. If the
+  tunnel routes several public hostnames, the first one wins; wildcard (`*.example.com`)
+  and path-scoped rules are skipped, since neither yields a URL pairing can reach.
+- Configure the tunnel's public hostname to point at the gateway's listen address
+  (`http://localhost:8443` by default) in the Cloudflare dashboard.
+- Reading that ingress requires `cloudflared --loglevel info`, so this mode runs it one
+  level chattier than the others. The extra lines are classified as debug and stay below
+  the fold unless you pass `--log-level debug`.
 
 ### Local
 

--- a/internal/tunnel/cloudflare.go
+++ b/internal/tunnel/cloudflare.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/MunifTanjim/argus/internal/shell"
@@ -18,12 +19,23 @@ import (
 // quickURLRe matches the public URL cloudflared prints for a quick tunnel.
 var quickURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 
+// remoteConfigRe captures the Go-quoted config blob a remotely-managed cloudflared
+// logs on connect and on every config change:
+//
+//	<ts> INF Updated to new configuration config="{\"ingress\":[…]}" version=10
+//
+// The body pattern skips escaped characters, so the match ends at the first
+// *unescaped* quote — correct whether or not another quoted field follows, and for
+// a hostname or path that itself contains a quote.
+var remoteConfigRe = regexp.MustCompile(`config="((?:[^"\\]|\\.)*)"`)
+
 // Cloudflare runs cloudflared in one of three modes by which fields are set:
 //
 //   - quick: neither Token nor Tunnel set. Ephemeral unauthenticated tunnel with a
 //     printed *.trycloudflare.com URL.
 //   - remotely-managed: Token set. Hostname/ingress configured on Cloudflare's side;
-//     run with --token.
+//     run with --token. cloudflared logs the ingress it pulled, so the public
+//     hostname is scraped from its output (see remoteIngressHostname).
 //   - locally-managed: Tunnel set. argus creates the tunnel (if absent), routes a DNS
 //     record for Hostname to it, then runs it (credentials in ~/.cloudflared/<UUID>.json).
 type Cloudflare struct {
@@ -42,8 +54,8 @@ func (c Cloudflare) Name() string { return "cloudflare" }
 func (c Cloudflare) Command(origin string) (CommandSpec, error) {
 	// Global flags (incl. --loglevel) go after "tunnel" and before the subcommand.
 	base := []string{"tunnel", "--no-autoupdate"}
-	if c.LogLevel != "" {
-		base = append(base, "--loglevel", c.LogLevel)
+	if lvl := c.effectiveLogLevel(); lvl != "" {
+		base = append(base, "--loglevel", lvl)
 	}
 	switch {
 	case c.Tunnel != "":
@@ -57,10 +69,22 @@ func (c Cloudflare) Command(origin string) (CommandSpec, error) {
 	}
 }
 
+// effectiveLogLevel floors quick and remotely-managed modes at info: they scrape their
+// public URL from cloudflared output (see ExtractURL), which is emitted only at info or
+// below, so a caller asking for warn/error would never get a URL. ClassifyLine keeps the
+// resulting INF noise below argus's threshold. Locally-managed mode learns its hostname
+// from Prepare, so it keeps whatever level was asked for.
+func (c Cloudflare) effectiveLogLevel() string {
+	if c.Tunnel == "" && c.LogLevel != "" && c.LogLevel != "debug" {
+		return "info"
+	}
+	return c.LogLevel
+}
+
 // cfLevelByToken maps cloudflared's log-level tokens to slog levels. INF → Debug:
-// cloudflared's INFO is chatty noise, but quick mode must run at --loglevel info to
-// emit its URL banner (extracted separately via ExtractURL), so demote it below
-// argus's info threshold. FTL → Error, never fatal: classification only sets a level.
+// cloudflared's INFO is chatty noise, and the scrape modes must run at --loglevel info
+// (see effectiveLogLevel), so demote it below argus's info threshold. FTL → Error, never
+// fatal: classification only sets a level.
 var cfLevelByToken = map[string]slog.Level{
 	"DBG": slog.LevelDebug,
 	"INF": slog.LevelDebug,
@@ -85,11 +109,48 @@ func (c Cloudflare) ClassifyLine(line string) slog.Level {
 }
 
 func (c Cloudflare) ExtractURL(line string) (string, bool) {
-	if c.Token != "" || c.Tunnel != "" {
-		return "", false // configured hostname is not printed by cloudflared
+	switch {
+	case c.Tunnel != "":
+		return "", false // locally-managed: Hostname is known ahead of time, reported by Prepare
+	case c.Token != "":
+		return remoteIngressHostname(line)
+	default:
+		m := quickURLRe.FindString(line)
+		return m, m != ""
 	}
-	if m := quickURLRe.FindString(line); m != "" {
-		return m, true
+}
+
+// remoteIngressHostname pulls the public URL from the ingress a remotely-managed
+// cloudflared logs at INF ("Updated to new configuration"). Returns the first rule with
+// a usable hostname; the trailing catch-all (http_status:404) has none, and a tunnel
+// routing several hostnames yields the first — argus can't pick between them.
+func remoteIngressHostname(line string) (string, bool) {
+	m := remoteConfigRe.FindStringSubmatch(line)
+	if m == nil {
+		return "", false
+	}
+	// cloudflared escapes the blob Go-style, so unquote before parsing it as JSON.
+	raw, err := strconv.Unquote(`"` + m[1] + `"`)
+	if err != nil {
+		return "", false
+	}
+	var cfg struct {
+		Ingress []struct {
+			Hostname string `json:"hostname"`
+			Path     string `json:"path"`
+		} `json:"ingress"`
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return "", false
+	}
+	for _, in := range cfg.Ingress {
+		// A wildcard hostname doesn't resolve, and a path-scoped rule doesn't route the
+		// bare hostname. Either would publish a URL that pairing can't reach — and unlike
+		// every other failure here it would report success, so nothing downstream notices.
+		if in.Hostname == "" || strings.Contains(in.Hostname, "*") || in.Path != "" {
+			continue
+		}
+		return "https://" + in.Hostname, true
 	}
 	return "", false
 }

--- a/internal/tunnel/cloudflare_test.go
+++ b/internal/tunnel/cloudflare_test.go
@@ -49,11 +49,71 @@ func TestCloudflareExtractURLQuick(t *testing.T) {
 	}
 }
 
-func TestCloudflareExtractURLNamedNeverMatches(t *testing.T) {
+func TestCloudflareExtractURLRemote(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "single hostname",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"hostname\":\"argus.example.com\",\"originRequest\":{},\"service\":\"http://localhost:8443\"},{\"service\":\"http_status:404\"}],\"warp-routing\":{\"enabled\":false}}" version=10`,
+			want: "https://argus.example.com",
+		},
+		{
+			name: "several hostnames yields the first",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"hostname\":\"one.example.com\",\"service\":\"http://localhost:8443\"},{\"hostname\":\"two.example.com\",\"service\":\"http://localhost:9000\"},{\"service\":\"http_status:404\"}]}" version=3`,
+			want: "https://one.example.com",
+		},
+		{
+			name: "catch-all only",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"service\":\"http_status:404\"}]}" version=1`,
+		},
+		{
+			name: "unrelated line",
+			line: "2026-07-31T11:52:12Z INF Registered tunnel connection connIndex=0",
+		},
+		{
+			name: "quick-tunnel URL is not honoured in remote mode",
+			line: "2026-07-31T11:52:12Z INF |  https://fluffy-cat-123.trycloudflare.com  |",
+		},
+		{
+			name: "unterminated quote",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"hostname\":\"argus.example.com\"}]}`,
+		},
+		{
+			name: "malformed json",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[" version=1`,
+		},
+		{
+			name: "wildcard hostname is skipped for the next usable rule",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"hostname\":\"*.example.com\",\"service\":\"http://localhost:9000\"},{\"hostname\":\"argus.example.com\",\"service\":\"http://localhost:8443\"},{\"service\":\"http_status:404\"}]}" version=4`,
+			want: "https://argus.example.com",
+		},
+		{
+			name: "wildcard only yields nothing",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"hostname\":\"*.example.com\",\"service\":\"http://localhost:8443\"},{\"service\":\"http_status:404\"}]}" version=5`,
+		},
+		{
+			name: "path-scoped rule is skipped",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"hostname\":\"shared.example.com\",\"path\":\"/argus\",\"service\":\"http://localhost:8443\"},{\"service\":\"http_status:404\"}]}" version=6`,
+		},
+		{
+			// zerolog sorts fields, so anything quoted after config= must not extend the
+			// match past config's own closing quote.
+			name: "quoted field after config",
+			line: `2026-07-31T11:52:12Z INF Updated to new configuration config="{\"ingress\":[{\"hostname\":\"argus.example.com\",\"service\":\"http://localhost:8443\"}]}" event="reload" version=7`,
+			want: "https://argus.example.com",
+		},
+	}
 	c := Cloudflare{Bin: "cloudflared", Token: "tok"}
-	// Named mode's hostname is configured on Cloudflare's side, not printed.
-	if _, ok := c.ExtractURL("https://gateway.example.com is up"); ok {
-		t.Error("named tunnel must not report a URL")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := c.ExtractURL(tc.line)
+			if ok != (tc.want != "") || got != tc.want {
+				t.Errorf("ExtractURL = %q, %v; want %q, %v", got, ok, tc.want, tc.want != "")
+			}
+		})
 	}
 }
 
@@ -84,20 +144,40 @@ func TestCloudflareCommandLogLevel(t *testing.T) {
 		c    Cloudflare
 		want []string
 	}{
+		// Quick and remote scrape their URL from output, so anything above info is
+		// floored — at warn or error cloudflared never prints the line they need.
 		{
-			name: "quick",
+			name: "quick floors warn to info",
 			c:    Cloudflare{Bin: "cloudflared", LogLevel: "warn"},
-			want: []string{"tunnel", "--no-autoupdate", "--loglevel", "warn", "--url", "http://127.0.0.1:8443"},
+			want: []string{"tunnel", "--no-autoupdate", "--loglevel", "info", "--url", "http://127.0.0.1:8443"},
 		},
 		{
-			name: "remote",
+			name: "remote floors error to info",
 			c:    Cloudflare{Bin: "cloudflared", Token: "tok", LogLevel: "error"},
-			want: []string{"tunnel", "--no-autoupdate", "--loglevel", "error", "run", "--token", "tok"},
+			want: []string{"tunnel", "--no-autoupdate", "--loglevel", "info", "run", "--token", "tok"},
 		},
 		{
-			name: "local",
+			name: "quick keeps debug",
+			c:    Cloudflare{Bin: "cloudflared", LogLevel: "debug"},
+			want: []string{"tunnel", "--no-autoupdate", "--loglevel", "debug", "--url", "http://127.0.0.1:8443"},
+		},
+		{
+			// Empty omits the flag; cloudflared's own default is already info.
+			name: "quick unset omits the flag",
+			c:    Cloudflare{Bin: "cloudflared"},
+			want: []string{"tunnel", "--no-autoupdate", "--url", "http://127.0.0.1:8443"},
+		},
+		// Local knows its hostname up front (Prepare reports it), so it scrapes nothing
+		// and keeps whatever level was asked for.
+		{
+			name: "local keeps debug",
 			c:    Cloudflare{Bin: "cloudflared", Tunnel: "argus", LogLevel: "debug"},
 			want: []string{"tunnel", "--no-autoupdate", "--loglevel", "debug", "run", "--url", "http://127.0.0.1:8443", "argus"},
+		},
+		{
+			name: "local keeps error",
+			c:    Cloudflare{Bin: "cloudflared", Tunnel: "argus", LogLevel: "error"},
+			want: []string{"tunnel", "--no-autoupdate", "--loglevel", "error", "run", "--url", "http://127.0.0.1:8443", "argus"},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## What

A remotely-managed Cloudflare tunnel (`cloudflare:remote`) keeps its hostname on Cloudflare's side, so argus never reported a public URL. Pairing fell back to the LAN URL and put an unreachable address in the QR code.

Fix: scrape the hostname from the ingress `cloudflared` logs on connect. This log is the only source that needs no extra credentials (the CLI and REST API both need the origin cert or a separate API token). The match is structural, so a reworded log line does not break it.

## Also

- A tunnel that reports no public URL within 60s is now fatal, for **every** provider. Before, argus served a wrong pairing QR.
- The `--loglevel info` floor (needed to read the ingress line) moved from `resolveTunnel` into `Cloudflare.Command`, next to `Ngrok.Command` and `Zrok.Command`.

## Notes

- Wildcard and path-scoped ingress rules are skipped — neither gives a reachable URL.
- A tunnel with several hostnames yields the first; no override. Deferred.
- Pre-existing: a tunnel that reports a URL, dies, restarts, and stays silent keeps serving the stale URL (affects quick mode too). Own issue.

## Testing

`go build`, `go vet`, `go test`, and `-race` pass. Covers remote `ExtractURL` cases, the log-level floor, and the 60s timeout (both paths).
