### PR TITLE
fix: compare current version before upgrade

### DIFF
--- a/cmd/argus/upgrade.go
+++ b/cmd/argus/upgrade.go
@@ -25,15 +25,8 @@ func upgradeAssetName(tag, goos, goarch string) string {
 	return fmt.Sprintf("%s-%s-%s-%s", config.BinaryName, tag, goos, goarch)
 }
 
-func downloadLatestBinary(ctx context.Context, dst string) error {
-	useGH := util.HasTool("gh")
-
-	tag, err := latestTag(ctx, useGH)
-	if err != nil {
-		return fmt.Errorf("failed to resolve latest release: %w", err)
-	}
-	shell.StdErrF("Latest version: %s\n", tag)
-
+// downloadBinary writes the release binary for tag to dst.
+func downloadBinary(ctx context.Context, tag, dst string, useGH bool) error {
 	assetName := upgradeAssetName(tag, runtime.GOOS, runtime.GOARCH)
 	shell.StdErrF("Downloading %s...\n", assetName)
 
@@ -152,11 +145,26 @@ func newUpgradeCmd() *cobra.Command {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 			defer cancel()
 
+			useGH := util.HasTool("gh")
+			tag, err := latestTag(ctx, useGH)
+			if err != nil {
+				return fail(cmd, fmt.Errorf("failed to resolve latest release: %w", err))
+			}
+			currVersion := cmd.Root().Version
+
+			shell.StdErrF("Current version: %s\n", currVersion)
+			shell.StdErrF("Latest version: %s\n", tag)
+
+			if tag == currVersion {
+				shell.StdErrLn("Already on the latest version!")
+				return nil
+			}
+
 			// Keep the temp file beside the target so the final rename stays on the
 			// same filesystem (atomic, and safe to swap a running binary on Unix).
 			tempPath := execPath + ".tmp"
 
-			if err := downloadLatestBinary(ctx, tempPath); err != nil {
+			if err := downloadBinary(ctx, tag, tempPath, useGH); err != nil {
 				os.Remove(tempPath)
 				return fail(cmd, fmt.Errorf("failed to download: %w", err))
 			}
@@ -174,7 +182,7 @@ func newUpgradeCmd() *cobra.Command {
 
 			// Report success before refreshing completion: a completion problem must
 			// not mask that the upgrade itself already succeeded.
-			shell.StdErrLn("Upgraded to the latest version!")
+			shell.StdErrF("Upgraded to %s!\n", tag)
 
 			switch err := completion.Install(cmd); {
 			case err == nil:


### PR DESCRIPTION
`argus upgrade` never told you which version it was moving to, and it re-downloaded and swapped the binary even when already on the latest release.

Now it prints the current and latest version up front, names the version in the success message, and exits early when they match.

## QA

```sh
d=$(mktemp -d)

# outdated -> upgrades
go build -o "$d/argus" ./cmd/argus
"$d/argus" upgrade

v=$("$d/argus" --version | awk '{print $2}')

# already latest -> no download, no swap
go build -ldflags "-X main.version=$v" -o "$d/argus" ./cmd/argus
"$d/argus" upgrade

rm -rf "$d"
```

Expected:

```
Current version: dev
Latest version: 0.0.11
Downloading argus-0.0.11-darwin-arm64...
Verifying downloaded binary...
Upgraded to 0.0.11!

Current version: 0.0.11
Latest version: 0.0.11
Already on the latest version!
```

Runs in a temp dir, so your installed `argus` is untouched.