### PR TITLE
PR 5a — trust-log sync + authorized-device enforcement

### DIFF
--- a/cmd/argus/embed.go
+++ b/cmd/argus/embed.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -14,26 +15,41 @@ import (
 	"github.com/MunifTanjim/argus/internal/api"
 	"github.com/MunifTanjim/argus/internal/client"
 	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/e2e"
 	"github.com/MunifTanjim/argus/internal/logbuf"
 	"github.com/MunifTanjim/argus/internal/logger"
 	"github.com/MunifTanjim/argus/internal/node"
 	"github.com/MunifTanjim/argus/internal/push"
 	"github.com/MunifTanjim/argus/internal/shell"
+	"github.com/MunifTanjim/argus/internal/trustpin"
 	"github.com/MunifTanjim/argus/internal/tui"
 )
 
 // connect returns a client that re-dials with backoff if the connection drops. With a
-// gateway URL it dials over WebSocket; otherwise the local node's unix socket (which
-// must already be running — use connectLocalSpawn to start one first).
-// When gatewayURL is non-empty and cfg.E2EE.Enabled, an E2E (TOFU) client is returned;
-// otherwise a plaintext api.ReconnectingClient is used (unix socket is always plaintext).
-func connect(ctx context.Context, cfg *config.Config, gatewayURL, token, socket string) (tui.Client, error) {
+// gateway URL and E2EE enabled it dials over E2E; otherwise the local node's unix socket
+// (which must already be running — use connectLocalSpawn to start one first) uses
+// plaintext. When head is non-nil the E2E client enforces the trust log (locked mode);
+// otherwise it uses TOFU.
+func connect(ctx context.Context, cfg *config.Config, gatewayURL, token, socket string, head []byte) (tui.Client, error) {
 	dial, err := gatewayDialer(gatewayURL, token, socket)
 	if err != nil {
 		shell.StdErrF("argus: %v\n", err)
 		return nil, err
 	}
 	if gatewayURL != "" && cfg.E2EE.Enabled {
+		if len(head) > 0 {
+			static, ierr := e2e.LoadOrCreateIdentity(config.GetStatePath("client-identity.json"))
+			if ierr != nil {
+				shell.StdErrF("argus: client identity: %v\n", ierr)
+				return nil, ierr
+			}
+			c, err := client.NewReconnectingE2EClientLocked(ctx, dial, head, static, config.GetStatePath("client-trustlog-chain"))
+			if err != nil {
+				shell.StdErrF("argus: cannot establish e2e session with gateway at %s: %v\n", gatewayURL, err)
+				return nil, err
+			}
+			return c, nil
+		}
 		c, err := client.NewReconnectingE2EClient(ctx, dial)
 		if err != nil {
 			shell.StdErrF("argus: cannot connect to gateway at %s: %v\n", gatewayURL, err)
@@ -87,14 +103,15 @@ func localNodeRunning(socket string) (bool, error) {
 // connectLocalSpawn starts an ephemeral embedded node (tied to ctx), waits for it to
 // accept, then connects. Returns the node's log buffer for the TUI's Logs tab.
 func connectLocalSpawn(ctx context.Context, cfg *config.Config, token, socket string) (tui.Client, *logbuf.Buffer, error) {
-	return connectLocalSpawnWithGateway(ctx, cfg, "", token, socket)
+	return connectLocalSpawnWithGateway(ctx, cfg, "", token, socket, nil)
 }
 
 // connectLocalSpawnWithGateway starts an ephemeral embedded node (tied to ctx). Empty
 // gatewayURL (isolated spawn): the TUI drives the local socket. Set gatewayURL
 // (connected spawn): the node uplinks to that gateway so this machine joins the fleet,
 // and the TUI drives the gateway so it sees the whole fleet, this machine included.
-func connectLocalSpawnWithGateway(ctx context.Context, cfg *config.Config, gatewayURL, token, socket string) (tui.Client, *logbuf.Buffer, error) {
+// genesisHash is the client's resolved trust root; nil means TOFU.
+func connectLocalSpawnWithGateway(ctx context.Context, cfg *config.Config, gatewayURL, token, socket string, genesisHash []byte) (tui.Client, *logbuf.Buffer, error) {
 	var wsURL string
 	var gatewayClient *http.Client
 	if gatewayURL != "" {
@@ -112,7 +129,11 @@ func connectLocalSpawnWithGateway(ctx context.Context, cfg *config.Config, gatew
 		}
 		probe.Close()
 	}
-	d, logs := startEmbeddedNode(ctx, cfg, socket)
+	d, logs, serr := startEmbeddedNode(ctx, cfg, socket)
+	if serr != nil {
+		shell.StdErrF("argus: %v\n", serr)
+		return nil, nil, serr
+	}
 	if gatewayURL != "" {
 		go d.ConnectGateway(ctx, wsURL, token, gatewayClient)
 	} else if cfg.Push.Desktop.Enabled {
@@ -131,7 +152,7 @@ func connectLocalSpawnWithGateway(ctx context.Context, cfg *config.Config, gatew
 	}
 	conn.Close() // probe only; the client opens its own connection
 	// Isolated spawn drives the local node; connected spawn drives the gateway.
-	c, err := connect(ctx, cfg, gatewayURL, token, socket)
+	c, err := connect(ctx, cfg, gatewayURL, token, socket, genesisHash)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -160,7 +181,12 @@ func connectLocalGateway(ctx context.Context, cfg *config.Config, socket string)
 	// as a disconnect.
 	ctx, cancel := context.WithCancel(ctx)
 
-	d, logs := startEmbeddedNode(ctx, cfg, socket)
+	d, logs, serr := startEmbeddedNode(ctx, cfg, socket)
+	if serr != nil {
+		cancel()
+		shell.StdErrF("argus: %v\n", serr)
+		return nil, nil, serr
+	}
 	baseLog := logger.NewBufferLogger(logs)
 	gwLog := baseLog.With("scope", "gateway")
 	httpSrv := serveGateway(ctx, gatewayServeOpts{
@@ -201,7 +227,13 @@ func connectLocalGateway(ctx context.Context, cfg *config.Config, socket string)
 	}
 	probe.Close()
 
-	c, err := connect(ctx, cfg, gwURL, cfg.Token, socket)
+	pin, perr := trustpin.Resolve(cfg.Lock.Genesis, clientPinFile())
+	if perr != nil {
+		cancel()
+		shell.StdErrF("argus: %v\n", fmt.Errorf("refusing to connect open: %w", perr))
+		return nil, nil, fmt.Errorf("refusing to connect open: %w", perr)
+	}
+	c, err := connect(ctx, cfg, gwURL, cfg.Token, socket, pin.Genesis)
 	if err != nil {
 		cancel()
 		return nil, nil, err
@@ -231,7 +263,10 @@ func nodeAbsent(err error) bool {
 // alt-screen clean. Like `argus start` it reconciles installed Claude Code hooks,
 // but keeps the installed binary path: this ephemeral launch may run from a
 // different path than the install, which must not be written into the user's hooks.
-func startEmbeddedNode(ctx context.Context, cfg *config.Config, socket string) (*node.Node, *logbuf.Buffer) {
+//
+// Fail-closed: a non-empty but unusable lock.genesis is returned as an error so the
+// node is never started in open mode when a genesis is configured.
+func startEmbeddedNode(ctx context.Context, cfg *config.Config, socket string) (*node.Node, *logbuf.Buffer, error) {
 	d := node.New()
 	logs := logbuf.New(1000)
 	log := logger.NewBufferLogger(logs)
@@ -241,9 +276,14 @@ func startEmbeddedNode(ctx context.Context, cfg *config.Config, socket string) (
 	d.SetVersion(version)
 	// Without this the embedded node drops every desktop alert.
 	d.SetDesktopNotify(cfg.Push.Desktop.Enabled, desktopClickCmd(cfg))
+	if cfg.E2EE.Enabled {
+		if err := configureNodeLock(d, cfg, log.With("scope", "node")); err != nil {
+			return nil, nil, err
+		}
+	}
 	reconcileEmbeddedHooks(log.With("scope", "hooks"))
 	go func() { _ = d.Run(ctx, socket) }()
-	return d, logs
+	return d, logs, nil
 }
 
 // reconcileEmbeddedHooks reconciles hooks best-effort (empty bin keeps the installed path).

--- a/cmd/argus/main_test.go
+++ b/cmd/argus/main_test.go
@@ -72,9 +72,7 @@ func TestConnectLocalSpawn(t *testing.T) {
 	}
 }
 
-// An embedded node must opt into desktop notifications when config enables them;
-// otherwise it silently drops every alert (gateway push.desktop RPC and the local
-// Watch both gate on this flag).
+// An embedded node must opt into desktop notifications when config enables them.
 func TestEmbeddedNodeOptsIntoDesktopNotify(t *testing.T) {
 	sandboxHookDirs(t)
 	sock := shortSocket(t)

--- a/cmd/argus/main_test.go
+++ b/cmd/argus/main_test.go
@@ -83,7 +83,10 @@ func TestEmbeddedNodeOptsIntoDesktopNotify(t *testing.T) {
 
 	cfg := &config.Config{}
 	cfg.Push.Desktop.Enabled = true
-	d, _ := startEmbeddedNode(ctx, cfg, sock)
+	d, _, err := startEmbeddedNode(ctx, cfg, sock)
+	if err != nil {
+		t.Fatalf("startEmbeddedNode: %v", err)
+	}
 	if !d.DesktopNotifyEnabled() {
 		t.Fatal("embedded node should render desktop notifications when config enables them")
 	}
@@ -102,7 +105,7 @@ func TestConnectLocalSpawnWithGatewayEnrolls(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c, _, err := connectLocalSpawnWithGateway(ctx, &config.Config{}, wsURL(ts.URL), "", sock)
+	c, _, err := connectLocalSpawnWithGateway(ctx, &config.Config{}, wsURL(ts.URL), "", sock, nil)
 	if err != nil {
 		t.Fatalf("connectLocalSpawnWithGateway: %v", err)
 	}
@@ -136,12 +139,12 @@ func TestConnectLocalSpawnWithGatewayReportsBadGateway(t *testing.T) {
 	defer cancel()
 
 	// Wrong token: the gateway rejects the upgrade, so the probe must fail.
-	if _, _, err := connectLocalSpawnWithGateway(ctx, &config.Config{}, wsURL(ts.URL), "WRONG", shortSocket(t)); err == nil {
+	if _, _, err := connectLocalSpawnWithGateway(ctx, &config.Config{}, wsURL(ts.URL), "WRONG", shortSocket(t), nil); err == nil {
 		t.Fatal("expected an error for a rejected gateway token")
 	}
 
 	// Unreachable host: dial failure must also surface.
-	if _, _, err := connectLocalSpawnWithGateway(ctx, &config.Config{}, "ws://127.0.0.1:1", "right", shortSocket(t)); err == nil {
+	if _, _, err := connectLocalSpawnWithGateway(ctx, &config.Config{}, "ws://127.0.0.1:1", "right", shortSocket(t), nil); err == nil {
 		t.Fatal("expected an error for an unreachable gateway")
 	}
 }

--- a/cmd/argus/nodelock.go
+++ b/cmd/argus/nodelock.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+// configureNodeLock loads the node's e2ee identity, then activates locked mode
+// from the resolved genesis pin. Call it only when cfg.E2EE.Enabled is true.
+//
+// It fails CLOSED on the identity: when e2ee is enabled the identity must load,
+// because a node left with the trust log on but encryption off serves
+// unauthenticated plaintext channels — a locked-mode bypass.
+func configureNodeLock(d *node.Node, cfg *config.Config, log *slog.Logger) error {
+	kp, err := e2e.LoadOrCreateIdentity(config.GetStatePath("node-identity.json"))
+	if err != nil {
+		return fmt.Errorf("e2ee enabled but identity unavailable (refusing to start open): %w", err)
+	}
+	d.SetIdentityKey(kp)
+	d.SetE2EE(true)
+
+	pin, perr := trustpin.Resolve(cfg.Lock.Genesis, nodePinFile())
+	if perr != nil {
+		return fmt.Errorf("refusing to start open: %w", perr)
+	}
+	d.SetPinSource(pin.Source.String())
+	chainPath := config.GetStatePath("trustlog-chain")
+	if head := pin.Genesis; len(head) > 0 {
+		if err := d.EnableTrustLog(head, chainPath); err != nil {
+			return fmt.Errorf("locked mode configured but enabling trust log failed (refusing to start open): %w", err)
+		}
+	} else {
+		d.SetTrustChainPath(chainPath)
+	}
+	return nil
+}

--- a/cmd/argus/nodelock_test.go
+++ b/cmd/argus/nodelock_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/node"
+)
+
+func nodeLockTempStateDir(t *testing.T) {
+	t.Helper()
+	old := config.StateDir
+	config.StateDir = t.TempDir()
+	t.Cleanup(func() { config.StateDir = old })
+}
+
+// A node configured for e2ee whose identity file is corrupt must refuse to start
+// (fail closed) rather than run with the trust log on but encryption off, which
+// would serve unauthenticated plaintext channels — a locked-mode bypass.
+func TestConfigureNodeLockFailsClosedOnBadIdentity(t *testing.T) {
+	nodeLockTempStateDir(t)
+	if err := os.WriteFile(config.GetStatePath("node-identity.json"), []byte("not a valid identity"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d := node.New()
+	cfg := &config.Config{}
+	cfg.E2EE.Enabled = true
+
+	err := configureNodeLock(d, cfg, slog.New(slog.DiscardHandler))
+
+	if err == nil {
+		t.Fatal("want an error (refuse to start) on a corrupt identity, got nil")
+	}
+	if d.TrustStore() != nil {
+		t.Error("trust log must not be enabled after an identity failure")
+	}
+}
+
+// A fresh node (no pin, TOFU) still starts: the fail-closed policy must not turn
+// a normal e2ee startup into an error.
+func TestConfigureNodeLockStartsWithFreshIdentity(t *testing.T) {
+	nodeLockTempStateDir(t)
+	d := node.New()
+	cfg := &config.Config{}
+	cfg.E2EE.Enabled = true
+
+	if err := configureNodeLock(d, cfg, slog.New(slog.DiscardHandler)); err != nil {
+		t.Fatalf("fresh identity (TOFU) must start, got %v", err)
+	}
+}

--- a/cmd/argus/pin.go
+++ b/cmd/argus/pin.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+// nodePinFile is the local node's genesis pin, kept beside its chain.
+func nodePinFile() *trustpin.File {
+	return trustpin.New(config.GetStatePath("trustlog-genesis"))
+}
+
+// clientPinFile is this device's client-role genesis pin. A machine running both
+// roles pins both; they always hold the same trust root.
+func clientPinFile() *trustpin.File {
+	return trustpin.New(config.GetStatePath("client-trustlog-genesis"))
+}

--- a/cmd/argus/root.go
+++ b/cmd/argus/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/MunifTanjim/argus/internal/api"
 	"github.com/MunifTanjim/argus/internal/logbuf"
 	"github.com/MunifTanjim/argus/internal/shell"
+	"github.com/MunifTanjim/argus/internal/trustpin"
 	"github.com/MunifTanjim/argus/internal/tui"
 )
 
@@ -47,6 +49,15 @@ func newRootCmd(version string) *cobra.Command {
 				return errSilent
 			}
 
+			var head []byte
+			if cfg.E2EE.Enabled {
+				pin, perr := trustpin.Resolve(cfg.Lock.Genesis, clientPinFile())
+				if perr != nil {
+					return fail(cmd, fmt.Errorf("refusing to connect open: %w", perr))
+				}
+				head = pin.Genesis
+			}
+
 			var client tui.Client
 			var logs *logbuf.Buffer
 			switch {
@@ -55,12 +66,12 @@ func newRootCmd(version string) *cobra.Command {
 				// spawn an ephemeral one enrolled on the same gateway so this machine joins
 				// too; otherwise the running node enrolls itself.
 				if running {
-					client, err = connect(ctx, cfg, cfg.Gateway.URL, cfg.Token, cfg.Socket)
+					client, err = connect(ctx, cfg, cfg.Gateway.URL, cfg.Token, cfg.Socket, head)
 				} else {
-					client, logs, err = connectLocalSpawnWithGateway(ctx, cfg, cfg.Gateway.URL, cfg.Token, cfg.Socket)
+					client, logs, err = connectLocalSpawnWithGateway(ctx, cfg, cfg.Gateway.URL, cfg.Token, cfg.Socket, head)
 				}
 			case running:
-				client, err = connect(ctx, cfg, "", cfg.Token, cfg.Socket)
+				client, err = connect(ctx, cfg, "", cfg.Token, cfg.Socket, nil)
 			default:
 				choice, lerr := runLauncher(cfg.Token)
 				if lerr != nil {
@@ -74,9 +85,9 @@ func newRootCmd(version string) *cobra.Command {
 				case launchSpawnGateway:
 					client, logs, err = connectLocalGateway(ctx, cfg, cfg.Socket)
 				case launchSpawnConnected:
-					client, logs, err = connectLocalSpawnWithGateway(ctx, cfg, choice.gatewayURL, choice.token, cfg.Socket)
+					client, logs, err = connectLocalSpawnWithGateway(ctx, cfg, choice.gatewayURL, choice.token, cfg.Socket, head)
 				case launchGateway:
-					client, err = connect(ctx, cfg, choice.gatewayURL, choice.token, cfg.Socket)
+					client, err = connect(ctx, cfg, choice.gatewayURL, choice.token, cfg.Socket, head)
 				}
 			}
 			if err != nil {

--- a/cmd/argus/start.go
+++ b/cmd/argus/start.go
@@ -18,7 +18,6 @@ import (
 	"github.com/MunifTanjim/argus/internal/adapters"
 	"github.com/MunifTanjim/argus/internal/clienttoken"
 	"github.com/MunifTanjim/argus/internal/config"
-	"github.com/MunifTanjim/argus/internal/e2e"
 	"github.com/MunifTanjim/argus/internal/gateway"
 	"github.com/MunifTanjim/argus/internal/logger"
 	applog "github.com/MunifTanjim/argus/internal/logger/log"
@@ -134,12 +133,8 @@ func runStart(ctx context.Context, stop context.CancelFunc, cmd *cobra.Command, 
 	}
 
 	if local && cfg.E2EE.Enabled {
-		kp, err := e2e.LoadOrCreateIdentity(config.GetStatePath("node-identity.json"))
-		if err != nil {
-			logger.Scoped("node").Warn("e2ee identity unavailable; running plaintext uplink", "err", err)
-		} else {
-			d.SetIdentityKey(kp)
-			d.SetE2EE(true)
+		if err := configureNodeLock(d, cfg, slog.Default().With("scope", "node")); err != nil {
+			return fail(cmd, err)
 		}
 	}
 

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -612,6 +612,19 @@ type TrustLogSyncResult struct {
 	Disjoint bool     `json:"disjoint,omitempty"`
 }
 
+// TrustLogPushParams carries individually marshalled entries a node is publishing
+// to the gateway, ordered parents before children.
+type TrustLogPushParams struct {
+	Entries [][]byte `json:"entries,omitempty"`
+}
+
+// TrustLogChangedParams is the payload of a MethodTrustLogChanged notification.
+// Heads are the gateway's head hashes after the change. A receiver that already
+// holds every one of them has nothing to fetch and can skip the sync entirely.
+type TrustLogChangedParams struct {
+	Heads [][]byte `json:"heads,omitempty"`
+}
+
 // NodeDescriptor is one node in the gateway's roster (nodes.list / node.event). It
 // carries the node's Noise static public key so an E2E client can open a channel
 // (Noise IK precondition), and the online flag the gateway derives from socket +

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Tunnel  TunnelConfig
 	Tmux    TmuxConfig
 	E2EE    E2EEConfig
+	Lock    LockConfig
 }
 
 type GatewayConfig struct {
@@ -95,6 +96,11 @@ type E2EEConfig struct {
 	Enabled bool
 }
 
+// Lock.Genesis is the base64 trust-log genesis this install is pinned to; "" = not configured (open/TOFU).
+type LockConfig struct {
+	Genesis string
+}
+
 // defaults are the built-in fallback values for unset keys.
 var defaults = map[string]any{
 	"socket":                        GetRuntimePath("argus.sock"),
@@ -118,6 +124,7 @@ var defaults = map[string]any{
 	"tmux.mirror-session-prefix":    "_",
 	"tmux.mirror-session-suffix":    "_",
 	"e2ee.enabled":                  false,
+	"lock.genesis":                  "",
 }
 
 // Load configures v with argus's defaults, env binding, and config file. configPath,
@@ -230,6 +237,9 @@ func FromViper(v *viper.Viper) Config {
 		},
 		E2EE: E2EEConfig{
 			Enabled: v.GetBool("e2ee.enabled"),
+		},
+		Lock: LockConfig{
+			Genesis: v.GetString("lock.genesis"),
 		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -262,3 +262,17 @@ func TestE2EEFromEnv(t *testing.T) {
 		t.Fatal("e2ee.enabled from env = false, want true")
 	}
 }
+
+func TestLockGenesisDefaultEmpty(t *testing.T) {
+	isolateConfigDir(t)
+	if c := load(t, ""); c.Lock.Genesis != "" {
+		t.Fatalf("lock.genesis default = %q, want empty", c.Lock.Genesis)
+	}
+}
+
+func TestLockGenesisFromFile(t *testing.T) {
+	path := writeConfig(t, "lock:\n  genesis: abc123\n")
+	if c := load(t, path); c.Lock.Genesis != "abc123" {
+		t.Fatalf("lock.genesis from file = %q, want abc123", c.Lock.Genesis)
+	}
+}

--- a/internal/e2etest/lock_enforcement_e2e_test.go
+++ b/internal/e2etest/lock_enforcement_e2e_test.go
@@ -1,0 +1,214 @@
+package e2etest
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+// TestLockEnforcement is the PR 5a acceptance test: on a pinned locked-mode
+// network an authorized device connects and an unauthorized device is rejected.
+func TestLockEnforcement(t *testing.T) {
+	agg := gateway.New(time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("node keypair: %v", err)
+	}
+	n := node.New()
+	n.SetIdentity("le-node", "Lock Enforcement Node")
+	n.SetVersion("itest")
+	n.SetIdentityKey(nodeKP)
+	n.SetE2EE(true)
+
+	signer, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	authKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("authKP: %v", err)
+	}
+
+	tlog, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+
+	// Authorize the node's identity pub so locked clients open a channel to it.
+	if err := tlog.AuthorizeDevice(nodeKP.Public, signer); err != nil {
+		t.Fatalf("AuthorizeDevice(node): %v", err)
+	}
+	// Authorize the client's static so the node accepts its channel.
+	if err := tlog.AuthorizeDevice(authKP.Public, signer); err != nil {
+		t.Fatalf("AuthorizeDevice(authKP): %v", err)
+	}
+	chain := trustlog.MarshalChain(tlog.Entries())
+
+	dir := t.TempDir()
+	nodeChainPath := filepath.Join(dir, "node-trustlog")
+	if err := os.WriteFile(nodeChainPath, chain, 0o600); err != nil {
+		t.Fatalf("write node chain: %v", err)
+	}
+	if err := n.EnableTrustLog(genesisHash, nodeChainPath); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	go n.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	pollConn, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	if err != nil {
+		t.Fatalf("poll dial: %v", err)
+	}
+	poll := api.NewClient(pollConn)
+	waitFor(t, "le-node online", func() bool {
+		var r api.NodesListResult
+		if poll.Call(api.MethodNodesList, nil, &r) != nil {
+			return false
+		}
+		for _, nd := range r.Nodes {
+			if nd.ID == "le-node" && nd.IdentityPubKey != "" && nd.Online {
+				return true
+			}
+		}
+		return false
+	})
+	poll.Close()
+
+	// The chain is also written to disk for the client so the trust store is seeded
+	// from disk, sidestepping a race where the client syncs before the node pushes.
+	clientChainPath := filepath.Join(dir, "client-trustlog")
+	if err := os.WriteFile(clientChainPath, chain, 0o600); err != nil {
+		t.Fatalf("write client chain: %v", err)
+	}
+
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	}
+
+	t.Run("authorized", func(t *testing.T) {
+		c, err := client.NewReconnectingE2EClientLocked(ctx, dial, genesisHash, authKP, clientChainPath)
+		if err != nil {
+			t.Fatalf("NewReconnectingE2EClientLocked: %v", err)
+		}
+		defer c.Close()
+
+		var roster api.NodesListResult
+		if err := c.Call(api.MethodNodesList, nil, &roster); err != nil {
+			t.Fatalf("nodes.list: %v", err)
+		}
+		if len(roster.Nodes) == 0 {
+			t.Fatal("nodes.list: empty roster")
+		}
+
+		var agents api.AgentsListResult
+		if err := c.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "le-node"}, &agents); err != nil {
+			t.Fatalf("agents.list over E2E (authorized): %v", err)
+		}
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		// Short timeout so the test does not block for the production 10-second window
+		// while waiting for a msg2 the node will never send.
+		client.SetHandshakeTimeoutForTest(500 * time.Millisecond)
+		t.Cleanup(func() { client.SetHandshakeTimeoutForTest(10 * time.Second) })
+
+		unauthKP, err := e2e.GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("unauthKP: %v", err)
+		}
+		// Same chain: the client's trust store accepts the node (nodeKP.Public is in
+		// the chain) but the node rejects this client (unauthKP.Public is absent).
+		c, err := client.NewReconnectingE2EClientLocked(ctx, dial, genesisHash, unauthKP, clientChainPath)
+		if err != nil {
+			t.Fatalf("NewReconnectingE2EClientLocked: %v", err)
+		}
+		defer c.Close()
+
+		var agents api.AgentsListResult
+		err = c.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "le-node"}, &agents)
+		if err == nil {
+			t.Fatal("unauthorized client: agents.list succeeded; node should have rejected the channel")
+		}
+		if !isTransportErr(err) {
+			// err is an *api.RPCError — the sealed call reached the node handler,
+			// meaning enforcement did not fire (security defect in Task 3/4 wiring).
+			t.Fatalf("unauthorized client: enforcement did not fire — sealed call reached node handler: %v", err)
+		}
+	})
+
+	t.Run("tofu", func(t *testing.T) {
+		// A separate gateway with a TOFU node (SetTrustChainPath only, no
+		// EnableTrustLog) confirms that the default open-mode behavior is unchanged.
+		tofuAgg := gateway.New(time.Second)
+		tofuSrv := gateway.NewServer(tofuAgg, nil, nil)
+		tofuTS := httptest.NewServer(tofuSrv.Handler())
+		defer tofuTS.Close()
+
+		tofuKP, err := e2e.GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("TOFU node keypair: %v", err)
+		}
+		tn := node.New()
+		tn.SetIdentity("tofu-node", "TOFU Node")
+		tn.SetVersion("itest")
+		tn.SetIdentityKey(tofuKP)
+		tn.SetE2EE(true)
+		tn.SetTrustChainPath(filepath.Join(t.TempDir(), "tofu-chain"))
+		go tn.ConnectGateway(ctx, wsURL(tofuTS.URL, "/node"), "", nil)
+
+		tofuPollConn, err := api.DialWSConn(ctx, wsURL(tofuTS.URL, "/client"), "", nil)
+		if err != nil {
+			t.Fatalf("TOFU poll dial: %v", err)
+		}
+		tofuPoll := api.NewClient(tofuPollConn)
+		waitFor(t, "tofu-node online", func() bool {
+			var r api.NodesListResult
+			if tofuPoll.Call(api.MethodNodesList, nil, &r) != nil {
+				return false
+			}
+			for _, nd := range r.Nodes {
+				if nd.ID == "tofu-node" && nd.IdentityPubKey != "" && nd.Online {
+					return true
+				}
+			}
+			return false
+		})
+		tofuPoll.Close()
+
+		tofuDial := func(ctx context.Context) (net.Conn, error) {
+			return api.DialWSConn(ctx, wsURL(tofuTS.URL, "/client"), "", nil)
+		}
+		c, err := client.NewReconnectingE2EClient(ctx, tofuDial)
+		if err != nil {
+			t.Fatalf("NewReconnectingE2EClient (TOFU): %v", err)
+		}
+		defer c.Close()
+
+		var roster api.NodesListResult
+		if err := c.Call(api.MethodNodesList, nil, &roster); err != nil {
+			t.Fatalf("nodes.list (TOFU): %v", err)
+		}
+		var agents api.AgentsListResult
+		if err := c.Call(api.MethodAgentsList, nil, &agents); err != nil {
+			t.Fatalf("agents.list over E2E (TOFU): %v", err)
+		}
+	})
+}

--- a/internal/gateway/aggregator.go
+++ b/internal/gateway/aggregator.go
@@ -178,6 +178,12 @@ func (a *Aggregator) SubscribeRoster() (<-chan api.NodeEvent, func()) {
 	}
 }
 
+// PublishTrustChanged broadcasts a trust-changed roster event to all subscribers,
+// signalling that clients should pull the trust log promptly.
+func (a *Aggregator) PublishTrustChanged() {
+	a.publishRoster(api.NodeEvent{Type: api.NodeEventTrustChanged})
+}
+
 func (a *Aggregator) publishRoster(ev api.NodeEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/internal/gateway/aggregator_test.go
+++ b/internal/gateway/aggregator_test.go
@@ -98,6 +98,36 @@ func TestNodeIDFromParams(t *testing.T) {
 	}
 }
 
+func TestPublishTrustChanged(t *testing.T) {
+	a := New(0)
+	events, cancel := a.SubscribeRoster()
+	defer cancel()
+
+	a.PublishTrustChanged()
+
+	ev := recvRosterEvent(t, events)
+	if ev.Type != api.NodeEventTrustChanged {
+		t.Fatalf("want %q event, got %q", api.NodeEventTrustChanged, ev.Type)
+	}
+	if ev.Node.ID != "" {
+		t.Fatalf("trust-changed event should have empty Node, got %+v", ev.Node)
+	}
+}
+
+func TestPublishTrustChangedNotMixedWithRosterEvent(t *testing.T) {
+	a := New(0)
+	events, cancel := a.SubscribeRoster()
+	defer cancel()
+
+	src := newFakeSource("home", "home-box")
+	a.AddSource(src)
+
+	ev := recvRosterEvent(t, events)
+	if ev.Type == api.NodeEventTrustChanged {
+		t.Fatal("AddSource should not emit a trust-changed event")
+	}
+}
+
 func TestRosterAndSubscribeRoster(t *testing.T) {
 	a := New(0)
 	events, cancel := a.SubscribeRoster()

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -616,6 +616,7 @@ func (s *Server) serveNode(conn net.Conn) {
 			added, _ := s.entries.PutAll(p.Entries)
 			if added > 0 {
 				s.notifyNodePeers(self.Load(), api.MethodTrustLogChanged, api.TrustLogChangedParams{Heads: s.entries.Heads()})
+				s.agg.PublishTrustChanged()
 			}
 			return nil, nil
 		default:

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MunifTanjim/argus/internal/api"
 	"github.com/MunifTanjim/argus/internal/clienttoken"
 	"github.com/MunifTanjim/argus/internal/push"
+	"github.com/MunifTanjim/argus/internal/trustlog"
 )
 
 // Server exposes an Aggregator over /node (node uplinks) and /client (consumers).
@@ -39,6 +40,7 @@ type Server struct {
 	relayMu   sync.Mutex
 	channels  map[string]*relayChannel // chan_id -> paired client/node + pumps
 	nodePeers map[string]*api.Peer     // node id -> live uplink peer (relay.open target)
+	entries   *trustlog.EntryStore     // retained trust-log entries (blind)
 	nextChan  atomic.Uint64            // chan_id allocator
 	log       *slog.Logger             // relay lifecycle logging; nil disables
 }
@@ -50,6 +52,7 @@ func NewServer(agg *Aggregator, nodeAuth, clientAuth func(token string) bool) *S
 		pairWaiters: map[string]<-chan struct{}{},
 		channels:    map[string]*relayChannel{},
 		nodePeers:   map[string]*api.Peer{},
+		entries:     trustlog.NewEntryStore(),
 	}
 	s.clientSrv = s.buildClientServer()
 	s.clientSrv.SetRelayFrameHandler(s.forwardFromClient)
@@ -466,6 +469,24 @@ func (s *Server) removeNodePeer(id string, peer *api.Peer) {
 	s.dropChannelsWhere("node uplink closed", func(ch *relayChannel) bool { return ch.node == peer })
 }
 
+// notifyNodePeers sends a notification to every connected node uplink except
+// except (nil sends to all). Node peers only — clients learn trust-log changes
+// via node events, so sending both would double-trigger pulls. The originator
+// is excluded because it already holds what it just pushed.
+func (s *Server) notifyNodePeers(except *api.Peer, method string, params any) {
+	s.relayMu.Lock()
+	peers := make([]*api.Peer, 0, len(s.nodePeers))
+	for _, p := range s.nodePeers {
+		if p != except {
+			peers = append(peers, p)
+		}
+	}
+	s.relayMu.Unlock()
+	for _, p := range peers {
+		_ = p.Notify(method, params)
+	}
+}
+
 // buildClientServer wires the client-facing JSON-RPC: ping, server.info,
 // nodes.list, relay.open/close, node.event roster stream, and clients.*.
 func (s *Server) buildClientServer() *api.Server {
@@ -479,6 +500,15 @@ func (s *Server) buildClientServer() *api.Server {
 
 	srv.Handle(api.MethodNodesList, func(context.Context, json.RawMessage) (any, error) {
 		return api.NodesListResult{Nodes: s.agg.Roster()}, nil
+	})
+
+	srv.Handle(api.MethodTrustLogSync, func(_ context.Context, params json.RawMessage) (any, error) {
+		p, err := api.Decode[api.TrustLogSyncParams](params)
+		if err != nil {
+			return nil, err
+		}
+		entries, want, disjoint := s.entries.Delta(p.Known)
+		return api.TrustLogSyncResult{Entries: entries, Want: want, Disjoint: disjoint && !p.Truncated}, nil
 	})
 
 	srv.Handle(api.MethodRelayOpen, func(ctx context.Context, params json.RawMessage) (any, error) {
@@ -565,10 +595,29 @@ func (s *Server) buildClientServer() *api.Server {
 // serveNode adopts an accepted node uplink: identify,
 // register as a source, record as a relay target, and block until it disconnects.
 func (s *Server) serveNode(conn net.Conn) {
+	var self atomic.Pointer[api.Peer]
+
 	nodeDispatch := func(_ context.Context, method string, params json.RawMessage) (any, error) {
 		switch method {
 		case api.MethodNodesList:
 			return api.NodesListResult{Nodes: s.agg.Roster()}, nil
+		case api.MethodTrustLogSync:
+			p, err := api.Decode[api.TrustLogSyncParams](params)
+			if err != nil {
+				return nil, err
+			}
+			entries, want, disjoint := s.entries.Delta(p.Known)
+			return api.TrustLogSyncResult{Entries: entries, Want: want, Disjoint: disjoint && !p.Truncated}, nil
+		case api.MethodTrustLogPush:
+			p, err := api.Decode[api.TrustLogPushParams](params)
+			if err != nil {
+				return nil, err
+			}
+			added, _ := s.entries.PutAll(p.Entries)
+			if added > 0 {
+				s.notifyNodePeers(self.Load(), api.MethodTrustLogChanged, api.TrustLogChangedParams{Heads: s.entries.Heads()})
+			}
+			return nil, nil
 		default:
 			return nil, &api.RPCError{Code: api.CodeMethodNotFound, Message: "method not found: " + method}
 		}
@@ -581,6 +630,7 @@ func (s *Server) serveNode(conn net.Conn) {
 		Dispatch:                  nodeDispatch,
 		OnRelayFrame:              s.forwardFromNode,
 	})
+	self.Store(peer)
 	defer peer.Close()
 
 	idCtx, idCancel := context.WithTimeout(context.Background(), nodeIdentifyTimeout)

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/trustlog"
 )
 
 // TestClientServerServesVAPIDKey guards a regression where the unified client
@@ -93,4 +95,91 @@ func TestRelayOpenCloseAndNodesList(t *testing.T) {
 		_, stillThere := srv.channels[chanID]
 		return !stillThere
 	})
+}
+
+// makeBlindNodeEntries builds a small valid trust-log chain and returns its
+// entries as individually marshalled blobs, ready for TrustLogPushParams.
+func makeBlindNodeEntries(t *testing.T) [][]byte {
+	t.Helper()
+	signer, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	log, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	raw := trustlog.MarshalChain(log.Entries())
+	entries, err := trustlog.ChainEntries(raw)
+	if err != nil {
+		t.Fatalf("ChainEntries: %v", err)
+	}
+	return entries
+}
+
+// TestBlindTrustLogPushSyncAndChanged exercises the blind trust-log path:
+// a node peer pushes entries, trustlog.sync returns them, and a second node
+// peer receives a trustlog.changed notification after the push.
+func TestBlindTrustLogPushSyncAndChanged(t *testing.T) {
+	a := New(0)
+	srv := NewServer(a, nil, nil)
+
+	connectNode := func(id string, got chan api.Notification) *api.Peer {
+		t.Helper()
+		gwConn, nodeConn := net.Pipe()
+		t.Cleanup(func() { gwConn.Close() })
+		p := api.NewPeer(nodeConn, api.PeerOptions{
+			Dispatch: func(_ context.Context, method string, _ json.RawMessage) (any, error) {
+				if method == api.MethodNodeIdentify {
+					return api.IdentifyResult{ID: id, Label: id + "-box"}, nil
+				}
+				return nil, &api.RPCError{Code: api.CodeMethodNotFound, Message: "method not found: " + method}
+			},
+			OnNotify: func(n api.Notification) {
+				if got != nil {
+					got <- n
+				}
+			},
+		})
+		t.Cleanup(func() { p.Close() })
+		go srv.serveNode(gwConn)
+		return p
+	}
+
+	// node1 is the pusher; node2 must receive trustlog.changed.
+	node2Got := make(chan api.Notification, 4)
+	node1 := connectNode("node1", nil)
+	connectNode("node2", node2Got)
+
+	eventually(t, func() bool {
+		srv.relayMu.Lock()
+		defer srv.relayMu.Unlock()
+		return len(srv.nodePeers) >= 2
+	})
+
+	entries := makeBlindNodeEntries(t)
+
+	// Push entries from node1 (call gateway's nodeDispatch from the node side).
+	if err := node1.Call(api.MethodTrustLogPush, api.TrustLogPushParams{Entries: entries}, nil); err != nil {
+		t.Fatalf("trustlog.push: %v", err)
+	}
+
+	// node2 must receive trustlog.changed.
+	select {
+	case n := <-node2Got:
+		if n.Method != api.MethodTrustLogChanged {
+			t.Fatalf("node2 got %q, want %q", n.Method, api.MethodTrustLogChanged)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("node2 did not receive trustlog.changed after push")
+	}
+
+	// trustlog.sync with empty Known must return the pushed entries.
+	var syncResult api.TrustLogSyncResult
+	if err := node1.Call(api.MethodTrustLogSync, api.TrustLogSyncParams{}, &syncResult); err != nil {
+		t.Fatalf("trustlog.sync: %v", err)
+	}
+	if len(syncResult.Entries) != len(entries) {
+		t.Fatalf("trustlog.sync: got %d entries, want %d", len(syncResult.Entries), len(entries))
+	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -48,13 +48,30 @@ type Node struct {
 	identityPubB64 string      // base64 public half, announced to the gateway
 	e2ee           bool
 
-	// compile-only trust fields: wired as nil/zero in TOFU mode; enforcement
-	// uses them only when a trust store is loaded via external lock machinery.
-	trust             atomic.Pointer[trustlog.SyncStore]
-	trustGate         trustpin.Gate
-	localDisabledFlag atomic.Bool
+	// Locked-mode trust state: nil/zero in TOFU mode; enforcement engages only once
+	// a trust store is loaded via EnableTrustLog.
+	trust             atomic.Pointer[trustlog.SyncStore] // locked-mode trust store; nil when off
+	trustGate         trustpin.Gate                      // fail-closed state when unpinned on a locked network
+	localDisabledFlag atomic.Bool                        // per-node locked-mode escape hatch (persisted marker)
+	trustPath         string                             // on-disk chain path for persistence
+	trustPersistMu    sync.Mutex                         // serializes atomic temp-file+rename persist
+	pinSource         string                             // "config", "file", or "none"
+	pinGenesis        []byte                             // copy of the resolved genesis hash
+	// pinMu serializes the pin-state decision and guards every post-start read and
+	// write of pinGenesis/pinSource/retainedEntries. Quarantined() and
+	// rejectsChannels() must stay lock-free.
+	pinMu              sync.Mutex
+	retainedEntries    *trustlog.EntryStore // every retained entry, indexed by hash; the sole source of the sync offer; guarded by pinMu
+	lastUnplacedLogged int                  // last unplaced count that triggered a warning; 0 means none; guarded by pinMu
+	lastDisjointLogged bool                 // true when the last sync returned disjoint; suppresses repeat warnings; guarded by pinMu
 
 	activeResponder atomic.Pointer[relayResponder]
+	activeUplink    atomic.Pointer[api.Peer] // current gateway uplink peer for event-triggered pulls
+
+	// trustPullTrigger rate-limits pulls a gateway trustlog.changed hint can
+	// provoke, so one untrusted notification amplifies into at most one pull/window.
+	trustPullTrigger triggerLimiter
+	testTriggerPeer  atomic.Pointer[trustCaller] // test override for triggerPeer
 
 	mirrorPrefix string // wraps the argus-mirror-<termID> marker for naming mirror sessions
 	mirrorSuffix string

--- a/internal/node/trigger.go
+++ b/internal/node/trigger.go
@@ -1,0 +1,104 @@
+package node
+
+import (
+	"sync"
+	"time"
+)
+
+// triggerLimiter runs an untrusted party's request at most once per interval.
+// A request that arrives inside the window is deferred to the end of it, never
+// dropped: two operator changes seconds apart must both be acted on, not one of
+// them left to the multi-minute backstop. Deferred requests coalesce into a single
+// run, so a flood still costs one run per window rather than a queue of them.
+//
+// The zero value is ready to use. fn must be the same function for every request
+// on a given limiter; it is stashed so the deferred run can call it.
+type triggerLimiter struct {
+	mu       sync.Mutex
+	fn       func()
+	last     time.Time
+	inFlight bool
+	pending  bool
+	timer    *time.Timer
+}
+
+func (l *triggerLimiter) request(interval time.Duration, fn func()) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.fn = fn
+	if l.pending {
+		return
+	}
+	if l.inFlight {
+		l.pending = true // re-armed when the running one finishes
+		return
+	}
+	if wait := interval - time.Since(l.last); wait > 0 {
+		l.pending = true
+		if l.timer != nil {
+			l.timer.Stop()
+		}
+		l.timer = time.AfterFunc(wait, func() { l.fire(interval) })
+		return
+	}
+	l.startLocked(interval)
+}
+
+func (l *triggerLimiter) fire(interval time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.pending || l.inFlight {
+		return
+	}
+	l.pending = false
+	l.startLocked(interval)
+}
+
+// startLocked runs fn on its own goroutine: requests are dispatched on a peer's
+// read loop, and fn issues RPCs only that loop can answer. Caller holds mu.
+func (l *triggerLimiter) startLocked(interval time.Duration) {
+	l.last = time.Now()
+	l.inFlight = true
+	fn := l.fn
+	go func() {
+		defer l.finish(interval)
+		fn()
+	}()
+}
+
+func (l *triggerLimiter) finish(interval time.Duration) {
+	l.mu.Lock()
+	l.inFlight = false
+	pending := l.pending
+	l.pending = false
+	fn := l.fn
+	l.mu.Unlock()
+	if pending {
+		l.request(interval, fn)
+	}
+}
+
+// stop cancels a deferred run. Used by tests.
+func (l *triggerLimiter) stop() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.pending = false
+	if l.timer != nil {
+		l.timer.Stop()
+	}
+}
+
+// idle reports that nothing is running or owed.
+func (l *triggerLimiter) idle() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return !l.inFlight && !l.pending
+}
+
+// backdate moves the last-run stamp back by d so a test can reopen the window
+// without sleeping through it.
+func (l *triggerLimiter) backdate(d time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.last = l.last.Add(-d)
+}

--- a/internal/node/trustlog.go
+++ b/internal/node/trustlog.go
@@ -1,0 +1,390 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/atomicfile"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+// trustSyncInterval is the BACKSTOP for trust-log convergence, not the primary
+// path: a change normally arrives via a trustlog.changed notification within
+// milliseconds and triggers a pull. This timer only bounds how long a node can
+// lag when no notification arrives, so shortening it is safe and lengthening it
+// widens that window.
+// Stored as nanoseconds in an atomic so SetTrustSyncIntervalForTest is race-free
+// when background goroutines read it concurrently.
+var trustSyncInterval atomic.Int64
+
+func init() {
+	trustSyncInterval.Store(int64(5 * time.Minute))
+	triggeredPullIntervalNs.Store(int64(DefaultTriggeredPullInterval))
+}
+
+// SetTrustSyncIntervalForTest overrides the node's trust-log sync cadence. Test-only.
+func SetTrustSyncIntervalForTest(d time.Duration) { trustSyncInterval.Store(int64(d)) }
+
+// trustCaller is the subset of *api.Peer runTrustSync needs; an interface so tests
+// can substitute a fake uplink.
+type trustCaller interface {
+	Call(method string, params, out any) error
+}
+
+// EnableTrustLog turns on locked-mode trust-log participation: it pins genesisHash
+// and loads any chain already persisted at path (rollback resistance across
+// reboots — a restarted node resumes from its last verified tip). A
+// malformed/rolled-back on-disk chain is ignored (the store stays empty rather than
+// adopting it); genuine corruption surfaces on next sync.
+//
+// Safe on a live, gateway-connected node: pinMu serializes the pin state it writes
+// against the sync loop.
+func (d *Node) EnableTrustLog(genesisHash []byte, path string) error {
+	d.pinMu.Lock()
+	defer d.pinMu.Unlock()
+	return d.enableTrustLogLocked(genesisHash, path)
+}
+
+// enableTrustLogLocked is EnableTrustLog for a caller that already holds pinMu.
+func (d *Node) enableTrustLogLocked(genesisHash []byte, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	sync := trustlog.NewSyncStore(genesisHash)
+	if b, err := os.ReadFile(path); err == nil && len(b) > 0 {
+		// A persisted chain we wrote ourselves; ingest is genesis-pinned so a
+		// tampered file is rejected rather than trusted.
+		if _, ierr := sync.Ingest(b); ierr != nil {
+			d.log.Warn("ignoring unusable persisted trust-log chain", "path", path, "err", ierr)
+		}
+	}
+	d.trustPath = path
+	d.pinGenesis = append([]byte(nil), genesisHash...)
+	d.retainedEntries = trustlog.NewEntryStore() // fresh store for the new genesis
+	d.trust.Store(sync)
+	if bytes.Equal(d.trustGate.Genesis(), genesisHash) {
+		d.trustGate.Clear()
+	}
+	return nil
+}
+
+// TrustStore returns the node's trust-log store, or nil when locked mode is off.
+func (d *Node) TrustStore() *trustlog.SyncStore { return d.trust.Load() }
+
+// SetTrustChainPath records where lock.init should persist the chain, without
+// enabling locked mode. Call at boot so a later live lock.init has a target path.
+func (d *Node) SetTrustChainPath(path string) { d.trustPath = path }
+
+// SetPinSource records where the resolved genesis pin came from, for lock status.
+func (d *Node) SetPinSource(s string) { d.pinSource = s }
+
+// knownHashes lists every entry hash this node retains, for a sync offer. The
+// entry store is the only source: an entry that was not retained is absent from
+// the offer automatically, so the offer can never claim more than is held.
+func (d *Node) knownHashes() (hashes [][]byte, truncated bool) {
+	d.pinMu.Lock()
+	re := d.retainedEntries
+	d.pinMu.Unlock()
+	if re == nil {
+		return nil, false
+	}
+	return re.Hashes()
+}
+
+// syncTrustOnce runs one full sync cycle against peer. It is the loop's per-tick
+// unit; it is a no-op while the store is unset.
+func (d *Node) syncTrustOnce(peer trustCaller) {
+	d.pullTrustOnce(peer)
+}
+
+// syncTrustChains exchanges known entry hashes with the gateway and returns the
+// assembled chains it served. The gateway computes a set-subtraction delta from
+// Known, so the node never needs to infer ancestry: every entry the node holds is
+// listed explicitly. A non-empty Want means the gateway is behind; it is answered
+// with only the specific entries named, so a node that locked the network while
+// the gateway was restarting still publishes.
+func (d *Node) syncTrustChains(peer trustCaller) ([][]byte, bool) {
+	d.pinMu.Lock()
+	if d.retainedEntries == nil {
+		d.retainedEntries = trustlog.NewEntryStore()
+	}
+	re := d.retainedEntries
+	d.pinMu.Unlock()
+	// Compute own entries once: seed the store before knownHashes so the offer
+	// always reflects locally-held entries (including after a restart), then
+	// reuse for the merge. PutAll is idempotent for already-present entries.
+	var ownEntries [][]byte
+	if st := d.trust.Load(); st != nil {
+		if mine := st.Bytes(); mine != nil {
+			if raw, err := trustlog.ChainEntries(mine); err == nil {
+				ownEntries = raw
+			}
+		}
+	}
+	re.PutAll(ownEntries)
+	known, truncated := d.knownHashes()
+	var got api.TrustLogSyncResult
+	if err := peer.Call(api.MethodTrustLogSync, api.TrustLogSyncParams{Known: known, Truncated: truncated}, &got); err != nil {
+		return nil, false
+	}
+	d.pinMu.Lock()
+	prevDisjoint := d.lastDisjointLogged
+	d.lastDisjointLogged = got.Disjoint
+	d.pinMu.Unlock()
+	if got.Disjoint && !prevDisjoint {
+		d.log.Warn("trust log: this device shares no history with the network's; it is likely pinned to a different trust root")
+	}
+
+	merged := append([][]byte{}, got.Entries...)
+	merged = append(merged, ownEntries...)
+	if retained := re.All(); len(retained) > 0 {
+		merged = append(merged, retained...)
+	}
+	chains, unplaced := trustlog.AssembleChainsReport(merged)
+	d.pinMu.Lock()
+	prevUnplaced := d.lastUnplacedLogged
+	d.lastUnplacedLogged = unplaced
+	d.pinMu.Unlock()
+	if unplaced > 0 && unplaced != prevUnplaced {
+		d.log.Warn("trust-log sync has unplaced entries; gateway may hold an incomplete branch", "unplaced", unplaced)
+	}
+
+	// Retain assembled chains' entries so the next offer reflects what is held.
+	refused := 0
+	for _, chain := range chains {
+		raw, err := trustlog.ChainEntries(chain)
+		if err != nil {
+			continue
+		}
+		_, r := re.PutAll(raw)
+		refused += r
+	}
+	if refused > 0 {
+		d.log.Warn("trust-log entry store at ceiling; entries refused", "refused", refused)
+	}
+
+	if len(got.Want) > 0 {
+		d.pushWanted(peer, got.Want)
+	}
+	return chains, true
+}
+
+func (d *Node) pushWanted(peer trustCaller, want [][]byte) {
+	d.pinMu.Lock()
+	re := d.retainedEntries
+	d.pinMu.Unlock()
+	if re == nil {
+		return
+	}
+	held := map[string][]byte{}
+	for _, raw := range re.All() {
+		e, err := trustlog.UnmarshalEntry(raw)
+		if err != nil {
+			continue
+		}
+		held[string(trustlog.HashEntry(&e))] = raw
+	}
+	var out [][]byte
+	for _, h := range want {
+		if raw, ok := held[string(h)]; ok {
+			out = append(out, raw)
+		}
+	}
+	if len(out) == 0 {
+		return
+	}
+	_ = peer.Call(api.MethodTrustLogPush, api.TrustLogPushParams{Entries: out}, nil)
+}
+
+// pullTrustOnce runs one sync cycle over peer.
+// The genesis-pinned store's fork-choice accepts the best valid branch; invalid
+// or rolled-back branches are silently skipped. A single advance triggers persist.
+// Returns false when there is no store or the sync failed.
+func (d *Node) pullTrustOnce(peer trustCaller) bool {
+	st := d.trust.Load()
+	if st == nil {
+		return false
+	}
+	chains, ok := d.syncTrustChains(peer)
+	if !ok {
+		return false
+	}
+	anyChanged := false
+	for _, chain := range chains {
+		changed, err := st.Ingest(chain)
+		if err != nil {
+			continue // rollback/fork/tamper/wrong-genesis: skip this branch
+		}
+		if changed {
+			anyChanged = true
+		}
+	}
+	if anyChanged {
+		if werr := d.persistTrust(); werr != nil {
+			d.log.Warn("persisting trust-log chain failed", "path", d.trustPath, "err", werr)
+		}
+	}
+	return true
+}
+
+// persistChain writes chain bytes to trustPath atomically via atomicfile.Write.
+// A dedicated mutex ensures two goroutines (e.g. lingering + new uplink) never
+// race the rename.
+func (d *Node) persistChain(chain []byte) error {
+	d.trustPersistMu.Lock()
+	defer d.trustPersistMu.Unlock()
+	return atomicfile.Write(d.trustPath, chain)
+}
+
+// persistTrust writes the current chain to disk. It is a no-op when the store
+// is unset. For the atomic write mechanics see persistChain.
+func (d *Node) persistTrust() error {
+	st := d.trust.Load()
+	if st == nil {
+		return nil
+	}
+	return d.persistChain(st.Bytes())
+}
+
+// runTrustSync drives the pull loop for the uplink's lifetime. It cancels the
+// loop when the peer drops or ctx ends.
+func (d *Node) runTrustSync(ctx context.Context, peer *api.Peer) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		select {
+		case <-peer.Done():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	d.runTrustSyncLoop(ctx, peer)
+}
+
+// runTrustSyncLoop pulls on connect and every trustSyncInterval until ctx ends or
+// the uplink drops. It polls the (atomic) trust store each tick, so a node enabled
+// live via lock.init begins syncing without a reconnect. syncTrustOnce is a no-op
+// while the store is unset.
+func (d *Node) runTrustSyncLoop(ctx context.Context, peer trustCaller) {
+	d.syncTrustOnce(peer)
+	t := time.NewTicker(time.Duration(trustSyncInterval.Load()))
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			d.syncTrustOnce(peer)
+		}
+	}
+}
+
+// genesisHashPath is the state file holding the pinned genesis hash, kept beside
+// the chain so a node's locked state is self-contained in its state dir.
+func genesisHashPath(chainPath string) string {
+	return filepath.Join(filepath.Dir(chainPath), "trustlog-genesis")
+}
+
+// writeGenesisHash atomically persists the pinned genesis hash beside the chain.
+func (d *Node) writeGenesisHash(hash []byte) error {
+	d.trustPersistMu.Lock()
+	defer d.trustPersistMu.Unlock()
+	return trustpin.New(genesisHashPath(d.trustPath)).Save(hash)
+}
+
+// DefaultTriggeredPullInterval bounds how often a gateway notification can cause a
+// pull, and so bounds how far one untrusted notification can amplify. It is
+// deliberately small because the cost of being slow is an operator watching a peer
+// lag behind a lock ceremony. Suppressed notifications coalesce into one deferred
+// pull, so a peer reaches the current tip within this window regardless of how many
+// writes landed inside it.
+const DefaultTriggeredPullInterval = time.Second
+
+// triggeredPullIntervalNs holds DefaultTriggeredPullInterval as nanoseconds in an
+// atomic so setTriggeredPullIntervalForTest is race-free when background goroutines
+// read it concurrently.
+var triggeredPullIntervalNs atomic.Int64
+
+func minTriggeredPullInterval() time.Duration {
+	return time.Duration(triggeredPullIntervalNs.Load())
+}
+
+// setTriggeredPullIntervalForTest overrides the notification rate-limit window so a
+// test can observe deferral without waiting out the production window. Test-only.
+func setTriggeredPullIntervalForTest(d time.Duration) { triggeredPullIntervalNs.Store(int64(d)) }
+
+// SetTriggeredPullIntervalForTest is setTriggeredPullIntervalForTest for integration
+// tests in other packages, which drive several notification-triggered pulls in a row
+// and would otherwise spend the production window between each. Test-only.
+func SetTriggeredPullIntervalForTest(d time.Duration) { setTriggeredPullIntervalForTest(d) }
+
+// ResetTriggeredPullIntervalForTest restores the production window, so callers do
+// not each repeat the default. Test-only.
+func ResetTriggeredPullIntervalForTest() {
+	setTriggeredPullIntervalForTest(DefaultTriggeredPullInterval)
+}
+
+// onGatewayNotify handles gateway→node notifications. The only one is a hint that
+// the trust log moved; everything else is ignored.
+//
+// The notification only schedules work — a forged one changes when the node pulls,
+// not what it accepts (every branch is verified against the pinned genesis).
+func (d *Node) onGatewayNotify(n api.Notification) {
+	if n.Method != api.MethodTrustLogChanged {
+		return
+	}
+	// Resolve the peer first: nothing to schedule when there is nothing to pull
+	// against (e.g. during a reconnect gap).
+	if d.triggerPeer() == nil {
+		return
+	}
+	if p, err := api.Decode[api.TrustLogChangedParams](n.Params); err == nil && len(p.Heads) > 0 {
+		hashes, _ := d.knownHashes()
+		known := make(map[string]bool, len(hashes))
+		for _, h := range hashes {
+			known[string(h)] = true
+		}
+		fresh := false
+		for _, h := range p.Heads {
+			if !known[string(h)] {
+				fresh = true
+				break
+			}
+		}
+		if !fresh {
+			return
+		}
+	}
+	d.trustPullTrigger.request(minTriggeredPullInterval(), func() {
+		// The peer is resolved at run time, not at notification time: a deferred pull
+		// must use whichever uplink is live when it fires.
+		peer := d.triggerPeer()
+		if peer == nil {
+			return
+		}
+		d.pullTrustOnce(peer)
+	})
+}
+
+// triggerPeer returns the peer an event-triggered RPC should use: the test
+// override when set, otherwise the live gateway uplink. Returns nil (not a typed
+// nil) when no peer is available, so callers can guard with peer != nil.
+func (d *Node) triggerPeer() trustCaller {
+	if tp := d.testTriggerPeer.Load(); tp != nil {
+		return *tp
+	}
+	if p := d.activeUplink.Load(); p != nil {
+		return p
+	}
+	return nil
+}
+
+// setTriggerPeerForTest installs a trustCaller used by the event-driven pull in
+// place of the live uplink. Test-only.
+func (d *Node) setTriggerPeerForTest(p trustCaller) { d.testTriggerPeer.Store(&p) }

--- a/internal/node/trustlog_test.go
+++ b/internal/node/trustlog_test.go
@@ -1,0 +1,242 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+// seedChain builds genesis[+authorize] and returns marshaled bytes + pieces.
+func seedChain(t *testing.T, withDevice bool) (chain, head, device []byte, signer trustlog.SignerKey) {
+	t.Helper()
+	var err error
+	signer, err = trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	log, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	head = log.Tip()
+	device = bytes.Repeat([]byte{0x11}, 32)
+	if withDevice {
+		if err := log.AuthorizeDevice(device, signer); err != nil {
+			t.Fatalf("AuthorizeDevice: %v", err)
+		}
+	}
+	return trustlog.MarshalChain(log.Entries()), head, device, signer
+}
+
+// fakePeer serves a canned chain as entries on trustlog.sync, standing in for the
+// gateway uplink so the sync path can be exercised without a network.
+type fakePeer struct {
+	pullChain []byte
+}
+
+func (f *fakePeer) Call(method string, params, out any) error {
+	switch method {
+	case api.MethodTrustLogSync:
+		res := out.(*api.TrustLogSyncResult)
+		if f.pullChain != nil {
+			if raw, err := trustlog.ChainEntries(f.pullChain); err == nil {
+				res.Entries = raw
+			}
+		}
+	}
+	return nil
+}
+
+// Compile-time checks: fakePeer satisfies trustCaller and runTrustSync takes *api.Peer.
+var _ trustCaller = (*fakePeer)(nil)
+var _ = (*Node).runTrustSync
+
+func TestEnableTrustLogGatesAuthorizedDevices(t *testing.T) {
+	chain, head, device, _ := seedChain(t, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	if err := os.WriteFile(path, chain, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	d := New()
+	if err := d.EnableTrustLog(head, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	if d.TrustStore() == nil {
+		t.Fatal("TrustStore should be non-nil after EnableTrustLog")
+	}
+	if !d.TrustStore().DeviceAuthorized(device) {
+		t.Fatal("authorized device should be authorized")
+	}
+	unauthorized := bytes.Repeat([]byte{0x22}, 32)
+	if d.TrustStore().DeviceAuthorized(unauthorized) {
+		t.Fatal("unauthorized device must not be authorized")
+	}
+}
+
+func TestEnableTrustLogRejectsForeignGenesisChain(t *testing.T) {
+	// A valid chain authorizing a device, but built under its own genesis.
+	chain, chainGenesis, device, _ := seedChain(t, true)
+
+	// Pin a DIFFERENT genesis than the on-disk chain roots to.
+	pinnedGenesis := bytes.Repeat([]byte{0x33}, len(chainGenesis))
+	if bytes.Equal(pinnedGenesis, chainGenesis) {
+		t.Fatal("test setup: pinned genesis must differ from the chain's")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	if err := os.WriteFile(path, chain, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	d := New()
+	// EnableTrustLog must not error: the foreign chain is logged and ignored, the
+	// node continues with an empty store rather than adopting untrusted data.
+	if err := d.EnableTrustLog(pinnedGenesis, path); err != nil {
+		t.Fatalf("EnableTrustLog should not error on a foreign-genesis chain: %v", err)
+	}
+	if d.TrustStore() == nil {
+		t.Fatal("TrustStore should be non-nil (store created) after EnableTrustLog")
+	}
+	if d.TrustStore().Tip() != nil {
+		t.Fatal("foreign chain must be rejected on ingest; store must start empty")
+	}
+	if d.TrustStore().DeviceAuthorized(device) {
+		t.Fatal("a device from a foreign-genesis chain must not be authorized")
+	}
+}
+
+func TestEnableTrustLogRejectsTamperedChain(t *testing.T) {
+	chain, head, device, _ := seedChain(t, true)
+	// Corrupt the persisted chain: bitflip a byte so genesis-pinned ingest rejects it.
+	tampered := append([]byte(nil), chain...)
+	tampered[len(tampered)/2] ^= 0xFF
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	if err := os.WriteFile(path, tampered, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	d := New()
+	if err := d.EnableTrustLog(head, path); err != nil {
+		t.Fatalf("EnableTrustLog should not error on a tampered chain: %v", err)
+	}
+	if d.TrustStore() == nil {
+		t.Fatal("TrustStore should be non-nil (store created) after EnableTrustLog")
+	}
+	if d.TrustStore().Tip() != nil {
+		t.Fatal("tampered chain must be rejected on ingest; store must start empty")
+	}
+	if d.TrustStore().DeviceAuthorized(device) {
+		t.Fatal("a device from a tampered chain must not be authorized")
+	}
+}
+
+func TestSyncTrustOnceIngestsAndPersists(t *testing.T) {
+	// Node starts with a genesis-only chain; gateway offers a longer one authorizing a device.
+	shortChain, head, device, signer := seedChain(t, false)
+	log, err := trustlog.Load(mustUnmarshalChain(t, shortChain))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := log.AuthorizeDevice(device, signer); err != nil {
+		t.Fatalf("AuthorizeDevice: %v", err)
+	}
+	longChain := trustlog.MarshalChain(log.Entries())
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	if err := os.WriteFile(path, shortChain, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	d := New()
+	if err := d.EnableTrustLog(head, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	if d.TrustStore().DeviceAuthorized(device) {
+		t.Fatal("device should not be authorized before sync")
+	}
+
+	d.syncTrustOnce(&fakePeer{pullChain: longChain})
+
+	if !d.TrustStore().DeviceAuthorized(device) {
+		t.Fatal("device from pulled chain should be authorized after sync")
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(onDisk, longChain) {
+		t.Fatal("advanced chain must be persisted to disk")
+	}
+}
+
+func TestSyncTrustRejectsRollback(t *testing.T) {
+	shortChain, head, device, signer := seedChain(t, false)
+	log, err := trustlog.Load(mustUnmarshalChain(t, shortChain))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := log.AuthorizeDevice(device, signer); err != nil {
+		t.Fatalf("AuthorizeDevice: %v", err)
+	}
+	longChain := trustlog.MarshalChain(log.Entries())
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	if err := os.WriteFile(path, longChain, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	d := New()
+	if err := d.EnableTrustLog(head, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+
+	// Malicious gateway offers the short (stale) chain.
+	d.syncTrustOnce(&fakePeer{pullChain: shortChain})
+
+	if !d.TrustStore().DeviceAuthorized(device) {
+		t.Fatal("rollback must be rejected; device should stay authorized")
+	}
+}
+
+func TestRunTrustSyncLoopConverges(t *testing.T) {
+	trustSyncInterval.Store(int64(10 * time.Millisecond))
+	t.Cleanup(func() { trustSyncInterval.Store(int64(5 * time.Minute)) })
+
+	chain, head, device, _ := seedChain(t, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	if err := d.EnableTrustLog(head, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	// Wait the loop out before TempDir cleanup: a persist still in flight when the
+	// context ends would otherwise recreate the chain file under RemoveAll.
+	t.Cleanup(func() { cancel(); <-loopDone })
+	go func() {
+		defer close(loopDone)
+		d.runTrustSyncLoop(ctx, &fakePeer{pullChain: chain})
+	}()
+
+	waitFor(t, func() bool {
+		return d.TrustStore() != nil && d.TrustStore().DeviceAuthorized(device)
+	})
+}
+
+func mustUnmarshalChain(t *testing.T, b []byte) []trustlog.Entry {
+	t.Helper()
+	e, err := trustlog.UnmarshalChain(b)
+	if err != nil {
+		t.Fatalf("UnmarshalChain: %v", err)
+	}
+	return e
+}

--- a/internal/node/uplink.go
+++ b/internal/node/uplink.go
@@ -100,6 +100,7 @@ func (d *Node) runUplinkBlind(ctx context.Context, url, token string, httpClient
 	resp := d.newRelayResponder()
 	peer, err := api.DialWSPeer(ctx, url, token, httpClient, api.PeerOptions{
 		Dispatch:     d.uplinkDispatch(),
+		OnNotify:     d.onGatewayNotify,
 		OnRelayFrame: resp.onFrame,
 	})
 	if err != nil {
@@ -110,10 +111,15 @@ func (d *Node) runUplinkBlind(ctx context.Context, url, token string, httpClient
 	}
 	resp.peer.Store(peer)
 	d.activeResponder.Store(resp)
+	d.activeUplink.Store(peer)
 	defer peer.Close()
 	defer resp.closeAll()
 	defer d.activeResponder.CompareAndSwap(resp, nil)
+	defer d.activeUplink.CompareAndSwap(peer, nil)
 	d.log.Info("gateway uplink established", "url", url)
+
+	// Sync the trust-log chain over this uplink (no-op unless locked mode is on).
+	go d.runTrustSync(ctx, peer)
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
> **⚠️ Updated (beacon → tip cross-check).** The anti-equivocation *beacon* mechanism referenced below was removed stack-wide and replaced by an authenticated tip cross-check: the client reads each node's trust-log tip over its already-authenticated Noise channel (via `node.identify`) and compares tips against its resolved chain — no per-node beacon key, no gateway-supplied verification input. See PR #44 and `docs/superpowers/plans/2026-09-02-beacon-to-tip-crosscheck.md`. Any "beacon"/"equivocation" wording below is historical.

> **⚠️ Updated (transport unified on relay).** "Flag-off = plaintext unchanged" below means semantically unchanged (same RPCs/results). The stack later unified transport onto relay channels, so flag-off now runs an unencrypted relay channel rather than the old direct path — not byte-for-byte the pre-relay `main` path. The TOFU→pinned enforcement boundary this PR introduces is unchanged. See `docs/superpowers/plans/2026-08-28-unify-transport-on-relay-channels.md`.

---

Sixth stacked PR (base: `pr/04b-session-control`). Opt-in locked mode: on a pinned network, authorized devices connect and unauthorized ones are rejected.

**What it wires** (the enforcement predicates shipped inert in PR 3, gated on `d.trust != nil`; this activates them):
- **Gateway (blind):** `EntryStore` + `trustlog.sync`/`push` handlers + `notifyNodePeers`/`trustlog.changed`. Stores and set-subtracts entry bytes; never verifies.
- **Node:** trust-log sync loop + `EnableTrustLog` (creates the `SyncStore`, the nil→populated transition) — trimmed from the branch's 718-line trustlog.go to 393, **excluding beacon (PR 7) and quarantine/recovery (PR 5b)** which are entangled there.
- **Config/CLI:** `lock.genesis`; `trustpin.Resolve` at node/client startup with a fail-closed genesis-pin-conflict refusal; `NewReconnectingE2EClientLocked` when pinned.

**Security properties (final review, traced + `-race`):** flag-off = plaintext unchanged; e2ee-on + no genesis = TOFU (trust nil, no enforcement); `EnableTrustLog` rejects a tampered/foreign chain on ingest (starts empty, never trusts corrupted data); genesis-pin conflict refuses to start/connect (no open fallback); excluded beacon/quarantine/signing are inert (no live callers).

**Design note:** `trustlog.sync` is served to any client without authorization *by design* — the trust log is public (mirrors Tailscale tailnet-lock's public key set); clients need it for genesis discovery.

**Test:** authorized device connects + round-trips a sealed call; unauthorized is rejected by the node responder (cannot false-pass); TOFU default connects freely. Full `go test -short ./...` green. See `docs/superpowers/specs/2026-08-08-incremental-e2e-merge-plan-design.md` (PR 5a).

