### PR TITLE
PR 5b — quarantine + recovery

### DIFF
--- a/cmd/argus/nodelock.go
+++ b/cmd/argus/nodelock.go
@@ -37,5 +37,6 @@ func configureNodeLock(d *node.Node, cfg *config.Config, log *slog.Logger) error
 	} else {
 		d.SetTrustChainPath(chainPath)
 	}
+	d.LoadLocalDisabled()
 	return nil
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -58,6 +58,9 @@ func (c *Client) States() <-chan bool { return nil }
 // Reconnect is a no-op: a plain Client does not reconnect.
 func (c *Client) Reconnect() {}
 
+// Quarantined is always false: the plaintext client never enforces trust-log locking.
+func (c *Client) Quarantined() bool { return false }
+
 // Close terminates the connection.
 func (c *Client) Close() error { return c.peer.Close() }
 

--- a/internal/api/reconnect.go
+++ b/internal/api/reconnect.go
@@ -147,6 +147,9 @@ func (c *ReconnectingClient) Reconnect() {
 	}
 }
 
+// Quarantined is always false: the plaintext client never enforces trust-log locking.
+func (c *ReconnectingClient) Quarantined() bool { return false }
+
 // Call routes to the live peer, erroring promptly when disconnected rather than blocking.
 func (c *ReconnectingClient) Call(method string, params, out any) error {
 	p := c.currentPeer()

--- a/internal/e2etest/lock_quarantine_e2e_test.go
+++ b/internal/e2etest/lock_quarantine_e2e_test.go
@@ -1,0 +1,261 @@
+package e2etest
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+// TestLockQuarantine: an unpinned node on a locked
+// network quarantines (refuses all channels) and recovers when pinned via AdoptPin.
+// The default TOFU case (no chain anywhere) is unchanged.
+func TestLockQuarantine(t *testing.T) {
+	node.SetTrustSyncIntervalForTest(100 * time.Millisecond)
+	t.Cleanup(func() { node.SetTrustSyncIntervalForTest(5 * time.Minute) })
+	node.SetTriggeredPullIntervalForTest(50 * time.Millisecond)
+	t.Cleanup(node.ResetTriggeredPullIntervalForTest)
+
+	agg := gateway.New(time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	signer, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	authKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("authKP: %v", err)
+	}
+
+	tlog, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+
+	pinnedKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("pinnedKP: %v", err)
+	}
+	pinnedNode := node.New()
+	pinnedNode.SetIdentity("lq-pinned", "LQ Pinned Node")
+	pinnedNode.SetVersion("itest")
+	pinnedNode.SetIdentityKey(pinnedKP)
+	pinnedNode.SetE2EE(true)
+
+	// Unpinned node's identity pub is authorized so a locked client can open a
+	// channel to it after recovery.
+	unpinnedKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("unpinnedKP: %v", err)
+	}
+	if err := tlog.AuthorizeDevice(unpinnedKP.Public, signer); err != nil {
+		t.Fatalf("AuthorizeDevice(unpinnedKP): %v", err)
+	}
+	// authKP is the client static the node accepts post-recovery.
+	if err := tlog.AuthorizeDevice(authKP.Public, signer); err != nil {
+		t.Fatalf("AuthorizeDevice(authKP): %v", err)
+	}
+	chain := trustlog.MarshalChain(tlog.Entries())
+
+	dir := t.TempDir()
+	pinnedChainPath := filepath.Join(dir, "pinned-chain")
+	if err := os.WriteFile(pinnedChainPath, chain, 0o600); err != nil {
+		t.Fatalf("write pinned chain: %v", err)
+	}
+	if err := pinnedNode.EnableTrustLog(genesisHash, pinnedChainPath); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	go pinnedNode.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	unpinnedNode := node.New()
+	unpinnedNode.SetIdentity("lq-unpinned", "LQ Unpinned Node")
+	unpinnedNode.SetVersion("itest")
+	unpinnedNode.SetIdentityKey(unpinnedKP)
+	unpinnedNode.SetE2EE(true)
+	unpinnedChainPath := filepath.Join(dir, "unpinned-chain")
+	unpinnedNode.SetTrustChainPath(unpinnedChainPath)
+	go unpinnedNode.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	// The chain is also written to disk for locked clients so their trust stores are
+	// seeded before Connect(), avoiding a race where the client syncs before the
+	// pinned node has pushed.
+	clientChainPath := filepath.Join(dir, "client-chain")
+	if err := os.WriteFile(clientChainPath, chain, 0o600); err != nil {
+		t.Fatalf("write client chain: %v", err)
+	}
+
+	pollConn, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	if err != nil {
+		t.Fatalf("poll dial: %v", err)
+	}
+	poll := api.NewClient(pollConn)
+	waitFor(t, "both lq nodes online", func() bool {
+		var r api.NodesListResult
+		if poll.Call(api.MethodNodesList, nil, &r) != nil {
+			return false
+		}
+		pinned, unpinned := false, false
+		for _, nd := range r.Nodes {
+			switch {
+			case nd.ID == "lq-pinned" && nd.IdentityPubKey != "" && nd.Online:
+				pinned = true
+			case nd.ID == "lq-unpinned" && nd.IdentityPubKey != "" && nd.Online:
+				unpinned = true
+			}
+		}
+		return pinned && unpinned
+	})
+	poll.Close()
+
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	}
+
+	t.Run("quarantine", func(t *testing.T) {
+		waitFor(t, "lq-unpinned quarantined", func() bool {
+			return unpinnedNode.Quarantined()
+		})
+
+		// Short timeout so the test does not block for the production 10-second window
+		// while waiting for a msg2 the quarantined node will never send.
+		client.SetHandshakeTimeoutForTest(500 * time.Millisecond)
+		t.Cleanup(func() { client.SetHandshakeTimeoutForTest(10 * time.Second) })
+
+		// Locked client: trust store knows lq-unpinned's identity pub so it opens a
+		// channel to it; the quarantined node drops the handshake regardless.
+		c, err := client.NewReconnectingE2EClientLocked(ctx, dial, genesisHash, authKP, clientChainPath)
+		if err != nil {
+			t.Fatalf("NewReconnectingE2EClientLocked: %v", err)
+		}
+		defer c.Close()
+
+		var agents api.AgentsListResult
+		err = c.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "lq-unpinned"}, &agents)
+		if err == nil {
+			t.Fatal("quarantined node: agents.list succeeded; node should have refused the channel")
+		}
+		if !isTransportErr(err) {
+			t.Fatalf("quarantined node: enforcement did not fire — sealed call reached handler: %v", err)
+		}
+	})
+
+	t.Run("recovery", func(t *testing.T) {
+		if err := unpinnedNode.AdoptPin(genesisHash); err != nil {
+			t.Fatalf("AdoptPin: %v", err)
+		}
+		if unpinnedNode.Quarantined() {
+			t.Fatal("AdoptPin must clear the quarantine gate")
+		}
+
+		t.Run("authorized", func(t *testing.T) {
+			c, err := client.NewReconnectingE2EClientLocked(ctx, dial, genesisHash, authKP, clientChainPath)
+			if err != nil {
+				t.Fatalf("NewReconnectingE2EClientLocked: %v", err)
+			}
+			defer c.Close()
+
+			var agents api.AgentsListResult
+			if err := c.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "lq-unpinned"}, &agents); err != nil {
+				t.Fatalf("authorized client: agents.list failed after recovery: %v", err)
+			}
+		})
+
+		t.Run("unauthorized", func(t *testing.T) {
+			client.SetHandshakeTimeoutForTest(500 * time.Millisecond)
+			t.Cleanup(func() { client.SetHandshakeTimeoutForTest(10 * time.Second) })
+
+			unauthKP, err := e2e.GenerateKeyPair()
+			if err != nil {
+				t.Fatalf("unauthKP: %v", err)
+			}
+			cu, err := client.NewReconnectingE2EClientLocked(ctx, dial, genesisHash, unauthKP, clientChainPath)
+			if err != nil {
+				t.Fatalf("unauthorized client: NewReconnectingE2EClientLocked: %v", err)
+			}
+			defer cu.Close()
+
+			var uagents api.AgentsListResult
+			err = cu.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "lq-unpinned"}, &uagents)
+			if err == nil {
+				t.Fatal("unauthorized client: agents.list succeeded after recovery; enforcement should reject it")
+			}
+			if !isTransportErr(err) {
+				t.Fatalf("unauthorized client: enforcement did not fire — sealed call reached handler: %v", err)
+			}
+		})
+	})
+
+	t.Run("tofu", func(t *testing.T) {
+		// A separate gateway serving NO chain. An unpinned node must NOT quarantine.
+		tofuAgg := gateway.New(time.Second)
+		tofuSrv := gateway.NewServer(tofuAgg, nil, nil)
+		tofuTS := httptest.NewServer(tofuSrv.Handler())
+		defer tofuTS.Close()
+
+		tofuKP, err := e2e.GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("TOFU keypair: %v", err)
+		}
+		tn := node.New()
+		tn.SetIdentity("lq-tofu", "LQ TOFU Node")
+		tn.SetVersion("itest")
+		tn.SetIdentityKey(tofuKP)
+		tn.SetE2EE(true)
+		tn.SetTrustChainPath(filepath.Join(t.TempDir(), "tofu-chain"))
+		go tn.ConnectGateway(ctx, wsURL(tofuTS.URL, "/node"), "", nil)
+
+		tofuPollConn, err := api.DialWSConn(ctx, wsURL(tofuTS.URL, "/client"), "", nil)
+		if err != nil {
+			t.Fatalf("TOFU poll dial: %v", err)
+		}
+		tofuPoll := api.NewClient(tofuPollConn)
+		waitFor(t, "lq-tofu online", func() bool {
+			var r api.NodesListResult
+			if tofuPoll.Call(api.MethodNodesList, nil, &r) != nil {
+				return false
+			}
+			for _, nd := range r.Nodes {
+				if nd.ID == "lq-tofu" && nd.IdentityPubKey != "" && nd.Online {
+					return true
+				}
+			}
+			return false
+		})
+		tofuPoll.Close()
+
+		if tn.Quarantined() {
+			t.Fatal("unpinned node on a TOFU network must not quarantine")
+		}
+
+		tofuDial := func(ctx context.Context) (net.Conn, error) {
+			return api.DialWSConn(ctx, wsURL(tofuTS.URL, "/client"), "", nil)
+		}
+		c, err := client.NewReconnectingE2EClient(ctx, tofuDial)
+		if err != nil {
+			t.Fatalf("NewReconnectingE2EClient (TOFU): %v", err)
+		}
+		defer c.Close()
+
+		var agents api.AgentsListResult
+		if err := c.Call(api.MethodAgentsList, nil, &agents); err != nil {
+			t.Fatalf("agents.list over E2E (TOFU): %v", err)
+		}
+	})
+}

--- a/internal/node/localdisable.go
+++ b/internal/node/localdisable.go
@@ -1,0 +1,36 @@
+package node
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/MunifTanjim/argus/internal/atomicfile"
+)
+
+func (d *Node) localDisableMarkerPath() string {
+	return filepath.Join(filepath.Dir(d.trustPath), "trustlog-local-disabled")
+}
+
+// LocalDisable turns off locked-mode enforcement for THIS node only — the guaranteed
+// escape hatch when the gateway censors a network-wide `lock disable`. Persisted so
+// it survives reboot; re-locking requires removing the marker / re-init.
+func (d *Node) LocalDisable() error {
+	if d.trustPath == "" {
+		return errors.New("node: trust state path not configured")
+	}
+	if err := atomicfile.Write(d.localDisableMarkerPath(), []byte("1")); err != nil {
+		return err
+	}
+	d.localDisabledFlag.Store(true)
+	return nil
+}
+
+func (d *Node) LoadLocalDisabled() {
+	if d.trustPath == "" {
+		return
+	}
+	if _, err := os.Stat(d.localDisableMarkerPath()); err == nil {
+		d.localDisabledFlag.Store(true)
+	}
+}

--- a/internal/node/localdisable_test.go
+++ b/internal/node/localdisable_test.go
@@ -1,0 +1,133 @@
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalDisableOverridesQuarantine(t *testing.T) {
+	chain, _, _, _ := seedChain(t, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	d.SetTrustChainPath(path)
+
+	d.pullTrustOnce(&fakePeer{pullChain: chain})
+	if !d.Quarantined() {
+		t.Fatal("should be quarantined after seeing an unrecognized chain")
+	}
+	if !d.rejectsChannels() {
+		t.Fatal("quarantined node must reject channels before local-disable")
+	}
+
+	if err := d.LocalDisable(); err != nil {
+		t.Fatalf("LocalDisable: %v", err)
+	}
+	if d.rejectsChannels() {
+		t.Fatal("local-disable must override quarantine: rejectsChannels must be false")
+	}
+}
+
+func TestLoadLocalDisabledPicksUpPreExistingMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	markerPath := filepath.Join(dir, "trustlog-local-disabled")
+	if err := os.WriteFile(markerPath, []byte("1"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	d := New()
+	d.SetTrustChainPath(path)
+	d.LoadLocalDisabled()
+
+	if !d.localDisabled() {
+		t.Fatal("LoadLocalDisabled must set the flag when the marker exists")
+	}
+}
+
+func TestLoadLocalDisabledNoMarkerIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	d.SetTrustChainPath(path)
+	d.LoadLocalDisabled()
+
+	if d.localDisabled() {
+		t.Fatal("LoadLocalDisabled without a marker must leave the flag false")
+	}
+}
+
+func TestAdoptPinClearsQuarantine(t *testing.T) {
+	// seedChain(false): genesis-only chain; head == genesis hash (single entry → Tip() == genesis)
+	chain, genesis, _, _ := seedChain(t, false)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	d.SetTrustChainPath(path)
+
+	d.pullTrustOnce(&fakePeer{pullChain: chain})
+	if !d.Quarantined() {
+		t.Fatal("unpinned node must be quarantined after seeing a served chain")
+	}
+
+	if err := d.AdoptPin(genesis); err != nil {
+		t.Fatalf("AdoptPin: %v", err)
+	}
+	if d.Quarantined() {
+		t.Fatal("AdoptPin must clear the quarantine gate")
+	}
+	if d.TrustStore() == nil {
+		t.Fatal("AdoptPin must enable the trust store")
+	}
+}
+
+// Pinning a genesis the network does not serve must NOT clear the quarantine gate:
+// no chain ingests, so the node stays quarantined and diagnosable, rather than
+// silently going dark on an empty store while `lock status` reads "pinned".
+func TestAdoptPinMismatchedGenesisStaysQuarantined(t *testing.T) {
+	chain, genesis, _, _ := seedChain(t, false)
+	dir := t.TempDir()
+	d := New()
+	d.SetTrustChainPath(filepath.Join(dir, "trustlog-chain"))
+	d.pullTrustOnce(&fakePeer{pullChain: chain})
+	if !d.Quarantined() {
+		t.Fatal("must quarantine after seeing a served chain")
+	}
+	wrong := append([]byte(nil), genesis...)
+	wrong[0] ^= 0xff
+	if err := d.AdoptPin(wrong); err != nil {
+		t.Fatalf("AdoptPin: %v", err)
+	}
+	if !d.Quarantined() {
+		t.Fatal("AdoptPin with a mismatched genesis must stay quarantined")
+	}
+}
+
+func TestDropPinClearsPersistedPin(t *testing.T) {
+	chain, head, _, _ := seedChain(t, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	if err := d.EnableTrustLog(head, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	d.syncTrustOnce(&fakePeer{pullChain: chain})
+	if b, err := os.ReadFile(path); err != nil || len(b) == 0 {
+		t.Fatal("chain must be persisted after sync")
+	}
+
+	if err := d.DropPin(); err != nil {
+		t.Fatalf("DropPin: %v", err)
+	}
+	if d.TrustStore() != nil {
+		t.Fatal("DropPin must clear the trust store")
+	}
+	if !d.Quarantined() {
+		t.Fatal("DropPin on a node that held a chain must quarantine it")
+	}
+	pinPath := genesisHashPath(path)
+	if _, err := os.Stat(pinPath); !os.IsNotExist(err) {
+		t.Fatal("DropPin must remove the persisted genesis pin file")
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -176,6 +176,14 @@ func (d *Node) Quarantined() bool { return d.trustGate.Tripped() }
 
 func (d *Node) localDisabled() bool { return d.localDisabledFlag.Load() }
 
+// reevaluateTrustChannels drops live client channels no longer authorized after a
+// trust-store advance. No-op when no uplink responder is active.
+func (d *Node) reevaluateTrustChannels() {
+	if r := d.activeResponder.Load(); r != nil {
+		r.reevaluate()
+	}
+}
+
 // remoteDispatch rejects lock.* methods (local-admin only) and dispatches the rest.
 func (d *Node) remoteDispatch() api.DispatchFunc {
 	full := d.server.DispatchFunc()

--- a/internal/node/trustlog.go
+++ b/internal/node/trustlog.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -209,6 +210,7 @@ func (d *Node) pushWanted(peer trustCaller, want [][]byte) {
 func (d *Node) pullTrustOnce(peer trustCaller) bool {
 	st := d.trust.Load()
 	if st == nil {
+		d.detectUnpinnedChain(peer)
 		return false
 	}
 	chains, ok := d.syncTrustChains(peer)
@@ -230,7 +232,89 @@ func (d *Node) pullTrustOnce(peer trustCaller) bool {
 			d.log.Warn("persisting trust-log chain failed", "path", d.trustPath, "err", werr)
 		}
 	}
+	d.detectSupersedingChain(chains)
+	d.reevaluateTrustChannels()
 	return true
+}
+
+// detectUnpinnedChain quarantines this node when the network has a trust log but
+// this node holds no pin to verify it against. The chain is only decoded, never
+// verified: anyone can mint a keypair and build a self-consistent chain, so
+// verification would prove nothing about who authored it.
+//
+// A hostile gateway can therefore quarantine unpinned nodes with a fabricated
+// chain. It can already refuse to relay at all, so this grants it no new power.
+func (d *Node) detectUnpinnedChain(peer trustCaller) {
+	if d.trustGate.Tripped() {
+		return
+	}
+	chains, ok := d.syncTrustChains(peer)
+	if !ok {
+		return
+	}
+	// Guard under pinMu: a concurrent AdoptPin that set the store between the sync
+	// and this point means the detection loop should not trip the gate for the old
+	// genesis.
+	d.pinMu.Lock()
+	if d.trust.Load() != nil {
+		d.pinMu.Unlock()
+		return
+	}
+	d.pinMu.Unlock()
+	for _, chain := range chains {
+		entries, err := trustlog.UnmarshalChain(chain)
+		if err != nil || len(entries) == 0 {
+			continue
+		}
+		genesis := trustlog.HashEntry(&entries[0])
+		// pinMu serializes the "store is nil → trip" decision against AdoptPin's
+		// "EnableTrustLog → Clear" sequence, closing the window where a concurrent
+		// adopt could have set the store and cleared the gate between our store-read
+		// above and this Trip call.
+		d.pinMu.Lock()
+		if d.trust.Load() == nil {
+			d.trustGate.Trip(genesis)
+			d.pinMu.Unlock()
+			d.log.Warn("unpinned node saw a trust log; refusing all channels until pinned",
+				"genesis", base64.StdEncoding.EncodeToString(genesis),
+				"fix", "argus lock pin")
+			d.reevaluateTrustChannels()
+		} else {
+			d.pinMu.Unlock()
+		}
+		return
+	}
+}
+
+// detectSupersedingChain quarantines a node whose own chain is disabled once the
+// network serves a different trust root. A disabled log authorizes nobody and can
+// never be re-enabled, so the pin holding it protects nothing while still refusing
+// the live root — the same rootless state detectUnpinnedChain exists for, reached
+// from the other direction. Decode only, for the reason given there.
+func (d *Node) detectSupersedingChain(chains [][]byte) {
+	if st := d.trust.Load(); st == nil || !st.Disabled() {
+		return
+	}
+	d.pinMu.Lock()
+	st := d.trust.Load()
+	if st == nil || !st.Disabled() {
+		d.pinMu.Unlock()
+		return
+	}
+	genesis := trustlog.SupersedingGenesis(chains, d.pinGenesis)
+	if genesis == nil || bytes.Equal(genesis, d.trustGate.Genesis()) {
+		d.pinMu.Unlock()
+		return
+	}
+	// Observe, not Trip: the network can relock more than once, and each time the
+	// root this device must be told to adopt changes. A first-sighting-wins gate
+	// would keep naming a root that no longer exists.
+	d.trustGate.Observe(genesis)
+	d.pinMu.Unlock()
+	d.log.Warn("this device's trust log is disabled and the network moved to a different root; refusing all channels until pinned",
+		"genesis", base64.StdEncoding.EncodeToString(genesis),
+		"fix", "argus lock pin")
+	d.reevaluateTrustChannels()
 }
 
 // persistChain writes chain bytes to trustPath atomically via atomicfile.Write.

--- a/internal/node/trustlog.go
+++ b/internal/node/trustlog.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -472,3 +474,98 @@ func (d *Node) triggerPeer() trustCaller {
 // setTriggerPeerForTest installs a trustCaller used by the event-driven pull in
 // place of the live uplink. Test-only.
 func (d *Node) setTriggerPeerForTest(p trustCaller) { d.testTriggerPeer.Store(&p) }
+
+// AdoptPin pins this node to genesis at runtime so an operator recovers a
+// quarantined node without a restart.
+//
+// Re-pinning the same genesis is a no-op; a different one is refused unless the
+// current chain is disabled (stale pin that no longer guards anything).
+func (d *Node) AdoptPin(genesis []byte) error {
+	if len(genesis) != trustpin.GenesisLen {
+		return fmt.Errorf("node: genesis is %d bytes, want %d", len(genesis), trustpin.GenesisLen)
+	}
+	if err := func() error {
+		d.pinMu.Lock()
+		defer d.pinMu.Unlock()
+		if len(d.pinGenesis) > 0 {
+			if bytes.Equal(d.pinGenesis, genesis) {
+				return nil
+			}
+			// A disabled chain enforces nothing and can never be re-enabled, so the pin
+			// holding it is stale rather than conflicting — replacing it is safe.
+			if st := d.trust.Load(); st == nil || !st.Disabled() {
+				return errors.New("node: already pinned to a different genesis; run `argus lock unpin` first")
+			}
+			if err := os.Remove(d.trustPath); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			d.pinGenesis = nil
+		}
+		if d.trustPath == "" {
+			return errors.New("node: trust state path not configured")
+		}
+		if err := trustpin.New(genesisHashPath(d.trustPath)).Save(genesis); err != nil {
+			return err
+		}
+		if err := d.enableTrustLogLocked(genesis, d.trustPath); err != nil {
+			return err
+		}
+		d.pinSource = trustpin.SourceFile.String()
+		return nil
+	}(); err != nil {
+		return err
+	}
+	d.reevaluateTrustChannels()
+	if peer := d.triggerPeer(); peer != nil {
+		d.pullTrustOnce(peer)
+	}
+	// Clear the quarantine gate only once a chain for this pin has actually
+	// ingested. A pin that does not match the network's genesis never ingests, so
+	// the node stays quarantined and diagnosable in `lock status` rather than
+	// silently going dark on an empty store. (enableTrustLogLocked already clears
+	// the gate up front when the pin equals the genesis the gate observed.)
+	d.pinMu.Lock()
+	if st := d.trust.Load(); st != nil && st.Bytes() != nil {
+		d.trustGate.Clear()
+	}
+	d.pinMu.Unlock()
+	return nil
+}
+
+// DropPin clears the pin, the persisted chain, and the trust store. A node that
+// held a chain quarantines immediately. DropPin never releases a quarantine and
+// deliberately does not touch the local-disable marker.
+func (d *Node) DropPin() error {
+	if err := func() error {
+		d.pinMu.Lock()
+		defer d.pinMu.Unlock()
+		if d.trustPath == "" {
+			return errors.New("node: trust state path not configured")
+		}
+		if err := trustpin.New(genesisHashPath(d.trustPath)).Clear(); err != nil {
+			return err
+		}
+		if err := os.Remove(d.trustPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		st := d.trust.Load()
+		sawChain := st != nil && st.Bytes() != nil
+		lastGenesis := d.pinGenesis
+		if sawChain {
+			// Trip BEFORE niling the store so there is never a window where both the
+			// store is nil (device-auth skipped) and the gate is un-tripped (channels
+			// accepted). Only a chain we actually held proves this network is locked;
+			// tripping without that proof would strand a node whose network has no trust log.
+			d.trustGate.Trip(lastGenesis)
+		}
+		d.trust.Store(nil)
+		d.pinGenesis = nil
+		d.pinSource = ""
+		d.retainedEntries = nil
+		return nil
+	}(); err != nil {
+		return err
+	}
+	d.reevaluateTrustChannels()
+	return nil
+}

--- a/internal/node/trustlog_test.go
+++ b/internal/node/trustlog_test.go
@@ -240,3 +240,65 @@ func mustUnmarshalChain(t *testing.T, b []byte) []trustlog.Entry {
 	}
 	return e
 }
+
+// TestUnpinnedNodeQuarantinesOnServedChain verifies that a node with no pin
+// (SetTrustChainPath only, d.trust nil) trips Quarantined()+rejectsChannels()
+// when the gateway serves a non-empty trust chain.
+func TestUnpinnedNodeQuarantinesOnServedChain(t *testing.T) {
+	chain, _, _, _ := seedChain(t, true)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	d.SetTrustChainPath(path)
+	// d.trust is nil — unpinned
+
+	d.pullTrustOnce(&fakePeer{pullChain: chain})
+
+	if !d.Quarantined() {
+		t.Fatal("unpinned node seeing a served chain must be quarantined")
+	}
+	if !d.rejectsChannels() {
+		t.Fatal("quarantined node must reject channels")
+	}
+}
+
+// TestPinnedAuthorizedNodeDoesNotQuarantine verifies that a pinned node that
+// successfully ingests its chain does not trip the quarantine gate.
+func TestPinnedAuthorizedNodeDoesNotQuarantine(t *testing.T) {
+	chain, head, _, _ := seedChain(t, true)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	if err := d.EnableTrustLog(head, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+
+	d.pullTrustOnce(&fakePeer{pullChain: chain})
+
+	if d.Quarantined() {
+		t.Fatal("pinned node that ingested its chain must not be quarantined")
+	}
+	if d.rejectsChannels() {
+		t.Fatal("authorized pinned node must not reject channels")
+	}
+}
+
+// TestUnpinnedNodeWithNoServedChainDoesNotQuarantine verifies that pure TOFU
+// (no chain served) never trips the gate.
+func TestUnpinnedNodeWithNoServedChainDoesNotQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d := New()
+	d.SetTrustChainPath(path)
+
+	d.pullTrustOnce(&fakePeer{pullChain: nil}) // empty — no chain served
+
+	if d.Quarantined() {
+		t.Fatal("no served chain must never quarantine")
+	}
+	if d.rejectsChannels() {
+		t.Fatal("TOFU node must not reject channels")
+	}
+}

--- a/internal/tui/fileclient.go
+++ b/internal/tui/fileclient.go
@@ -121,6 +121,7 @@ func (c *fileClient) Call(method string, params, out any) error {
 func (c *fileClient) Events() <-chan api.Notification { return c.events }
 func (c *fileClient) States() <-chan bool             { return c.states }
 func (c *fileClient) Reconnect()                      {}
+func (c *fileClient) Quarantined() bool               { return false }
 
 // Close releases the client. The extracted destDir is left in place: it's a
 // deterministic per-bundle cache (see RunBundle) reused on the next open.

--- a/internal/tui/logs_test.go
+++ b/internal/tui/logs_test.go
@@ -19,6 +19,7 @@ func (logsStubClient) Events() <-chan api.Notification { return make(chan api.No
 func (logsStubClient) States() <-chan bool             { return make(chan bool) }
 func (logsStubClient) Reconnect()                      {}
 func (logsStubClient) Close() error                    { return nil }
+func (logsStubClient) Quarantined() bool               { return false }
 
 func fillLogs(b *logbuf.Buffer, n int) {
 	for i := 0; i < n; i++ {

--- a/internal/tui/quarantine_test.go
+++ b/internal/tui/quarantine_test.go
@@ -1,0 +1,95 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+type stubQuarantinedClient struct{ q bool }
+
+func (c *stubQuarantinedClient) Call(_ string, _, _ any) error   { return nil }
+func (c *stubQuarantinedClient) Events() <-chan api.Notification { return nil }
+func (c *stubQuarantinedClient) States() <-chan bool             { return nil }
+func (c *stubQuarantinedClient) Reconnect()                      {}
+func (c *stubQuarantinedClient) Close() error                    { return nil }
+func (c *stubQuarantinedClient) Quarantined() bool               { return c.q }
+
+func quarantinedModel(q bool, sessions ...session.Session) model {
+	m := modelWith(sessions...)
+	m.client = &stubQuarantinedClient{q: q}
+	return m
+}
+
+func TestListViewQuarantineBanner(t *testing.T) {
+	s := session.Session{ID: "s1", Status: session.StatusIdle, Tmux: session.TmuxLocation{PaneID: "%1"}}
+	out := quarantinedModel(true, s).listView()
+	if !strings.Contains(out, "QUARANTINED") {
+		t.Fatalf("quarantined list view missing QUARANTINED banner:\n%s", out)
+	}
+	if !strings.Contains(out, "argus lock pin") {
+		t.Fatalf("quarantined list view missing pin hint:\n%s", out)
+	}
+}
+
+func TestListViewNoBannerWhenNotQuarantined(t *testing.T) {
+	s := session.Session{ID: "s1", Status: session.StatusIdle, Tmux: session.TmuxLocation{PaneID: "%1"}}
+	out := quarantinedModel(false, s).listView()
+	if strings.Contains(out, "QUARANTINED") {
+		t.Fatalf("non-quarantined list view must not show QUARANTINED banner:\n%s", out)
+	}
+}
+
+func TestEmptyListViewQuarantineBanner(t *testing.T) {
+	out := quarantinedModel(true).listView()
+	if !strings.Contains(out, "QUARANTINED") {
+		t.Fatalf("quarantined empty list view missing QUARANTINED banner:\n%s", out)
+	}
+}
+
+func TestEmptyListViewNoBannerWhenNotQuarantined(t *testing.T) {
+	out := quarantinedModel(false).listView()
+	if strings.Contains(out, "QUARANTINED") {
+		t.Fatalf("non-quarantined empty list view must not show QUARANTINED banner:\n%s", out)
+	}
+}
+
+// TestEmptyListViewQuarantineHeight verifies that when quarantined the empty-list
+// view accounts for the extra banner row, keeping the welcome block from overlapping
+// the footer. pinFooter always produces exactly height lines; the test checks that
+// the footer key hint lands on the last line (not buried inside the body).
+func TestEmptyListViewQuarantineHeight(t *testing.T) {
+	const height, width = 16, 60
+	m := quarantinedModel(true)
+	m.height, m.width = height, width
+
+	out := m.listView()
+	lines := strings.Split(out, "\n")
+
+	if len(lines) != height {
+		t.Fatalf("output = %d lines, want %d", len(lines), height)
+	}
+
+	last := lipgloss.NewStyle().Render(lines[height-1])
+	if !strings.Contains(last, "n") {
+		t.Fatalf("footer key hint not found on last line: %q", last)
+	}
+
+	bannerLine := -1
+	for i, l := range lines {
+		if strings.Contains(l, "QUARANTINED") {
+			bannerLine = i
+			break
+		}
+	}
+	if bannerLine < 0 {
+		t.Fatal("QUARANTINED not found in output")
+	}
+	if bannerLine == height-1 {
+		t.Fatal("QUARANTINED banner must not be on the last (footer) line")
+	}
+}

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -58,6 +58,7 @@ func (c *recordingClient) Events() <-chan api.Notification { return make(chan ap
 func (c *recordingClient) States() <-chan bool             { return make(chan bool) }
 func (c *recordingClient) Reconnect()                      {}
 func (c *recordingClient) Close() error                    { return nil }
+func (c *recordingClient) Quarantined() bool               { return false }
 
 func (c *recordingClient) calledMethods() []string {
 	c.mu.Lock()

--- a/internal/tui/spawn_test.go
+++ b/internal/tui/spawn_test.go
@@ -54,6 +54,7 @@ func (c *spawnPickClient) Events() <-chan api.Notification { return make(chan ap
 func (c *spawnPickClient) States() <-chan bool             { return make(chan bool) }
 func (c *spawnPickClient) Reconnect()                      {}
 func (c *spawnPickClient) Close() error                    { return nil }
+func (c *spawnPickClient) Quarantined() bool               { return false }
 
 func pumpAgents(t *testing.T, m model, cmd tea.Cmd) model {
 	t.Helper()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -27,6 +27,10 @@ type Client interface {
 	States() <-chan bool
 	Reconnect()
 	Close() error
+	// Quarantined reports whether this device is unpinned on a network that has a
+	// trust log and must run "argus lock pin" before it can reach any node.
+	// Always false for plaintext (non-E2E) clients.
+	Quarantined() bool
 }
 
 // Run connects the TUI and blocks until the user quits. Non-nil logs (embedded

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -178,6 +178,10 @@ func (m model) homeTabs(active viewMode) string {
 	return out
 }
 
+func (m model) quarantined() bool {
+	return m.client != nil && m.client.Quarantined()
+}
+
 func (m model) listView() string {
 	if m.spawn.active() {
 		return m.spawnView()
@@ -188,9 +192,18 @@ func (m model) listView() string {
 	}
 	title += "    " + m.homeTabs(modeList)
 
+	// chrome counts non-content rows: title + blank-after-title + footer + blank-before-footer.
+	// +1 when the quarantine banner is present (it adds a second title row).
+	chrome := 4
+	if m.quarantined() {
+		title += "\n" + StyleErrorBold.Render("⚠ QUARANTINED") +
+			dimStyle.Render("  pin this device: argus lock pin")
+		chrome++
+	}
+
 	// Empty state.
 	if len(m.order) == 0 {
-		return m.emptyListView(title)
+		return m.emptyListView(title, chrome)
 	}
 
 	// Populated.
@@ -226,9 +239,7 @@ func (m model) listView() string {
 		}
 	}
 
-	// Window to available height (chrome = 4: title + 2 blanks + footer), keeping
-	// the cursor card visible.
-	lines = windowSpan(lines, curStart, curEnd, max(1, m.height-4))
+	lines = windowSpan(lines, curStart, curEnd, max(1, m.height-chrome))
 
 	footer := m.footer(listKeys.Up, listKeys.Open, listKeys.Screen, listKeys.Jump,
 		listKeys.TabNext, listKeys.New, listKeys.Kill, listKeys.Refresh, listKeys.Quit)
@@ -278,7 +289,7 @@ func argusLogo(width, height int) string {
 
 // emptyListView renders the welcome screen: the argus logo, wordmark, tagline, and a
 // spawn hint, centered in the space between the tab bar and the footer.
-func (m model) emptyListView(title string) string {
+func (m model) emptyListView(title string, chrome int) string {
 	textW := max(16, min(m.width-2, 52))
 	center := lipgloss.NewStyle().Width(textW).Align(lipgloss.Center)
 	hint := dimStyle.Render("No sessions yet. Start an AI agent in a tmux pane, or press ") +
@@ -292,7 +303,7 @@ func (m model) emptyListView(title string) string {
 		center.Render(hint),
 	)
 
-	avail := max(1, m.height-4) // title + blank + welcome + footer
+	avail := max(1, m.height-chrome)
 	top := max(0, (avail-lipgloss.Height(welcome))/2)
 	block := strings.Repeat("\n", top) + centerBlock(welcome, lipgloss.Width(welcome), m.width)
 


### PR DESCRIPTION
> **⚠️ Updated (beacon → tip cross-check).** The anti-equivocation *beacon* mechanism referenced below was removed stack-wide and replaced by an authenticated tip cross-check: the client reads each node's trust-log tip over its already-authenticated Noise channel (via `node.identify`) and compares tips against its resolved chain — no per-node beacon key, no gateway-supplied verification input. See PR #44 and `docs/superpowers/plans/2026-09-02-beacon-to-tip-crosscheck.md`. Any "beacon"/"equivocation" wording below is historical.

---

Seventh stacked PR (base: `pr/05a-trustlog-enforcement`). Layers quarantine + recovery onto 5a's authorized-device enforcement.

- **Quarantine:** an *unpinned* node on a locked network (`detectUnpinnedChain`) trips its gate and refuses all E2E channels (fail-closed); `detectSupersedingChain` handles disabled-then-relocked; `reevaluateTrustChannels` closes now-unauthorized live channels.
- **Recovery:** `AdoptPin`/`DropPin` (runtime pin) and the local-disable escape hatch (marker file), with `LoadLocalDisabled` at startup.
- **Client:** `Quarantined()` surfaced in the Go TUI as a banner. Plaintext client returns false (never a banner).

**Security (final review, traced + `-race`):** no false quarantine of TOFU/legit nodes; `AdoptPin`⇄`detectUnpinnedChain` serialized under `pinMu`; recovery restores enforcement (authorized connects, unauthorized still rejected) — never wide-open; local-disable overrides quarantine; beacon (PR 7) stays trimmed; e2ee-off/no-genesis = TOFU/plaintext unchanged.

**Test:** unpinned node quarantines on a locked network (proof can't false-pass) and recovers via `AdoptPin`; TOFU stays open.

**Stack dependency:** `AdoptPin`/`DropPin`/`LocalDisable` are code-complete but not yet reachable from the CLI — **PR 6 (lock CLI) must wire `argus lock pin`/`unpin`/local-disable onto them** before the stack fast-forwards to main (the quarantine banner already advises `argus lock pin`). See `docs/superpowers/specs/2026-08-08-incremental-e2e-merge-plan-design.md` (PR 5b).
