### PR TITLE
PR 6a — lock recovery + status/log CLI

### DIFF
--- a/cmd/argus/lock.go
+++ b/cmd/argus/lock.go
@@ -1,0 +1,505 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/keyfmt"
+	"github.com/MunifTanjim/argus/internal/shell"
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+func newLockCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lock",
+		Short: "Manage locked mode (network trust log)",
+	}
+	cmd.AddCommand(newLockStatusCmd(), newLockLogCmd(), newLockPinCmd(), newLockUnpinCmd(), newLockLocalDisableCmd())
+	return cmd
+}
+
+func callLocal[R any](ctx context.Context, cfg *config.Config, method string, params any) (R, error) {
+	var res R
+	dial, err := gatewayDialer("", "", cfg.Socket) // force local socket
+	if err != nil {
+		return res, err
+	}
+	conn, err := dial(ctx)
+	if err != nil {
+		return res, err
+	}
+	c := api.NewClient(conn)
+	defer c.Close()
+	if err := c.Call(method, params, &res); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func lockStatusOnNode(ctx context.Context, cfg *config.Config) (api.LockStatusResult, error) {
+	return callLocal[api.LockStatusResult](ctx, cfg, api.MethodLockStatus, nil)
+}
+
+func lockLogOnNode(ctx context.Context, cfg *config.Config) (api.LockLogResult, error) {
+	return callLocal[api.LockLogResult](ctx, cfg, api.MethodLockLog, nil)
+}
+
+func newLockStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "status",
+		Short:         "Show locked-mode status (tip fingerprint, signers, this node's roles)",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := resolveConfig(cmd)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			st, err := lockStatusOnNode(ctx, cfg)
+			if err != nil {
+				kp, ierr := e2e.LoadOrCreateIdentity(config.GetStatePath("client-identity.json"))
+				if ierr != nil {
+					return fail(cmd, err) // surface the original node-dial error
+				}
+				shell.StdOutF("locked mode: (no local node)\nthis tui\n  identity: %s\n  → to authorize this tui, run on a signer node:\n      %s\n",
+					keyfmt.DeviceKey.Encode(kp.Public), lockSignHint(kp.Public))
+				printClientPinStatus(ctx, cfg)
+				// Exit 0 only when the socket was not explicitly requested and simply
+				// does not exist: that is a machine with no local node (client-only).
+				// An explicit --socket flag, or any error other than ENOENT (ECONNREFUSED,
+				// timeout, etc.), means the socket is broken or misconfigured.
+				if !cmd.Flags().Changed("socket") && errors.Is(err, os.ErrNotExist) {
+					return nil
+				}
+				return fail(cmd, fmt.Errorf("node socket: %v", err))
+			}
+			printLockStatus(st)
+			if hint := authorizeHint(st); hint != "" {
+				shell.StdOutF("%s", hint)
+			}
+			if pinErr := printTUIRole(ctx, cfg, st); pinErr != nil {
+				return fail(cmd, pinErr)
+			}
+			return nil
+		},
+	}
+	addClientFlags(cmd.Flags())
+	return cmd
+}
+
+// gatewayProbeTimeout: a gateway that upgrades then answers nothing would otherwise
+// hang `lock status` — the one command run when the gateway is broken.
+var gatewayProbeTimeout = 5 * time.Second
+
+func printClientPinStatus(ctx context.Context, cfg *config.Config) error {
+	line, err := clientPinLine(ctx, cfg)
+	shell.StdOutF("%s", line)
+	return err
+}
+
+// printTUIRole prints the "this tui" block: the dashboard client's identity, whether
+// that identity is authorized in the trust log, its pin line, and a sign hint when it is
+// not yet authorized. The node RPC says nothing about the client role, so this is the
+// only place it is reported.
+func printTUIRole(ctx context.Context, cfg *config.Config, st api.LockStatusResult) error {
+	kp, err := e2e.LoadOrCreateIdentity(config.GetStatePath("client-identity.json"))
+	if err != nil {
+		return printClientPinStatus(ctx, cfg) // identity unreadable: still show the pin line
+	}
+	shell.StdOutF("this tui\n  identity: %s", keyfmt.DeviceKey.Encode(kp.Public))
+	showAuthz := st.Enabled && devicesKnown(st)
+	authorized := showAuthz && keyAuthorized(kp.Public, st.Devices)
+	if showAuthz {
+		shell.StdOutF("   authorized: %s", yesNo(authorized))
+	}
+	shell.StdOutF("\n")
+	pinErr := printClientPinStatus(ctx, cfg)
+	if showAuthz && !authorized {
+		shell.StdOutF("  → to authorize this tui, run on a signer node:\n      %s\n", lockSignHint(kp.Public))
+	}
+	return pinErr
+}
+
+// devicesKnown reports whether st carries the authorized device set. A daemon that
+// predates the Devices field returns a count with no list; membership is unknowable then.
+func devicesKnown(st api.LockStatusResult) bool {
+	return st.DeviceCount == 0 || len(st.Devices) > 0
+}
+
+func keyAuthorized(key []byte, devices [][]byte) bool {
+	for _, d := range devices {
+		if bytes.Equal(d, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientPinLine is the only surface for the client (TUI) role's quarantine: it has no
+// RPC and the node status says nothing about it. A non-nil error means the probe could
+// not complete; the caller still prints the line, then exits non-zero.
+func clientPinLine(ctx context.Context, cfg *config.Config) (string, error) {
+	pin, perr := trustpin.Resolve(cfg.Lock.Genesis, clientPinFile())
+	// A pinned client is checked too, not just an unpinned one: when the chain it
+	// names has been disabled the pin is dead, and the network genesis is what the
+	// operator needs to see to understand why the dashboard went dark.
+	superseded := perr == nil && pin.Genesis != nil && clientPinSuperseded(pin.Genesis)
+	var netGenesis []byte
+	var neterr error
+	if perr == nil && (pin.Genesis == nil || superseded) && cfg.Gateway.URL != "" {
+		pctx, cancel := context.WithTimeout(ctx, gatewayProbeTimeout)
+		defer cancel()
+		if superseded {
+			netGenesis, neterr = supersedingGenesisFromNetwork(pctx, cfg, pin.Genesis)
+		} else {
+			netGenesis, neterr = quarantiningGenesis(pctx, cfg)
+		}
+		if errors.Is(neterr, context.DeadlineExceeded) {
+			neterr = fmt.Errorf("the gateway did not answer within %s", gatewayProbeTimeout)
+		}
+	}
+	return clientPinStatus(pin, perr, netGenesis, neterr, superseded), neterr
+}
+
+// netGenesis is the genesis this network offers (nil when none or unchecked), neterr
+// why the check failed. superseded means the pinned chain was disabled network-wide,
+// making the pin dead rather than protective.
+func clientPinStatus(pin trustpin.Pin, perr error, netGenesis []byte, neterr error, superseded bool) string {
+	switch {
+	case perr != nil:
+		return fmt.Sprintf("  pin: unreadable — %v\n       argus refuses to start until this is resolved\n", perr)
+	case pin.Genesis != nil && superseded:
+		if netGenesis != nil {
+			return fmt.Sprintf("  pin: %s — the network now uses a new root (%s)\n       this tui opens no channels; run:\n         %s\n       then restart argus\n",
+				fingerprintOf(pin.Genesis), fingerprintOf(netGenesis), "argus lock pin "+trustpin.Encode(netGenesis))
+		}
+		if neterr != nil {
+			// Probe failed: a replacement root may exist but could not be checked.
+			// Advising lock init here could mint a competing genesis and fork the fleet.
+			return fmt.Sprintf("  pin: %s — the pinned root was replaced, but the gateway could not be reached to find the new one: %v\n       this tui opens no channels; retry once the gateway is reachable\n",
+				fingerprintOf(pin.Genesis), neterr)
+		}
+		return fmt.Sprintf("  pin: %s — the pinned root was disabled network-wide; no new root yet\n       this tui opens no channels\n       a signer must run:\n         argus lock init\n       then on each device:\n         argus lock pin\n",
+			fingerprintOf(pin.Genesis))
+	case pin.Genesis != nil:
+		return fmt.Sprintf("  pin: %s (source: %s)\n", fingerprintOf(pin.Genesis), pin.Source)
+	case netGenesis != nil:
+		return fmt.Sprintf("  pin: none — locked out: not pinned to the network's root (%s)\n       this tui opens no channels; run: argus lock pin\n", fingerprintOf(netGenesis))
+	case neterr != nil:
+		return fmt.Sprintf("  pin: none (could not check this network for a trust log: %v)\n", neterr)
+	default:
+		return "  pin: none\n"
+	}
+}
+
+// authorizeHint is silent when there is no live root to authorize into: a disabled
+// chain authorizes nobody, a quarantined device follows a root the network left —
+// both want `argus lock pin`, which the pin line already says.
+func authorizeHint(st api.LockStatusResult) string {
+	if !st.Enabled || st.Authorized || st.Disabled || st.Quarantined || len(st.IdentityPubKey) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("\n  to authorize this node, run on a signer node:\n    %s\n", lockSignHint(st.IdentityPubKey))
+}
+
+func lockSignHint(pub []byte) string {
+	return "argus lock sign " + keyfmt.DeviceKey.Encode(pub)
+}
+
+func newLockLogCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "log",
+		Short:         "Show trust-log history (read-only)",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := resolveConfig(cmd)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			res, err := lockLogOnNode(ctx, cfg)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			for _, e := range res.Entries {
+				printLockLogEntry(e)
+			}
+			shell.StdOutF("%s", lockLogTrailer(res))
+			return nil
+		},
+	}
+	addClientFlags(cmd.Flags())
+	return cmd
+}
+
+// entryHashString spells an entry hash the way revoke-signer --fork-from parses it:
+// the genesis as gen:, every later entry as tip:.
+func entryHashString(e api.LockLogEntry) string {
+	if e.Index == 0 {
+		return keyfmt.Genesis.Encode(e.Hash)
+	}
+	return keyfmt.Tip.Encode(e.Hash)
+}
+
+func lockLogTrailer(res api.LockLogResult) string {
+	var b strings.Builder
+	b.WriteString("\n")
+	if len(res.Entries) > 0 {
+		if len(res.Entries[0].Hash) > 0 {
+			fmt.Fprintf(&b, "genesis: %s\n", keyfmt.Genesis.Encode(res.Entries[0].Hash))
+		} else {
+			b.WriteString("entry hashes not reported by the running daemon — restart it: argus start\n")
+		}
+	}
+	if len(res.Tip) > 0 {
+		fmt.Fprintf(&b, "tip:     %s\n", keyfmt.Tip.Encode(res.Tip))
+	}
+	fmt.Fprintf(&b, "length:  %d entries\n", len(res.Entries))
+	if len(res.Signers) > 0 {
+		fmt.Fprintf(&b, "signers: %d  fingerprint: %s\n", len(res.Signers), signerSetFingerprintOf(res.Signers))
+	}
+	return b.String()
+}
+
+func printLockLogEntry(e api.LockLogEntry) {
+	switch e.Kind {
+	case "genesis":
+		shell.StdOutF("[%d] genesis: %d signer(s)\n", e.Index, len(e.Signers))
+		for _, s := range e.Signers {
+			shell.StdOutF("  signer: %s\n", keyfmt.SignerKey.Encode(s))
+		}
+	case "add-signer":
+		shell.StdOutF("[%d] add-signer: %s\n", e.Index, keyfmt.SignerKey.Encode(e.Target))
+	case "remove-signer":
+		shell.StdOutF("[%d] remove-signer: %s\n", e.Index, keyfmt.SignerKey.Encode(e.Target))
+	case "authorize-device":
+		shell.StdOutF("[%d] authorize-device: %s\n", e.Index, keyfmt.DeviceKey.Encode(e.Target))
+	case "revoke-device":
+		shell.StdOutF("[%d] revoke-device: %s\n", e.Index, keyfmt.DeviceKey.Encode(e.Target))
+	case "revoke-signer":
+		shell.StdOutF("[%d] revoke-signer: %d revoked, %d co-sign(s)\n", e.Index, len(e.Revoked), e.CoSignCount)
+		for _, r := range e.Revoked {
+			shell.StdOutF("  revoked: %s\n", keyfmt.SignerKey.Encode(r))
+		}
+		for _, r := range e.Replaces {
+			shell.StdOutF("  replaces: %s\n", keyfmt.SignerKey.Encode(r))
+		}
+	case "disable":
+		shell.StdOutF("[%d] disable\n", e.Index)
+	default:
+		shell.StdOutF("[%d] %s\n", e.Index, e.Kind)
+	}
+	if len(e.Hash) > 0 {
+		shell.StdOutF("  hash: %s\n", entryHashString(e))
+	}
+}
+
+func newLockLocalDisableCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "local-disable",
+		Short:         "Disable locked-mode enforcement on THIS node only (persisted escape hatch)",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := resolveConfig(cmd)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if _, err := callLocal[struct{}](ctx, cfg, api.MethodLockLocalDisable, nil); err != nil {
+				return fail(cmd, err)
+			}
+			shell.StdOutF("locked-mode enforcement disabled on this node\n")
+			return nil
+		},
+	}
+	addClientFlags(cmd.Flags())
+	return cmd
+}
+
+func keyOrNone(k keyfmt.Kind, b []byte) string {
+	if len(b) == 0 {
+		return "(none)"
+	}
+	return k.Encode(b)
+}
+
+func printLockStatus(st api.LockStatusResult) {
+	out, warn := lockStatusLines(st)
+	shell.StdOutF("%s", out)
+	if warn != "" {
+		shell.StdErrF("%s", warn)
+	}
+}
+
+// lockStatusLines is pure so the wording is testable. Sections are unconditional: a
+// fact that does not exist prints as none, so absence is never ambiguous.
+func lockStatusLines(st api.LockStatusResult) (string, string) {
+	var b strings.Builder
+	b.WriteString(lockHeadline(st))
+	for _, section := range []string{
+		chainSection(st),
+		thisNodeSection(st),
+		signersSection(st),
+		devicesSection(st),
+	} {
+		b.WriteString("\n")
+		b.WriteString(section)
+	}
+	b.WriteString("\n")
+	b.WriteString(lockPinLines(st))
+	if st.LocalDisabled {
+		b.WriteString("  local-disable: active\n")
+	}
+	return b.String(), ""
+}
+
+// "disabled" is reserved for a network whose break-glass secret was spent, never one
+// simply never locked. Supersession outranks every headline: what matters first is
+// that THIS device serves nobody, not the history of the root it still holds.
+func lockHeadline(st api.LockStatusResult) string {
+	switch {
+	case st.Quarantined && st.Pinned:
+		return "locked mode: locked out — this node opens no channels\n" +
+			"  the trust root it is pinned to was disabled by break-glass (permanently), and\n" +
+			"  the network has since locked again under a new root\n"
+	case st.Quarantined:
+		return "locked mode: locked out — the network is locked, but this node is not pinned to it\n" +
+			"  this node opens no channels until you pin it (see pin: below)\n"
+	case st.Disabled:
+		return "locked mode: disabled network-wide — break-glass used, nothing is enforced\n" +
+			"  this is permanent: the log can never be re-enabled\n" +
+			"  to lock again: argus lock init (new genesis; every device repins)\n"
+	case !st.Enabled:
+		return "locked mode: not enabled\n"
+	default:
+		return "locked mode: enforcing\n"
+	}
+}
+
+func chainSection(st api.LockStatusResult) string {
+	if !st.Enabled {
+		return "chain: none — this node holds no trust log\n"
+	}
+	var b strings.Builder
+	b.WriteString("chain\n")
+	// Enabled implies pinned — the store is genesis-pinned at construction — so an
+	// absent genesis here is a bug, not a state. Say so rather than print "gen:".
+	if len(st.PinGenesis) > 0 {
+		fmt.Fprintf(&b, "  genesis: %s\n           %s\n",
+			keyfmt.Genesis.Encode(st.PinGenesis), fingerprintOf(st.PinGenesis))
+	} else {
+		b.WriteString("  genesis: (not reported)\n")
+	}
+	if len(st.Tip) == 0 {
+		b.WriteString("  tip:     none — no chain synced yet\n")
+	} else {
+		fmt.Fprintf(&b, "  tip:     %s\n           %s\n",
+			keyfmt.Tip.Encode(st.Tip), fingerprintOf(st.Tip))
+	}
+	if st.Length == 0 && st.DeviceCount > 0 {
+		b.WriteString("  length:  not reported by the running daemon\n")
+	} else {
+		fmt.Fprintf(&b, "  length:  %d entries\n", st.Length)
+	}
+	return b.String()
+}
+
+func thisNodeSection(st api.LockStatusResult) string {
+	var b strings.Builder
+	b.WriteString("this node\n")
+	fmt.Fprintf(&b, "  identity: %s", keyOrNone(keyfmt.DeviceKey, st.IdentityPubKey))
+	if st.Enabled {
+		fmt.Fprintf(&b, "   authorized: %s", yesNo(st.Authorized))
+	}
+	fmt.Fprintf(&b, "\n  signer:   %s", keyOrNone(keyfmt.SignerKey, st.SignerPubKey))
+	if st.Enabled {
+		fmt.Fprintf(&b, "   trusted: %s", yesNo(st.SignerTrusted))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func signersSection(st api.LockStatusResult) string {
+	if len(st.Signers) == 0 {
+		return "signers: none\n"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "signers (%d)\n", len(st.Signers))
+	fmt.Fprintf(&b, "  fingerprint: %s\n", signerSetFingerprintOf(st.Signers))
+	for _, s := range st.Signers {
+		fmt.Fprintf(&b, "  %s\n", keyfmt.SignerKey.Encode(s))
+	}
+	return b.String()
+}
+
+func devicesSection(st api.LockStatusResult) string {
+	if st.DeviceCount == 0 {
+		return "devices: none\n"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "devices (%d)\n", st.DeviceCount)
+	if len(st.Devices) == 0 {
+		b.WriteString("  list not reported by the running daemon — restart it: argus start\n")
+		return b.String()
+	}
+	for _, dev := range st.Devices {
+		fmt.Fprintf(&b, "  %s", keyfmt.DeviceKey.Encode(dev))
+		if bytes.Equal(dev, st.IdentityPubKey) {
+			b.WriteString("  ← this node")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// A quarantined device that still holds a pin is superseded: its root was disabled and
+// the network moved on, so it names both.
+func lockPinLines(st api.LockStatusResult) string {
+	switch {
+	case st.Quarantined && st.Pinned:
+		if len(st.SeenGenesis) == 0 {
+			// Gate tripped but no replacement root observed yet. Naming a new root here
+			// would mislead; advise the operator to wait for a signer to reinit.
+			return fmt.Sprintf("  pin: %s — the pinned root was disabled; no new root yet\n       when a signer runs argus lock init, run here:\n         argus lock pin\n",
+				fingerprintOf(st.PinGenesis))
+		}
+		// Name the genesis explicitly: a gateway that has seen a relock retains several
+		// competing roots, and bare `lock pin` refuses to pick between them.
+		seen := fingerprintOf(st.SeenGenesis)
+		fix := "argus lock pin " + keyfmt.Genesis.Encode(st.SeenGenesis)
+		return fmt.Sprintf("  pin: %s — the network now uses a new root (%s)\n       run:\n         %s\n",
+			fingerprintOf(st.PinGenesis), seen, fix)
+	case st.Quarantined:
+		seen := fingerprintOf(st.SeenGenesis)
+		fix := "argus lock pin " + keyfmt.Genesis.Encode(st.SeenGenesis)
+		return fmt.Sprintf("  pin: none — not pinned to the network's root (%s)\n       run:\n         %s\n", seen, fix)
+	case st.Pinned:
+		return fmt.Sprintf("  pin: %s (source: %s)\n",
+			fingerprintOf(st.PinGenesis), st.PinSource)
+	default:
+		return "  pin: none\n"
+	}
+}

--- a/cmd/argus/lock_log_text_test.go
+++ b/cmd/argus/lock_log_text_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/keyfmt"
+)
+
+// The whole point of printing entry hashes is that one can be pasted into
+// revoke-signer --fork-from, which parses with exactly this call.
+func TestLockLogEntryHashesParseBackAsForkPoints(t *testing.T) {
+	entries := []api.LockLogEntry{
+		{Index: 0, Kind: "genesis", Hash: testGenesis(0xE0)},
+		{Index: 1, Kind: "authorize-device", Hash: testGenesis(0xE1)},
+		{Index: 2, Kind: "add-signer", Hash: testGenesis(0xE2)},
+	}
+	for _, e := range entries {
+		s := entryHashString(e)
+		got, err := keyfmt.DecodeAny(s, keyfmt.Tip, keyfmt.Genesis)
+		if err != nil {
+			t.Fatalf("entry %d: %q is not a usable fork point: %v", e.Index, s, err)
+		}
+		if !bytes.Equal(got, e.Hash) {
+			t.Errorf("entry %d: round trip = %x, want %x", e.Index, got, e.Hash)
+		}
+	}
+}
+
+// Entry 0 is the trust root and every later entry is a mid-chain hash; the prefixes
+// must say which is which.
+func TestEntryHashStringTagsGenesisAndLaterEntriesDifferently(t *testing.T) {
+	genesis := entryHashString(api.LockLogEntry{Index: 0, Hash: testGenesis(0xE0)})
+	if !strings.HasPrefix(genesis, keyfmt.Genesis.Prefix()) {
+		t.Errorf("entry 0 = %q, want a %s prefix", genesis, keyfmt.Genesis.Prefix())
+	}
+	later := entryHashString(api.LockLogEntry{Index: 1, Hash: testGenesis(0xE1)})
+	if !strings.HasPrefix(later, keyfmt.Tip.Prefix()) {
+		t.Errorf("entry 1 = %q, want a %s prefix", later, keyfmt.Tip.Prefix())
+	}
+}
+
+func TestLockLogTrailerNamesGenesisTipLengthAndSigners(t *testing.T) {
+	res := api.LockLogResult{
+		Entries: []api.LockLogEntry{
+			{Index: 0, Kind: "genesis", Hash: testGenesis(0xE0)},
+			{Index: 1, Kind: "authorize-device", Hash: testGenesis(0xE1)},
+		},
+		Tip:     testGenesis(0xE1),
+		Signers: [][]byte{testGenesis(0xF1), testGenesis(0xF2)},
+	}
+	out := lockLogTrailer(res)
+	for _, want := range []string{
+		"genesis: " + keyfmt.Genesis.Encode(testGenesis(0xE0)),
+		"tip:     " + keyfmt.Tip.Encode(testGenesis(0xE1)),
+		"length:  2 entries",
+		"signers: 2  fingerprint: " + signerSetFingerprintOf(res.Signers),
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("trailer must contain %q:\n%s", want, out)
+		}
+	}
+}
+
+// The old label called the signer-set fingerprint a tip fingerprint. Two chains with
+// the same signers and different tips fingerprint identically, so the label lied.
+func TestLockLogTrailerDoesNotCallTheSignerSetATip(t *testing.T) {
+	out := lockLogTrailer(api.LockLogResult{
+		Entries: []api.LockLogEntry{{Index: 0, Kind: "genesis", Hash: testGenesis(0xE0)}},
+		Tip:     testGenesis(0xE0),
+		Signers: [][]byte{testGenesis(0xF1)},
+	})
+	if strings.Contains(out, "tip fingerprint") {
+		t.Errorf("trailer must not label the signer set a tip fingerprint:\n%s", out)
+	}
+}

--- a/cmd/argus/lock_pin.go
+++ b/cmd/argus/lock_pin.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/shell"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+// fingerprintWordsOf brackets fingerprint words so tooling can find them with
+// one pattern and operators can see where they stop when they appear mid-sentence.
+func fingerprintWordsOf(words []string) string {
+	return "[" + strings.Join(words, " ") + "]"
+}
+
+func fingerprintOf(genesis []byte) string {
+	return fingerprintWordsOf(trustlog.HashFingerprint(genesis))
+}
+
+func signerSetFingerprintOf(signers [][]byte) string {
+	return fingerprintWordsOf(trustlog.SignerSetFingerprint(signers))
+}
+
+func distinctGenesis(all [][]byte) [][]byte {
+	var out [][]byte
+	for _, g := range all {
+		seen := false
+		for _, have := range out {
+			if bytes.Equal(have, g) {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			out = append(out, append([]byte(nil), g...))
+		}
+	}
+	return out
+}
+
+// Anything other than y/yes declines, so a stray newline never pins a device.
+func confirmGenesis(r io.Reader, w io.Writer, genesis []byte) (bool, error) {
+	fmt.Fprintf(w, "genesis offered by this network:\n  %s\n  %s\n\n",
+		trustpin.Encode(genesis), fingerprintOf(genesis))
+	fmt.Fprintf(w, "Compare these words against `argus lock status` on a node you trust.\nPin this device to it? [y/N]: ")
+	line, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// Returns (nil, nil) only when no chains were offered; an error when chains arrived but
+// none decoded, or when more than one distinct genesis is present — competing roots mean
+// two networks share this gateway or someone offers a fake, and picking by branch length
+// would choose a trust root by popularity.
+func resolveGenesis(chains [][]byte) ([]byte, error) {
+	if len(chains) == 0 {
+		return nil, nil
+	}
+	var seen [][]byte
+	for _, chain := range chains {
+		entries, err := trustlog.UnmarshalChain(chain)
+		if err != nil || len(entries) == 0 {
+			continue
+		}
+		seen = append(seen, trustlog.HashEntry(&entries[0]))
+	}
+	if len(seen) == 0 {
+		return nil, fmt.Errorf("gateway offered %d chain(s) but none could be decoded; possible format mismatch or corruption", len(chains))
+	}
+	switch all := distinctGenesis(seen); len(all) {
+	case 1:
+		return all[0], nil
+	default:
+		var b strings.Builder
+		for _, g := range all {
+			fmt.Fprintf(&b, "\n  %s  %s", trustpin.Encode(g), fingerprintOf(g))
+		}
+		return nil, fmt.Errorf("this gateway is offering %d different trust roots:%s\n\npin the right one explicitly: argus lock pin gen:<hex>", len(all), b.String())
+	}
+}
+
+func pullChains(ctx context.Context, cfg *config.Config) ([][]byte, error) {
+	dial, err := gatewayDialer(cfg.Gateway.URL, cfg.Token, cfg.Socket)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := dial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c := api.NewClient(conn)
+	defer c.Close()
+	var got api.TrustLogSyncResult
+	if err := c.CallContext(ctx, api.MethodTrustLogSync, api.TrustLogSyncParams{}, &got); err != nil {
+		return nil, fmt.Errorf("trustlog.sync: %w", err)
+	}
+	return trustlog.AssembleChains(got.Entries), nil
+}
+
+func genesisFromNetwork(ctx context.Context, cfg *config.Config) ([]byte, error) {
+	chains, err := pullChains(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return resolveGenesis(chains)
+}
+
+// Mirrors the detector, not resolveGenesis: detection trips on the FIRST chain that
+// decodes, so competing roots — an error when choosing a pin — still report a quarantine.
+func quarantiningGenesis(ctx context.Context, cfg *config.Config) ([]byte, error) {
+	chains, err := pullChains(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	for _, chain := range chains {
+		entries, uerr := trustlog.UnmarshalChain(chain)
+		if uerr != nil || len(entries) == 0 {
+			continue
+		}
+		return trustlog.HashEntry(&entries[0]), nil
+	}
+	return nil, nil
+}
+
+// Unlike quarantiningGenesis it does not take the first chain that decodes: after a
+// relock the gateway still holds the dead root, and naming it sends the operator to pin
+// a genesis nobody is on.
+func supersedingGenesisFromNetwork(ctx context.Context, cfg *config.Config, own []byte) ([]byte, error) {
+	chains, err := pullChains(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return trustlog.SupersedingGenesis(chains, own), nil
+}
+
+// applyPin pins the node role first and writes the client pin only once the node has
+// accepted the genesis. The other order leaves node=X, client=Y on a rejected pin:
+// the client then resolves Y, never quarantines, and silently opens zero channels —
+// an empty dashboard with no error anywhere.
+func applyPin(ctx context.Context, cfg *config.Config, genesis []byte) error {
+	nodePinned, err := pinLocalNode(ctx, cfg, genesis)
+	if err != nil {
+		return err
+	}
+	// A chain from a superseded root can never ingest again; leaving it behind only
+	// produces a confusing error on the next sync (the cleanup unpinDevice does too).
+	if rerr := os.Remove(config.GetStatePath("client-trustlog-chain")); rerr != nil && !os.IsNotExist(rerr) {
+		return rerr
+	}
+	if err := clientPinFile().Save(genesis); err != nil {
+		return err
+	}
+	shell.StdOutF("pinned this device\n  genesis: %s\n  %s\n", trustpin.Encode(genesis), fingerprintOf(genesis))
+	if nodePinned {
+		shell.StdOutF("  local node pinned and enforcing\n")
+	}
+	return nil
+}
+
+// A node that REFUSES the genesis aborts the whole command — the two roles on one
+// machine must never end up on different trust roots. A node merely not running does
+// not: its persisted pin is checked instead and the operator is told to re-run.
+func pinLocalNode(ctx context.Context, cfg *config.Config, genesis []byte) (bool, error) {
+	_, err := callLocal[struct{}](ctx, cfg, api.MethodLockPin, api.LockPinParams{Genesis: genesis})
+	if err == nil {
+		return true, nil
+	}
+	var rpcErr *api.RPCError
+	if errors.As(err, &rpcErr) {
+		return false, fmt.Errorf("the local node refused this genesis: %s\n  nothing was written; this device is unchanged", rpcErr.Message)
+	}
+	if perr := guardExistingPin(nodePinFile(), genesis); perr != nil {
+		return false, fmt.Errorf("the local node is unreachable (%v) and its saved pin disagrees:\n  %w", err, perr)
+	}
+	shell.StdErrF("note: the local node is unreachable (%v)\n  pinning the client role only; run `argus lock pin` again once the node is up\n", err)
+	return false, nil
+}
+
+// Both pin and unpin must consult lock.genesis: it outranks the pin file, and
+// trustpin.Resolve turns a file that disagrees with it into a hard startup failure.
+func configPin(cfg *config.Config) ([]byte, error) {
+	if cfg.Lock.Genesis == "" {
+		return nil, nil
+	}
+	g, err := trustpin.Decode(cfg.Lock.Genesis)
+	if err != nil {
+		return nil, fmt.Errorf("lock.genesis in this device's config is unusable: %w", err)
+	}
+	return g, nil
+}
+
+func guardPin(cfg *config.Config, genesis []byte) error {
+	cfgGenesis, err := configPin(cfg)
+	if err != nil {
+		return err
+	}
+	if cfgGenesis != nil && !bytes.Equal(cfgGenesis, genesis) {
+		return configPinConflict(cfgGenesis)
+	}
+	cur, err := clientPinFile().Load()
+	if err != nil {
+		return err
+	}
+	if cur == nil || bytes.Equal(cur, genesis) || clientPinSuperseded(cur) {
+		return nil
+	}
+	return existingPinConflict(cur)
+}
+
+// A chain disabled network-wide enforces nothing and can never be re-enabled, so the
+// pin is stale rather than conflicting and `lock pin` may replace it without an unpin.
+// An absent or unreadable chain is no proof, so it is a no.
+func clientPinSuperseded(cur []byte) bool {
+	// Either role's chain is proof: on a node-only machine the client has never run
+	// and has no chain of its own, and on a client-only machine there is no node —
+	// so requiring one particular file would refuse on exactly the devices that need
+	// unsticking. Both are ingested under cur, so a chain from some other root can
+	// never stand in as evidence.
+	for _, name := range []string{"client-trustlog-chain", "trustlog-chain"} {
+		b, err := os.ReadFile(config.GetStatePath(name))
+		if err != nil || len(b) == 0 {
+			continue
+		}
+		st := trustlog.NewSyncStore(cur)
+		if _, ierr := st.Ingest(b); ierr != nil {
+			continue
+		}
+		if st.Disabled() {
+			return true
+		}
+	}
+	return false
+}
+
+func configPinConflict(cfgGenesis []byte) error {
+	return fmt.Errorf("this device is pinned by config: lock.genesis is %s (%s)\n  writing a different pin would make the next `argus` run fail with a genesis pin conflict;\n  remove lock.genesis from the config first",
+		trustpin.Encode(cfgGenesis), fingerprintOf(cfgGenesis))
+}
+
+func existingPinConflict(cur []byte) error {
+	return fmt.Errorf("this device is already pinned to %s (%s); run `argus lock unpin` first",
+		trustpin.Encode(cur), fingerprintOf(cur))
+}
+
+func pinFromNetwork(ctx context.Context, cfg *config.Config, in io.Reader, out io.Writer) error {
+	genesis, err := genesisFromNetwork(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	if genesis == nil {
+		shell.StdOutF("no trust log on this network; nothing to pin\n")
+		return nil
+	}
+	if err := guardPin(cfg, genesis); err != nil {
+		return err
+	}
+	ok, err := confirmGenesis(in, out, genesis)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		shell.StdOutF("not pinned\n")
+		return nil
+	}
+	return applyPin(ctx, cfg, genesis)
+}
+
+func newLockPinCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "pin [gen:<hex>]",
+		Short:         "Pin this device to the network's trust-log genesis",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := resolveConfig(cmd)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if len(args) == 1 {
+				genesis, derr := trustpin.Decode(args[0])
+				if derr != nil {
+					return fail(cmd, derr)
+				}
+				if perr := guardPin(cfg, genesis); perr != nil {
+					return fail(cmd, perr)
+				}
+				return applyPin(ctx, cfg, genesis)
+			}
+
+			if perr := pinFromNetwork(ctx, cfg, os.Stdin, os.Stdout); perr != nil {
+				return fail(cmd, perr)
+			}
+			return nil
+		},
+	}
+	addClientFlags(cmd.Flags())
+	return cmd
+}
+
+func guardExistingPin(pf *trustpin.File, genesis []byte) error {
+	cur, err := pf.Load()
+	if err != nil {
+		return err
+	}
+	if cur == nil || bytes.Equal(cur, genesis) {
+		return nil
+	}
+	return existingPinConflict(cur)
+}
+
+// lock.genesis outranks the pin file, so on a config-pinned device unpin drops only the
+// persisted copy; reporting "no trust root" there would be false.
+func unpinSummary(cfgGenesis []byte) string {
+	if cfgGenesis == nil {
+		return "\nThis device now has no trust root. It will refuse all channels while the\nnetwork has a trust log, until you run `argus lock pin`.\n"
+	}
+	return fmt.Sprintf("\nlock.genesis in this device's config still pins it to\n  %s (%s)\nso it stays pinned and enforcing. Remove lock.genesis from the config to unpin\nthis device completely.\n",
+		trustpin.Encode(cfgGenesis), fingerprintOf(cfgGenesis))
+}
+
+// A running node unpins itself over the socket. A stopped one cannot, and one whose pin
+// disagrees with lock.genesis refuses to start — so the file is cleared here, but only
+// when the config still pins this device. Without a config pin, clearing behind its
+// back would widen what it accepts on its next start.
+func unpinLocalNode(ctx context.Context, cfg *config.Config, cfgGenesis []byte) {
+	_, err := callLocal[struct{}](ctx, cfg, api.MethodLockUnpin, nil)
+	if err == nil {
+		shell.StdOutF("  local node unpinned\n")
+		return
+	}
+	var rpcErr *api.RPCError
+	if cfgGenesis == nil || errors.As(err, &rpcErr) {
+		shell.StdErrF("note: local node unpin failed (%v) — it still holds its pin and is still enforcing\n  run `argus lock unpin` again when the node is reachable\n", err)
+		return
+	}
+	if cerr := nodePinFile().Clear(); cerr != nil {
+		shell.StdErrF("note: local node unpin failed (%v) and its persisted pin could not be cleared (%v)\n", err, cerr)
+		return
+	}
+	if rerr := os.Remove(config.GetStatePath("trustlog-chain")); rerr != nil && !os.IsNotExist(rerr) {
+		shell.StdErrF("note: the node's stored chain could not be removed (%v)\n", rerr)
+	}
+	shell.StdOutF("  local node is not running; cleared its persisted pin\n")
+}
+
+// Deliberately allowed on a config-pinned device: a pin file that disagrees with
+// lock.genesis is a hard startup failure whose error names this command as the way out.
+// Clearing resolves the conflict, leaves the device pinned to lock.genesis, and never
+// opens anything it was refusing.
+func unpinDevice(ctx context.Context, cfg *config.Config) error {
+	cfgGenesis, err := configPin(cfg)
+	if err != nil {
+		return err
+	}
+	if err := clientPinFile().Clear(); err != nil {
+		return err
+	}
+	// A chain from the old genesis can never ingest again; leaving it behind
+	// only produces a confusing error on the next sync.
+	if rerr := os.Remove(config.GetStatePath("client-trustlog-chain")); rerr != nil && !os.IsNotExist(rerr) {
+		return rerr
+	}
+	shell.StdOutF("cleared this device's persisted pin\n")
+	unpinLocalNode(ctx, cfg, cfgGenesis)
+	shell.StdErrF("%s", unpinSummary(cfgGenesis))
+	return nil
+}
+
+func newLockUnpinCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "unpin",
+		Short:         "Clear this device's trust-log genesis pin",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := resolveConfig(cmd)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if uerr := unpinDevice(ctx, cfg); uerr != nil {
+				return fail(cmd, uerr)
+			}
+			return nil
+		},
+	}
+	addClientFlags(cmd.Flags())
+	return cmd
+}

--- a/cmd/argus/lock_pin_apply_test.go
+++ b/cmd/argus/lock_pin_apply_test.go
@@ -1,0 +1,615 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+func tempStateDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := config.StateDir
+	config.StateDir = dir
+	t.Cleanup(func() { config.StateDir = old })
+	return dir
+}
+
+// The socket lives in a short temp dir: macOS caps unix socket paths at ~104 bytes.
+func serveFakeNode(t *testing.T, handlers map[string]api.HandlerFunc) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ap")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	sock := filepath.Join(dir, "node.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := api.NewServer()
+	for method, h := range handlers {
+		srv.Handle(method, h)
+	}
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() {
+		l.Close()
+		os.RemoveAll(dir)
+	})
+	return sock
+}
+
+func acceptPin(_ context.Context, _ json.RawMessage) (any, error) { return nil, nil }
+
+func refusePin(_ context.Context, _ json.RawMessage) (any, error) {
+	return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "node: already pinned to a different genesis; run `argus lock unpin` first"}
+}
+
+// TestApplyPinLeavesTheClientUnpinnedWhenTheNodeRefuses is the node=X client=Y trap:
+// a client pinned to a genesis the node rejects opens zero channels forever, with no
+// error and no quarantine to explain it.
+func TestApplyPinLeavesTheClientUnpinnedWhenTheNodeRefuses(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: serveFakeNode(t, map[string]api.HandlerFunc{api.MethodLockPin: refusePin})}
+
+	err := applyPin(context.Background(), cfg, testGenesis(0x22))
+
+	if err == nil {
+		t.Fatal("a node-side refusal must fail the command")
+	}
+	if !strings.Contains(err.Error(), "refused") {
+		t.Fatalf("error must say the node refused, got: %v", err)
+	}
+	pin, perr := clientPinFile().Load()
+	if perr != nil || pin != nil {
+		t.Fatalf("no client pin must be written: got %x, %v", pin, perr)
+	}
+}
+
+func TestApplyPinWritesTheClientPinWhenTheNodeAccepts(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: serveFakeNode(t, map[string]api.HandlerFunc{api.MethodLockPin: acceptPin})}
+	genesis := testGenesis(0x33)
+
+	if err := applyPin(context.Background(), cfg, genesis); err != nil {
+		t.Fatalf("applyPin: %v", err)
+	}
+
+	pin, err := clientPinFile().Load()
+	if err != nil || !bytes.Equal(pin, genesis) {
+		t.Fatalf("client pin = %x (%v), want %x", pin, err, genesis)
+	}
+}
+
+func TestApplyPinRefusesWhenAnUnreachableNodeHoldsADifferentPin(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: filepath.Join(t.TempDir(), "absent.sock")}
+	if err := nodePinFile().Save(testGenesis(0x44)); err != nil {
+		t.Fatalf("seed node pin: %v", err)
+	}
+
+	err := applyPin(context.Background(), cfg, testGenesis(0x55))
+
+	if err == nil {
+		t.Fatal("a stopped node pinned to another genesis must still block the client pin")
+	}
+	pin, perr := clientPinFile().Load()
+	if perr != nil || pin != nil {
+		t.Fatalf("no client pin must be written: got %x, %v", pin, perr)
+	}
+}
+
+func TestApplyPinPinsTheClientWhenNoNodeIsRunning(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: filepath.Join(t.TempDir(), "absent.sock")}
+	genesis := testGenesis(0x66)
+
+	if err := applyPin(context.Background(), cfg, genesis); err != nil {
+		t.Fatalf("a client-only machine must still be pinnable: %v", err)
+	}
+
+	pin, err := clientPinFile().Load()
+	if err != nil || !bytes.Equal(pin, genesis) {
+		t.Fatalf("client pin = %x (%v), want %x", pin, err, genesis)
+	}
+}
+
+func networkGenesisNode(t *testing.T) (*config.Config, []byte) {
+	t.Helper()
+	chain := makeTestChainBytes(t)
+	raw, err := trustlog.ChainEntries(chain)
+	if err != nil {
+		t.Fatalf("ChainEntries: %v", err)
+	}
+	sync := func(_ context.Context, _ json.RawMessage) (any, error) {
+		return api.TrustLogSyncResult{Entries: raw}, nil
+	}
+	cfg := &config.Config{Socket: serveFakeNode(t, map[string]api.HandlerFunc{
+		api.MethodTrustLogSync: sync,
+		api.MethodLockPin:      acceptPin,
+	})}
+	entries, err := trustlog.UnmarshalChain(chain)
+	if err != nil {
+		t.Fatalf("UnmarshalChain: %v", err)
+	}
+	return cfg, trustlog.HashEntry(&entries[0])
+}
+
+// TestPinFromNetworkRefusesAGenesisThatContradictsTheConfig covers the bare form the
+// guide documents as primary: writing the network's genesis over a config pin bricks
+// the next `argus` run with a genesis pin conflict.
+func TestPinFromNetworkRefusesAGenesisThatContradictsTheConfig(t *testing.T) {
+	tempStateDir(t)
+	cfg, _ := networkGenesisNode(t)
+	cfg.Lock.Genesis = trustpin.Encode(testGenesis(0x77))
+
+	err := pinFromNetwork(context.Background(), cfg, strings.NewReader("y\n"), io.Discard)
+
+	if err == nil {
+		t.Fatal("the bare `lock pin` must refuse a genesis that contradicts lock.genesis")
+	}
+	if !strings.Contains(err.Error(), "lock.genesis") {
+		t.Fatalf("error must name the config key, got: %v", err)
+	}
+	pin, perr := clientPinFile().Load()
+	if perr != nil || pin != nil {
+		t.Fatalf("no client pin must be written: got %x, %v", pin, perr)
+	}
+}
+
+func TestPinFromNetworkPinsWhenTheConfigAgrees(t *testing.T) {
+	tempStateDir(t)
+	cfg, genesis := networkGenesisNode(t)
+	cfg.Lock.Genesis = trustpin.Encode(genesis)
+
+	if err := pinFromNetwork(context.Background(), cfg, strings.NewReader("y\n"), io.Discard); err != nil {
+		t.Fatalf("pinning the genesis the config already names must be allowed: %v", err)
+	}
+
+	pin, err := clientPinFile().Load()
+	if err != nil || !bytes.Equal(pin, genesis) {
+		t.Fatalf("client pin = %x (%v), want %x", pin, err, genesis)
+	}
+}
+
+// TestClientPinLineReturnsWhenTheGatewayNeverAnswers pins the diagnostic's contract: a
+// gateway that completes the upgrade and answers nothing is exactly the degraded state
+// `lock status` is run in, so the probe must be bounded and reported, not hang.
+func TestClientPinLineReturnsWhenTheGatewayNeverAnswers(t *testing.T) {
+	tempStateDir(t)
+	blackhole := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := api.AcceptWS(w, r)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		<-blackhole
+	}))
+	t.Cleanup(func() {
+		close(blackhole)
+		ts.Close()
+	})
+
+	restore := gatewayProbeTimeout
+	gatewayProbeTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { gatewayProbeTimeout = restore })
+
+	cfg := &config.Config{}
+	cfg.Gateway.URL = "ws://" + strings.TrimPrefix(ts.URL, "http://")
+
+	lines := make(chan string, 1)
+	go func() { line, _ := clientPinLine(context.Background(), cfg); lines <- line }()
+
+	select {
+	case line := <-lines:
+		if !strings.Contains(line, "did not answer") {
+			t.Fatalf("line must report the unanswered probe, got: %q", line)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("lock status hung on a gateway that never answers")
+	}
+}
+
+func TestGuardPinRefusesADifferentConfigGenesis(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{}
+	cfg.Lock.Genesis = trustpin.Encode(testGenesis(0x77))
+
+	err := guardPin(cfg, testGenesis(0x88))
+
+	if err == nil {
+		t.Fatal("writing a pin file that contradicts lock.genesis bricks the next start")
+	}
+	if !strings.Contains(err.Error(), "lock.genesis") {
+		t.Fatalf("error must name the config key, got: %v", err)
+	}
+}
+
+func TestGuardPinAllowsTheConfigGenesis(t *testing.T) {
+	tempStateDir(t)
+	genesis := testGenesis(0x99)
+	cfg := &config.Config{}
+	cfg.Lock.Genesis = trustpin.Encode(genesis)
+
+	if err := guardPin(cfg, genesis); err != nil {
+		t.Fatalf("pinning the genesis the config already names must be allowed: %v", err)
+	}
+}
+
+// TestClientPinStatusNamesQuarantine backs the doc promise that `argus lock status`
+// shows a quarantined device and the genesis it saw — the client-side quarantine has
+// no other surface.
+func TestClientPinStatusNamesQuarantine(t *testing.T) {
+	seen := testGenesis(0x11)
+
+	line := clientPinStatus(trustpin.Pin{}, nil, seen, nil, false)
+
+	if !strings.Contains(line, "locked out") {
+		t.Fatalf("line must name the lockout, got: %q", line)
+	}
+	if !strings.Contains(line, fingerprintOf(seen)) {
+		t.Fatalf("line must show the genesis that was seen, got: %q", line)
+	}
+	if !strings.Contains(line, "argus lock pin") {
+		t.Fatalf("line must name the fix, got: %q", line)
+	}
+}
+
+// TestClientPinStatusNamesACorruptPin covers the pin file that exists but is the
+// wrong length: the same file makes `argus` refuse to start, so reporting "none" is
+// actively misleading.
+func TestClientPinStatusNamesACorruptPin(t *testing.T) {
+	dir := tempStateDir(t)
+	if err := os.WriteFile(filepath.Join(dir, "client-trustlog-genesis"), []byte("short"), 0o600); err != nil {
+		t.Fatalf("write corrupt pin: %v", err)
+	}
+
+	pin, perr := trustpin.Resolve("", clientPinFile())
+	line := clientPinStatus(pin, perr, nil, nil, false)
+
+	if strings.Contains(line, "none") {
+		t.Fatalf("a corrupt pin must not be reported as no pin, got: %q", line)
+	}
+	if !strings.Contains(line, "corrupt") {
+		t.Fatalf("line must name the corruption, got: %q", line)
+	}
+}
+
+func TestClientPinStatusReportsAPinnedClient(t *testing.T) {
+	genesis := testGenesis(0x21)
+
+	line := clientPinStatus(trustpin.Pin{Genesis: genesis, Source: trustpin.SourceConfig}, nil, nil, nil, false)
+
+	if !strings.Contains(line, fingerprintOf(genesis)) || !strings.Contains(line, "config") {
+		t.Fatalf("line must show the fingerprint and its source, got: %q", line)
+	}
+}
+
+func TestClientPinStatusUnpinnedOnAnUnlockedNetwork(t *testing.T) {
+	line := clientPinStatus(trustpin.Pin{}, nil, nil, nil, false)
+
+	if strings.Contains(line, "locked out") {
+		t.Fatalf("no trust log on the network must not claim a lockout, got: %q", line)
+	}
+}
+
+// TestQuarantiningGenesisReportsCompetingRoots pins the difference between choosing a
+// pin and reporting one: two roots is a hard error when picking, but the device is
+// quarantined all the same, so status must still name a genesis.
+func TestQuarantiningGenesisReportsCompetingRoots(t *testing.T) {
+	chains := [][]byte{makeTestChainBytes(t), makeTestChainBytes(t)}
+	var allEntries [][]byte
+	for _, c := range chains {
+		raw, err := trustlog.ChainEntries(c)
+		if err != nil {
+			t.Fatalf("ChainEntries: %v", err)
+		}
+		allEntries = append(allEntries, raw...)
+	}
+	sync := func(_ context.Context, _ json.RawMessage) (any, error) {
+		return api.TrustLogSyncResult{Entries: allEntries}, nil
+	}
+	cfg := &config.Config{Socket: serveFakeNode(t, map[string]api.HandlerFunc{api.MethodTrustLogSync: sync})}
+
+	got, err := quarantiningGenesis(context.Background(), cfg)
+
+	if err != nil {
+		t.Fatalf("quarantiningGenesis: %v", err)
+	}
+	entries, _ := trustlog.UnmarshalChain(chains[0])
+	if want := trustlog.HashEntry(&entries[0]); !bytes.Equal(got, want) {
+		t.Fatalf("genesis = %x, want the first decodable chain's %x", got, want)
+	}
+	if _, rerr := resolveGenesis(chains); rerr == nil {
+		t.Fatal("precondition: resolveGenesis must reject competing roots")
+	}
+}
+
+func TestQuarantiningGenesisReportsNoneOnAnUnlockedNetwork(t *testing.T) {
+	sync := func(_ context.Context, _ json.RawMessage) (any, error) {
+		return api.TrustLogSyncResult{}, nil
+	}
+	cfg := &config.Config{Socket: serveFakeNode(t, map[string]api.HandlerFunc{api.MethodTrustLogSync: sync})}
+
+	got, err := quarantiningGenesis(context.Background(), cfg)
+
+	if err != nil || got != nil {
+		t.Fatalf("no chains → want (nil, nil), got (%x, %v)", got, err)
+	}
+}
+
+// TestUnpinResolvesAConfigFileConflict is the escape hatch trustpin.Resolve's conflict
+// error names: a device with lock.genesis X and a pin file holding Y refuses to start,
+// and `lock unpin` is the only command that can clear the file.
+func TestUnpinResolvesAConfigFileConflict(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: filepath.Join(t.TempDir(), "absent.sock")}
+	cfg.Lock.Genesis = trustpin.Encode(testGenesis(0x12))
+	if err := clientPinFile().Save(testGenesis(0x13)); err != nil {
+		t.Fatalf("seed client pin: %v", err)
+	}
+	if _, rerr := trustpin.Resolve(cfg.Lock.Genesis, clientPinFile()); rerr == nil {
+		t.Fatal("precondition: config X + file Y must be a conflict")
+	}
+
+	if err := unpinDevice(context.Background(), cfg); err != nil {
+		t.Fatalf("unpin must be able to clear the file it is documented to clear: %v", err)
+	}
+
+	pin, perr := trustpin.Resolve(cfg.Lock.Genesis, clientPinFile())
+	if perr != nil {
+		t.Fatalf("the conflict must be gone after unpin: %v", perr)
+	}
+	if pin.Source != trustpin.SourceConfig {
+		t.Fatalf("the device must stay pinned by config, got source %s", pin.Source)
+	}
+}
+
+func TestUnpinClearsAFilePin(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: filepath.Join(t.TempDir(), "absent.sock")}
+	if err := clientPinFile().Save(testGenesis(0x13)); err != nil {
+		t.Fatalf("seed client pin: %v", err)
+	}
+
+	if err := unpinDevice(context.Background(), cfg); err != nil {
+		t.Fatalf("a file-pinned device must be unpinnable: %v", err)
+	}
+
+	pin, perr := clientPinFile().Load()
+	if perr != nil || pin != nil {
+		t.Fatalf("client pin = %x (%v), want cleared", pin, perr)
+	}
+}
+
+// TestUnpinClearsAStoppedNodesPinWhenTheConfigStillPinsIt closes the loop on the
+// conflict: a node whose pin file disagrees with lock.genesis refuses to start, so it
+// can never answer the unpin RPC and only the CLI can clear its file.
+func TestUnpinClearsAStoppedNodesPinWhenTheConfigStillPinsIt(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: filepath.Join(t.TempDir(), "absent.sock")}
+	cfg.Lock.Genesis = trustpin.Encode(testGenesis(0x14))
+	if err := nodePinFile().Save(testGenesis(0x15)); err != nil {
+		t.Fatalf("seed node pin: %v", err)
+	}
+
+	if err := unpinDevice(context.Background(), cfg); err != nil {
+		t.Fatalf("unpinDevice: %v", err)
+	}
+
+	if _, rerr := trustpin.Resolve(cfg.Lock.Genesis, nodePinFile()); rerr != nil {
+		t.Fatalf("the node must be startable again after unpin: %v", rerr)
+	}
+}
+
+// TestUnpinLeavesAStoppedNodesPinAloneWithoutAConfigPin is the fail-closed direction:
+// with nothing left to pin the node, clearing its file behind its back would widen
+// what it accepts on its next start.
+func TestUnpinLeavesAStoppedNodesPinAloneWithoutAConfigPin(t *testing.T) {
+	tempStateDir(t)
+	cfg := &config.Config{Socket: filepath.Join(t.TempDir(), "absent.sock")}
+	seeded := testGenesis(0x16)
+	if err := nodePinFile().Save(seeded); err != nil {
+		t.Fatalf("seed node pin: %v", err)
+	}
+
+	if err := unpinDevice(context.Background(), cfg); err != nil {
+		t.Fatalf("unpinDevice: %v", err)
+	}
+
+	pin, perr := nodePinFile().Load()
+	if perr != nil || !bytes.Equal(pin, seeded) {
+		t.Fatalf("node pin = %x (%v), want the untouched %x", pin, perr, seeded)
+	}
+}
+
+func TestUnpinSummaryNamesTheRemainingConfigPin(t *testing.T) {
+	genesis := testGenesis(0x17)
+
+	msg := unpinSummary(genesis)
+
+	if strings.Contains(msg, "no trust root") {
+		t.Fatalf("a config-pinned device is still pinned, got: %q", msg)
+	}
+	if !strings.Contains(msg, "lock.genesis") || !strings.Contains(msg, fingerprintOf(genesis)) {
+		t.Fatalf("message must name lock.genesis and what it pins to, got: %q", msg)
+	}
+}
+
+func TestUnpinSummarySaysNoTrustRootWithoutAConfigPin(t *testing.T) {
+	msg := unpinSummary(nil)
+
+	if !strings.Contains(msg, "no trust root") {
+		t.Fatalf("a fully unpinned device has no trust root, got: %q", msg)
+	}
+}
+
+func liveChainForTest(t *testing.T) (chain []byte, genesis []byte) {
+	t.Helper()
+	signer, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	log, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, nil)
+	if err != nil {
+		t.Fatalf("genesis: %v", err)
+	}
+	return trustlog.MarshalChain(log.Entries()), log.Tip()
+}
+
+// disabledChainForTest returns the chain a device holds after `argus lock disable`:
+// a genesis carrying one disablement commitment, plus the entry that consumed it.
+func disabledChainForTest(t *testing.T) (chain []byte, genesis []byte) {
+	t.Helper()
+	signer, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	secret, err := trustlog.GenerateDisablementSecret()
+	if err != nil {
+		t.Fatalf("secret: %v", err)
+	}
+	log, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, [][]byte{trustlog.DisablementCommitment(secret)})
+	if err != nil {
+		t.Fatalf("genesis: %v", err)
+	}
+	tip := log.Tip()
+	if err := log.Disable(secret, signer); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	return trustlog.MarshalChain(log.Entries()), tip
+}
+
+// A client pin to a disabled chain is stale: `lock pin` adopts the live root in one
+// command, exactly as it does on a device that never had a pin.
+func TestGuardPinAllowsReplacingASupersededClientPin(t *testing.T) {
+	tempStateDir(t)
+	chain, genesis := disabledChainForTest(t)
+	if err := clientPinFile().Save(genesis); err != nil {
+		t.Fatalf("seed pin: %v", err)
+	}
+	if err := os.WriteFile(config.GetStatePath("client-trustlog-chain"), chain, 0o600); err != nil {
+		t.Fatalf("seed chain: %v", err)
+	}
+
+	if err := guardPin(&config.Config{}, testGenesis(0xEF)); err != nil {
+		t.Fatalf("a superseded pin must not block a new one: %v", err)
+	}
+}
+
+// A live pin still requires an explicit unpin.
+func TestGuardPinStillRefusesALiveClientPin(t *testing.T) {
+	tempStateDir(t)
+	chain, genesis := liveChainForTest(t)
+	if err := clientPinFile().Save(genesis); err != nil {
+		t.Fatalf("seed pin: %v", err)
+	}
+	if err := os.WriteFile(config.GetStatePath("client-trustlog-chain"), chain, 0o600); err != nil {
+		t.Fatalf("seed chain: %v", err)
+	}
+
+	if err := guardPin(&config.Config{}, testGenesis(0xEF)); err == nil {
+		t.Fatal("a live pin must still require unpin")
+	}
+}
+
+// Without the old chain there is no evidence the pin is stale; stay conservative.
+func TestGuardPinRefusesWhenStalenessCannotBeProven(t *testing.T) {
+	tempStateDir(t)
+	if err := clientPinFile().Save(testGenesis(0xCD)); err != nil {
+		t.Fatalf("seed pin: %v", err)
+	}
+
+	if err := guardPin(&config.Config{}, testGenesis(0xEF)); err == nil {
+		t.Fatal("no chain on disk means no proof of staleness")
+	}
+}
+
+// The client role is pinned separately, so after a relock it must say so on its own
+// line — otherwise the only signal is the node's, and a dark dashboard looks fine.
+func TestClientPinStatusNamesSupersession(t *testing.T) {
+	line := clientPinStatus(trustpin.Pin{Genesis: testGenesis(0xC1), Source: trustpin.SourceFile}, nil, testGenesis(0xC2), nil, true)
+
+	for _, want := range []string{"new root", "argus lock pin", "restart"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("line %q must contain %q", line, want)
+		}
+	}
+}
+
+// Supersession is proven by the disabled chain, not by the network probe; report it
+// even when the gateway could not be reached for the new fingerprint.
+func TestClientPinStatusNamesSupersessionWithoutTheNetwork(t *testing.T) {
+	line := clientPinStatus(trustpin.Pin{Genesis: testGenesis(0xC1), Source: trustpin.SourceFile}, nil, nil, nil, true)
+
+	if !strings.Contains(line, "no new root") {
+		t.Fatalf("line %q must still report supersession", line)
+	}
+}
+
+// A superseded node cannot be authorized into a chain it does not follow; the only
+// useful instruction is to pin.
+func TestAuthorizeHintSuppressedWhenThereIsNoLiveRoot(t *testing.T) {
+	id := testGenesis(0x44)
+	if h := authorizeHint(api.LockStatusResult{Enabled: true, IdentityPubKey: id}); h == "" {
+		t.Fatal("an enforcing chain that lacks this node must still hint how to authorize it")
+	}
+	if h := authorizeHint(api.LockStatusResult{Enabled: true, Disabled: true, IdentityPubKey: id}); h != "" {
+		t.Fatalf("a disabled chain authorizes nobody; got %q", h)
+	}
+	if h := authorizeHint(api.LockStatusResult{Enabled: true, Quarantined: true, IdentityPubKey: id}); h != "" {
+		t.Fatalf("a quarantined device must be told to pin, not to sign; got %q", h)
+	}
+	if h := authorizeHint(api.LockStatusResult{Enabled: true, Authorized: true, IdentityPubKey: id}); h != "" {
+		t.Fatalf("an authorized node needs no hint; got %q", h)
+	}
+}
+
+// On a node-only machine the client role may never have run, so the only proof this
+// device's root is dead is the NODE's persisted chain. Reading just the client's left
+// `lock pin` refusing on the very device the parity work exists to unstick.
+func TestGuardPinAllowsReplacementProvenByTheNodeChain(t *testing.T) {
+	tempStateDir(t)
+	chain, genesis := disabledChainForTest(t)
+	if err := clientPinFile().Save(genesis); err != nil {
+		t.Fatalf("seed pin: %v", err)
+	}
+	if err := os.WriteFile(config.GetStatePath("trustlog-chain"), chain, 0o600); err != nil {
+		t.Fatalf("seed node chain: %v", err)
+	}
+
+	if err := guardPin(&config.Config{}, testGenesis(0xEF)); err != nil {
+		t.Fatalf("a pin the node's own chain proves dead must not block: %v", err)
+	}
+}
+
+// A live node chain still guards the pin: only a disabled one makes it stale.
+func TestGuardPinRefusesWhenTheNodeChainIsLive(t *testing.T) {
+	tempStateDir(t)
+	chain, genesis := liveChainForTest(t)
+	if err := clientPinFile().Save(genesis); err != nil {
+		t.Fatalf("seed pin: %v", err)
+	}
+	if err := os.WriteFile(config.GetStatePath("trustlog-chain"), chain, 0o600); err != nil {
+		t.Fatalf("seed node chain: %v", err)
+	}
+
+	if err := guardPin(&config.Config{}, testGenesis(0xEF)); err == nil {
+		t.Fatal("a live node chain must still require unpin")
+	}
+}

--- a/cmd/argus/lock_pin_test.go
+++ b/cmd/argus/lock_pin_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/trustlog"
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+func makeTestChainBytes(t *testing.T) []byte {
+	t.Helper()
+	sk, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	log, err := trustlog.NewGenesis([][]byte{sk.Public}, sk, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	return trustlog.MarshalChain(log.Entries())
+}
+
+func TestDistinctGenesisFromChains(t *testing.T) {
+	a := testGenesis(0x01)
+	b := testGenesis(0x02)
+
+	got := distinctGenesis([][]byte{a, a, b})
+
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 distinct", len(got))
+	}
+	if !bytes.Equal(got[0], a) || !bytes.Equal(got[1], b) {
+		t.Fatal("distinctGenesis must preserve first-seen order")
+	}
+}
+
+func TestConfirmGenesisAcceptsY(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmGenesis(strings.NewReader("y\n"), &out, testGenesis(0x09))
+	if err != nil {
+		t.Fatalf("confirmGenesis: %v", err)
+	}
+	if !ok {
+		t.Fatal("y should accept")
+	}
+	if !strings.Contains(out.String(), fingerprintOf(testGenesis(0x09))) {
+		t.Fatalf("prompt must show the word fingerprint, got: %q", out.String())
+	}
+}
+
+func TestConfirmGenesisAcceptsYes(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmGenesis(strings.NewReader("yes\n"), &out, testGenesis(0x09))
+	if err != nil {
+		t.Fatalf("confirmGenesis: %v", err)
+	}
+	if !ok {
+		t.Fatal("yes should accept")
+	}
+}
+
+func TestConfirmGenesisDefaultsToNo(t *testing.T) {
+	var out bytes.Buffer
+	for _, in := range []string{"\n", "n\n", "no\n", ""} {
+		ok, err := confirmGenesis(strings.NewReader(in), &out, testGenesis(0x09))
+		if err != nil {
+			t.Fatalf("confirmGenesis(%q): %v", in, err)
+		}
+		if ok {
+			t.Fatalf("input %q must not accept", in)
+		}
+	}
+}
+
+func TestGuardExistingPinNoPin(t *testing.T) {
+	pf := trustpin.New(filepath.Join(t.TempDir(), "trustlog-genesis"))
+	if err := guardExistingPin(pf, testGenesis(0x01)); err != nil {
+		t.Fatalf("no existing pin should pass: %v", err)
+	}
+}
+
+func TestGuardExistingPinIdentical(t *testing.T) {
+	pf := trustpin.New(filepath.Join(t.TempDir(), "trustlog-genesis"))
+	g := testGenesis(0x01)
+	if err := pf.Save(g); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := guardExistingPin(pf, g); err != nil {
+		t.Fatalf("identical pin should be idempotent: %v", err)
+	}
+}
+
+func TestGuardExistingPinDifferent(t *testing.T) {
+	pf := trustpin.New(filepath.Join(t.TempDir(), "trustlog-genesis"))
+	if err := pf.Save(testGenesis(0x01)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	err := guardExistingPin(pf, testGenesis(0x02))
+	if err == nil {
+		t.Fatal("different pin must return an error")
+	}
+	if !strings.Contains(err.Error(), "lock unpin") {
+		t.Fatalf("error must mention lock unpin, got: %v", err)
+	}
+}
+
+func TestResolveGenesisNoChains(t *testing.T) {
+	g, err := resolveGenesis(nil)
+	if err != nil || g != nil {
+		t.Fatalf("no chains → want (nil, nil), got (%v, %v)", g, err)
+	}
+}
+
+func TestResolveGenesisGarbageChains(t *testing.T) {
+	_, err := resolveGenesis([][]byte{{1, 2, 3}, {4, 5, 6}})
+	if err == nil {
+		t.Fatal("garbage chains must return an error")
+	}
+	if !strings.Contains(err.Error(), "2 chain") {
+		t.Fatalf("error must mention count, got: %v", err)
+	}
+}
+
+func TestResolveGenesisMultipleRoots(t *testing.T) {
+	chain1 := makeTestChainBytes(t)
+	chain2 := makeTestChainBytes(t)
+	_, err := resolveGenesis([][]byte{chain1, chain2})
+	if err == nil {
+		t.Fatal("two distinct roots must return an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "2 different trust roots") {
+		t.Fatalf("error must say 2 different trust roots, got: %v", msg)
+	}
+	// Both genesis hashes — encoded form and word fingerprint — must appear so the
+	// operator can identify which root is theirs and pass it explicitly.
+	for _, chain := range [][]byte{chain1, chain2} {
+		entries, _ := trustlog.UnmarshalChain(chain)
+		genesis := trustlog.HashEntry(&entries[0])
+		enc := trustpin.Encode(genesis)
+		fp := fingerprintOf(genesis)
+		if !strings.Contains(msg, enc) {
+			t.Errorf("error must contain %s, got: %v", enc, msg)
+		}
+		if !strings.Contains(msg, fp) {
+			t.Errorf("error must contain fingerprint %q, got: %v", fp, msg)
+		}
+	}
+}
+
+func TestResolveGenesisSingleRoot(t *testing.T) {
+	chain := makeTestChainBytes(t)
+	g, err := resolveGenesis([][]byte{chain, chain})
+	if err != nil {
+		t.Fatalf("single root: %v", err)
+	}
+	if len(g) != trustpin.GenesisLen {
+		t.Fatalf("genesis len = %d, want %d", len(g), trustpin.GenesisLen)
+	}
+}
+
+func TestFingerprintsAreBracketed(t *testing.T) {
+	genesis := bytes.Repeat([]byte{0x01}, 32)
+	got := fingerprintOf(genesis)
+	if !strings.HasPrefix(got, "[") || !strings.HasSuffix(got, "]") {
+		t.Fatalf("fingerprintOf must bracket its words, got %q", got)
+	}
+	if strings.Contains(strings.Trim(got, "[]"), "[") {
+		t.Fatalf("nested brackets in %q", got)
+	}
+
+	signers := [][]byte{bytes.Repeat([]byte{0x02}, 32)}
+	gotSet := signerSetFingerprintOf(signers)
+	if !strings.HasPrefix(gotSet, "[") || !strings.HasSuffix(gotSet, "]") {
+		t.Fatalf("signerSetFingerprintOf must bracket its words, got %q", gotSet)
+	}
+}

--- a/cmd/argus/lock_status_clientonly_test.go
+++ b/cmd/argus/lock_status_clientonly_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLockStatusClientOnlyDetection covers the two sides of the ENOENT split in
+// newLockStatusCmd: a default socket that simply does not exist (client-only
+// machine) must exit 0 and still print the device identity; an explicit
+// --socket pointing at the same absent path must exit non-zero because the
+// operator named a socket they expected to find.
+func TestLockStatusClientOnlyDetection(t *testing.T) {
+	tempStateDir(t)
+	// Use MkdirTemp with a short prefix: macOS caps Unix socket paths at 104 bytes,
+	// and t.TempDir() produces paths that regularly exceed that limit.
+	dir, err := os.MkdirTemp("", "cl")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	absent := filepath.Join(dir, "absent.sock")
+
+	t.Run("default socket absent exits 0 and prints identity", func(t *testing.T) {
+		// Steer the resolved socket path to the known-absent socket without
+		// touching cmd.Flags(), so Changed("socket") stays false.
+		t.Setenv("ARGUS_SOCKET", absent)
+
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe: %v", err)
+		}
+		oldOut := os.Stdout
+		os.Stdout = w
+		cmd := newLockStatusCmd()
+		runErr := cmd.Execute()
+		w.Close()
+		os.Stdout = oldOut
+
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r); err != nil {
+			t.Fatalf("reading captured stdout: %v", err)
+		}
+		r.Close()
+
+		if runErr != nil {
+			t.Fatalf("client-only machine (default socket absent) must exit 0, got: %v", runErr)
+		}
+		for _, want := range []string{"this tui", "identity:"} {
+			if !strings.Contains(buf.String(), want) {
+				t.Errorf("stdout missing %q; got:\n%s", want, buf.String())
+			}
+		}
+	})
+
+	t.Run("explicit --socket absent exits non-zero", func(t *testing.T) {
+		cmd := newLockStatusCmd()
+		cmd.SetArgs([]string{"--socket", absent})
+		if err := cmd.Execute(); err == nil {
+			t.Fatal("expected non-zero exit when --socket is explicit and absent")
+		}
+	})
+}

--- a/cmd/argus/lock_status_text_test.go
+++ b/cmd/argus/lock_status_text_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/keyfmt"
+)
+
+func TestLockStatusLinesNamesTheThreeStates(t *testing.T) {
+	cases := []struct {
+		name string
+		st   api.LockStatusResult
+		want string
+	}{
+		{"never locked", api.LockStatusResult{}, "locked mode: not enabled"},
+		{"enforcing", api.LockStatusResult{Enabled: true, Pinned: true}, "locked mode: enforcing"},
+		{"break-glass", api.LockStatusResult{Enabled: true, Disabled: true, Pinned: true}, "locked mode: disabled network-wide"},
+	}
+	for _, tc := range cases {
+		out, _ := lockStatusLines(tc.st)
+		if !strings.Contains(out, tc.want) {
+			t.Fatalf("%s: output %q must contain %q", tc.name, out, tc.want)
+		}
+	}
+}
+
+// The break-glass state is terminal and the way back is a new genesis; say both.
+func TestLockStatusLinesExplainsBreakGlass(t *testing.T) {
+	out, _ := lockStatusLines(api.LockStatusResult{Enabled: true, Disabled: true, Pinned: true})
+	for _, want := range []string{"permanent", "argus lock init"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q must contain %q", out, want)
+		}
+	}
+}
+
+// A superseded device is pinned AND quarantined; the line must name both roots and
+// the one command that fixes it.
+func TestLockStatusLinesReportsSupersession(t *testing.T) {
+	out, _ := lockStatusLines(api.LockStatusResult{
+		Enabled:     true,
+		Disabled:    true,
+		Pinned:      true,
+		Quarantined: true,
+		PinGenesis:  testGenesis(0xC1),
+		SeenGenesis: testGenesis(0xC2),
+	})
+	for _, want := range []string{"locked out", "new root", "argus lock pin"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q must contain %q", out, want)
+		}
+	}
+	if strings.Contains(out, "locked mode: disabled network-wide") {
+		t.Fatal("the break-glass headline is subsumed by the supersession one")
+	}
+}
+
+func TestLockStatusLinesReportsUnpinnedLockout(t *testing.T) {
+	out, _ := lockStatusLines(api.LockStatusResult{Quarantined: true, SeenGenesis: testGenesis(0xC2)})
+	for _, want := range []string{"locked out", "argus lock pin"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q must contain %q", out, want)
+		}
+	}
+}
+
+// An unpinned node that has synced a locked network must NOT report "not enabled":
+// that headline reads as if no lock exists, contradicting the pin line right below it.
+func TestLockStatusLinesDoesNotSayNotEnabledWhenLockedOut(t *testing.T) {
+	out, _ := lockStatusLines(api.LockStatusResult{Quarantined: true, SeenGenesis: testGenesis(0xC2)})
+	head := strings.SplitN(out, "\n", 2)[0]
+	if strings.Contains(head, "not enabled") {
+		t.Fatalf("headline %q must report the network as locked, not 'not enabled'", head)
+	}
+}
+
+// A superseded device's own log being disabled is background: what matters is that
+// THIS device is refusing everything. Leading with "nothing is enforced" reads as a
+// contradiction two lines above "this device refuses all channels".
+func TestLockStatusLinesLeadsWithLockoutWhenSuperseded(t *testing.T) {
+	out, _ := lockStatusLines(api.LockStatusResult{
+		Enabled:     true,
+		Disabled:    true,
+		Pinned:      true,
+		Quarantined: true,
+		PinGenesis:  testGenesis(0xC1),
+		SeenGenesis: testGenesis(0xC2),
+	})
+	head := strings.SplitN(out, "\n", 2)[0]
+	if !strings.Contains(head, "locked out") {
+		t.Fatalf("headline %q must lead with the device's own state", head)
+	}
+	// The break-glass headline (lockStatusLines' st.Disabled branch) says "nothing is
+	// enforced", which reads as the opposite of opening no channels. A superseded device
+	// must not fall through to it: it is the most restrictive state there is.
+	if strings.Contains(out, "nothing is enforced") {
+		t.Fatalf("output %q must not claim it enforces nothing while opening no channels", out)
+	}
+	if n := strings.Count(out, "opens no channels"); n != 1 {
+		t.Fatalf("output %q states the lockout %d times, want exactly 1", out, n)
+	}
+}
+
+// After two relocks the gateway offers several roots, and bare `lock pin` refuses to
+// choose between them — so the instruction has to carry the genesis.
+func TestLockStatusLinesGivesAnExplicitPinCommand(t *testing.T) {
+	seen := testGenesis(0xC2)
+	for _, st := range []api.LockStatusResult{
+		{Enabled: true, Disabled: true, Pinned: true, Quarantined: true, PinGenesis: testGenesis(0xC1), SeenGenesis: seen},
+		{Quarantined: true, SeenGenesis: seen},
+	} {
+		out, _ := lockStatusLines(st)
+		if want := "argus lock pin " + keyfmt.Genesis.Encode(seen); !strings.Contains(out, want) {
+			t.Fatalf("output %q must contain %q", out, want)
+		}
+	}
+}
+
+// Every section renders in every state. Field presence must not depend on the
+// headline branch — that coupling is what hid the device set and the node's own
+// keys for as long as it did.
+func TestLockStatusLinesAlwaysRendersEverySection(t *testing.T) {
+	states := map[string]api.LockStatusResult{
+		"not enabled": {IdentityPubKey: testGenesis(0xB0)},
+		"enforcing": {
+			Enabled: true, Pinned: true,
+			PinGenesis: testGenesis(0xA1), Tip: testGenesis(0xB1),
+			IdentityPubKey: testGenesis(0xB0), DeviceCount: 1,
+		},
+		"disabled": {
+			Enabled: true, Disabled: true, Pinned: true,
+			PinGenesis: testGenesis(0xA2), Tip: testGenesis(0xB2),
+			IdentityPubKey: testGenesis(0xB0),
+		},
+		"quarantined": {
+			Enabled: true, Quarantined: true,
+			SeenGenesis: testGenesis(0xA3), Tip: testGenesis(0xB3),
+			IdentityPubKey: testGenesis(0xB0),
+		},
+		"superseded": {
+			Enabled: true, Disabled: true, Pinned: true, Quarantined: true,
+			PinGenesis: testGenesis(0xA4), SeenGenesis: testGenesis(0xA5),
+			Tip: testGenesis(0xB4), IdentityPubKey: testGenesis(0xB0),
+		},
+	}
+	// "  pin: " and not "pin": the disabled headline says "every device repins",
+	// which would satisfy a bare substring check with the pin section absent.
+	labels := []string{"chain", "this node", "signers", "devices", "  pin: "}
+	for name, st := range states {
+		out, _ := lockStatusLines(st)
+		for _, label := range labels {
+			if !strings.Contains(out, label) {
+				t.Errorf("%s: missing section %q in:\n%s", name, label, out)
+			}
+		}
+	}
+}
+
+// The node's own keys must be visible while locked mode is on, not only when it
+// is off.
+func TestLockStatusLinesNamesThisNodesKeysWhileEnforcing(t *testing.T) {
+	st := api.LockStatusResult{
+		Enabled: true, Pinned: true,
+		PinGenesis: testGenesis(0xA1), Tip: testGenesis(0xB1),
+		IdentityPubKey: testGenesis(0xB0), SignerPubKey: testGenesis(0xB5),
+		Authorized: true, SignerTrusted: true,
+	}
+	out, _ := lockStatusLines(st)
+	for _, want := range []string{
+		keyfmt.DeviceKey.Encode(testGenesis(0xB0)),
+		keyfmt.SignerKey.Encode(testGenesis(0xB5)),
+		"authorized: yes",
+		"trusted: yes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output must contain %q:\n%s", want, out)
+		}
+	}
+}
+
+// Locked mode off means there is nothing to be authorized against; a bare "no"
+// would read as a denial.
+func TestLockStatusLinesOmitsAuthorizedWhenNotEnabled(t *testing.T) {
+	out, _ := lockStatusLines(api.LockStatusResult{IdentityPubKey: testGenesis(0xB0)})
+	for _, unwanted := range []string{"authorized:", "trusted:"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("output must not contain %q when locked mode is off:\n%s", unwanted, out)
+		}
+	}
+}
+
+// The genesis must be printed in a form that can be copied, not only fingerprinted.
+func TestChainSectionPrintsGenesisTipAndLength(t *testing.T) {
+	st := api.LockStatusResult{
+		Enabled: true, Pinned: true,
+		PinGenesis: testGenesis(0xA1), Tip: testGenesis(0xB1), Length: 12,
+	}
+	out := chainSection(st)
+	for _, want := range []string{
+		keyfmt.Genesis.Encode(testGenesis(0xA1)),
+		fingerprintOf(testGenesis(0xA1)),
+		keyfmt.Tip.Encode(testGenesis(0xB1)),
+		fingerprintOf(testGenesis(0xB1)),
+		"length:  12 entries",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("chain section must contain %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestChainSectionCollapsesWhenNotEnabled(t *testing.T) {
+	out := chainSection(api.LockStatusResult{})
+	if !strings.Contains(out, "chain: none") {
+		t.Errorf("chain section = %q, want a none line", out)
+	}
+}
+
+func TestDevicesSectionListsEachDeviceAndMarksThisNode(t *testing.T) {
+	self, other := testGenesis(0xD0), testGenesis(0xD1)
+	out := devicesSection(api.LockStatusResult{
+		Enabled: true, DeviceCount: 2,
+		Devices:        [][]byte{self, other},
+		IdentityPubKey: self,
+	})
+	if !strings.Contains(out, "devices (2)") {
+		t.Errorf("want a count header:\n%s", out)
+	}
+	for _, want := range []string{keyfmt.DeviceKey.Encode(self), keyfmt.DeviceKey.Encode(other)} {
+		if !strings.Contains(out, want) {
+			t.Errorf("must list %q:\n%s", want, out)
+		}
+	}
+	selfLine := keyfmt.DeviceKey.Encode(self) + "  ← this node"
+	if !strings.Contains(out, selfLine) {
+		t.Errorf("must mark this node:\n%s", out)
+	}
+	if strings.Contains(out, keyfmt.DeviceKey.Encode(other)+"  ← this node") {
+		t.Errorf("must not mark another device:\n%s", out)
+	}
+}
+
+// An upgraded binary talking to a daemon that has not restarted returns a count with
+// no list. Printing an empty roster for a populated chain would be a lie.
+func TestDevicesSectionReportsAStaleDaemon(t *testing.T) {
+	out := devicesSection(api.LockStatusResult{Enabled: true, DeviceCount: 7})
+	if !strings.Contains(out, "devices (7)") {
+		t.Errorf("must keep the count:\n%s", out)
+	}
+	if !strings.Contains(out, "restart it: argus start") {
+		t.Errorf("must advise a restart:\n%s", out)
+	}
+}
+
+func TestDevicesSectionCollapsesOnAnEmptyRoster(t *testing.T) {
+	out := devicesSection(api.LockStatusResult{Enabled: true})
+	if !strings.Contains(out, "devices: none") {
+		t.Errorf("devices section = %q, want a none line", out)
+	}
+	if strings.Contains(out, "restart") {
+		t.Errorf("an empty roster is not a stale daemon:\n%s", out)
+	}
+}
+
+func TestSignersSectionListsSignersAndFingerprint(t *testing.T) {
+	sigA, sigB := testGenesis(0xA1), testGenesis(0xA2)
+	out := signersSection(api.LockStatusResult{
+		Enabled: true, Signers: [][]byte{sigA, sigB},
+	})
+	if !strings.Contains(out, "signers (2)") {
+		t.Errorf("want count header:\n%s", out)
+	}
+	for _, want := range []string{
+		keyfmt.SignerKey.Encode(sigA),
+		keyfmt.SignerKey.Encode(sigB),
+		"fingerprint:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("must contain %q:\n%s", want, out)
+		}
+	}
+}
+
+// Break-glass disables enforcement but the signer list records who held authority;
+// that list must still render so an operator can audit who had signing power.
+func TestSignersSectionRendersWhenLogDisabledByBreakGlass(t *testing.T) {
+	sigA := testGenesis(0xA1)
+	out := signersSection(api.LockStatusResult{
+		Enabled: true, Disabled: true,
+		Signers: [][]byte{sigA},
+	})
+	if !strings.Contains(out, "signers (1)") {
+		t.Errorf("want count header:\n%s", out)
+	}
+	if !strings.Contains(out, keyfmt.SignerKey.Encode(sigA)) {
+		t.Errorf("must list signer:\n%s", out)
+	}
+}
+
+func TestSignersSectionCollapsesWhenNoSigners(t *testing.T) {
+	out := signersSection(api.LockStatusResult{})
+	if !strings.Contains(out, "signers: none") {
+		t.Errorf("signers section = %q, want a none line", out)
+	}
+}
+
+func TestThisNodeSectionShowsKeysAndFlags(t *testing.T) {
+	st := api.LockStatusResult{
+		Enabled:        true,
+		IdentityPubKey: testGenesis(0xB0),
+		SignerPubKey:   testGenesis(0xB5),
+		Authorized:     true,
+		SignerTrusted:  true,
+	}
+	out := thisNodeSection(st)
+	for _, want := range []string{
+		"this node",
+		keyfmt.DeviceKey.Encode(testGenesis(0xB0)),
+		keyfmt.SignerKey.Encode(testGenesis(0xB5)),
+		"authorized: yes",
+		"trusted: yes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("must contain %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestThisNodeSectionShowsNoneWhenKeysAbsent(t *testing.T) {
+	out := thisNodeSection(api.LockStatusResult{})
+	if !strings.Contains(out, "this node") {
+		t.Errorf("section header missing:\n%s", out)
+	}
+	if strings.Count(out, "(none)") < 2 {
+		t.Errorf("expect (none) for both absent keys:\n%s", out)
+	}
+	for _, unwanted := range []string{"authorized:", "trusted:"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("must not contain %q when not enabled:\n%s", unwanted, out)
+		}
+	}
+}

--- a/cmd/argus/lock_status_tui_test.go
+++ b/cmd/argus/lock_status_tui_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/config"
+	"github.com/MunifTanjim/argus/internal/e2e"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("reading captured stdout: %v", err)
+	}
+	r.Close()
+	return buf.String()
+}
+
+func TestKeyAuthorized(t *testing.T) {
+	a, b := testGenesis(0x01), testGenesis(0x02)
+	if !keyAuthorized(a, [][]byte{b, a}) {
+		t.Error("a member key must be authorized")
+	}
+	if keyAuthorized(a, [][]byte{b}) {
+		t.Error("a non-member key must not be authorized")
+	}
+	if keyAuthorized(a, nil) {
+		t.Error("an empty set authorizes nobody")
+	}
+}
+
+func TestDevicesKnown(t *testing.T) {
+	if !devicesKnown(api.LockStatusResult{}) {
+		t.Error("no devices is a known (empty) set")
+	}
+	if !devicesKnown(api.LockStatusResult{DeviceCount: 2, Devices: [][]byte{testGenesis(0x1), testGenesis(0x2)}}) {
+		t.Error("a populated list is known")
+	}
+	if devicesKnown(api.LockStatusResult{DeviceCount: 2}) {
+		t.Error("a count with no list (stale daemon) must be treated as unknown")
+	}
+}
+
+// The gap this closes: while the node is up, the tui's own key and its sign command
+// must be reachable, so an operator can authorize the dashboard without stopping the node.
+func TestPrintTUIRoleUnauthorizedShowsSignHint(t *testing.T) {
+	tempStateDir(t)
+	out := captureStdout(t, func() {
+		_ = printTUIRole(context.Background(), &config.Config{}, api.LockStatusResult{
+			Enabled: true, DeviceCount: 1, Devices: [][]byte{testGenesis(0x99)},
+		})
+	})
+	for _, want := range []string{"this tui", "authorized: no", "argus lock sign"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output must contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintTUIRoleAuthorizedHidesSignHint(t *testing.T) {
+	tempStateDir(t)
+	kp, err := e2e.LoadOrCreateIdentity(config.GetStatePath("client-identity.json"))
+	if err != nil {
+		t.Fatalf("client identity: %v", err)
+	}
+	out := captureStdout(t, func() {
+		_ = printTUIRole(context.Background(), &config.Config{}, api.LockStatusResult{
+			Enabled: true, DeviceCount: 1, Devices: [][]byte{kp.Public},
+		})
+	})
+	if !strings.Contains(out, "authorized: yes") {
+		t.Errorf("output must show 'authorized: yes', got:\n%s", out)
+	}
+	if strings.Contains(out, "argus lock sign") {
+		t.Errorf("an authorized tui must not show a sign hint, got:\n%s", out)
+	}
+}

--- a/cmd/argus/lock_test.go
+++ b/cmd/argus/lock_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/keyfmt"
+)
+
+func TestLockCmdRegistersOnly6aSubcommands(t *testing.T) {
+	cmd := newLockCmd()
+	subs := cmd.Commands()
+
+	if len(subs) != 5 {
+		names := make([]string, len(subs))
+		for i, c := range subs {
+			names[i] = c.Name()
+		}
+		t.Fatalf("newLockCmd must register exactly 5 subcommands, got %d: %v", len(subs), names)
+	}
+
+	want := []string{"local-disable", "log", "pin", "status", "unpin"}
+	for _, name := range want {
+		found := false
+		for _, c := range subs {
+			if c.Name() == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected subcommand %q not registered", name)
+		}
+	}
+
+	forbidden := []string{"init", "sign", "revoke-device", "add-signer", "remove-signer", "disable", "revoke-signer"}
+	for _, name := range forbidden {
+		for _, c := range subs {
+			if c.Name() == name {
+				t.Errorf("signing/ceremony command %q must not be registered in 6a", name)
+			}
+		}
+	}
+}
+
+func TestLockSignHint(t *testing.T) {
+	pub := testGenesis(0xAB)
+	hint := lockSignHint(pub)
+	if !strings.HasPrefix(hint, "argus lock sign ") {
+		t.Fatalf("hint %q does not start with 'argus lock sign '", hint)
+	}
+	encoded := keyfmt.DeviceKey.Encode(pub)
+	if !strings.HasSuffix(hint, encoded) {
+		t.Fatalf("hint %q does not end with pubkey %s", hint, encoded)
+	}
+}

--- a/cmd/argus/pin_test.go
+++ b/cmd/argus/pin_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/trustpin"
+)
+
+func testGenesis(b byte) []byte {
+	g := make([]byte, trustpin.GenesisLen)
+	for i := range g {
+		g[i] = b
+	}
+	return g
+}
+
+func TestResolvePinPrefersConfig(t *testing.T) {
+	f := trustpin.New(filepath.Join(t.TempDir(), "trustlog-genesis"))
+	cfgG := testGenesis(0x77)
+
+	p, err := trustpin.Resolve(trustpin.Encode(cfgG), f)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if p.Source != trustpin.SourceConfig {
+		t.Fatalf("Source = %v, want config", p.Source)
+	}
+}
+
+func TestResolvePinRejectsShortConfigGenesis(t *testing.T) {
+	f := trustpin.New(filepath.Join(t.TempDir(), "trustlog-genesis"))
+	short := "gen:01020304"
+
+	_, err := trustpin.Resolve(short, f)
+	if err == nil {
+		t.Fatal("a 4-byte lock.genesis must be rejected")
+	}
+	if !strings.Contains(err.Error(), "lock.genesis") {
+		t.Fatalf("error must name the config key, got: %v", err)
+	}
+}
+
+func TestPinFilePathsAreDistinct(t *testing.T) {
+	if nodePinFile().Path() == clientPinFile().Path() {
+		t.Fatal("node and client pin files must be distinct paths")
+	}
+	if !strings.HasSuffix(nodePinFile().Path(), "trustlog-genesis") {
+		t.Fatalf("node pin path = %q, want it to end in trustlog-genesis", nodePinFile().Path())
+	}
+	if !strings.HasSuffix(clientPinFile().Path(), "client-trustlog-genesis") {
+		t.Fatalf("client pin path = %q, want it to end in client-trustlog-genesis", clientPinFile().Path())
+	}
+}

--- a/cmd/argus/root.go
+++ b/cmd/argus/root.go
@@ -114,7 +114,7 @@ func newRootCmd(version string) *cobra.Command {
 
 	addClientFlags(cmd.Flags())
 
-	cmd.AddCommand(newStartCmd(version), newSpawnCmd(), newHooksCmd(), newHookCmd(), newPingCmd(), newPairCmd(), newUnpairCmd(), newFocusCmd(), newUpgradeCmd(), newConfigCmd(), newViewCmd())
+	cmd.AddCommand(newStartCmd(version), newSpawnCmd(), newHooksCmd(), newHookCmd(), newPingCmd(), newPairCmd(), newUnpairCmd(), newFocusCmd(), newUpgradeCmd(), newConfigCmd(), newViewCmd(), newLockCmd())
 
 	cmd.InitDefaultCompletionCmd()
 	if subcmd, _, _ := cmd.Find([]string{"completion"}); subcmd != nil && subcmd.Name() == "completion" {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 )
@@ -67,4 +68,10 @@ func (c *Client) Close() error { return c.peer.Close() }
 // Call sends a request and unmarshals the result into out (which may be nil).
 func (c *Client) Call(method string, params, out any) error {
 	return c.peer.Call(method, params, out)
+}
+
+// CallContext is Call bounded by ctx: on cancel or deadline it abandons the request
+// and closes the connection so the peer does not serve a stale response.
+func (c *Client) CallContext(ctx context.Context, method string, params, out any) error {
+	return c.peer.CallContext(ctx, method, params, out)
 }

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -97,6 +97,13 @@ const (
 	MethodTrustLogChanged = "trustlog.changed" // gateway->node notification: TrustLogChangedParams
 	MethodSessionTasks    = "sessions.tasks"   // request: SessionRef; result: TasksResult
 	MethodTasksChanged    = "tasks.changed"    // notification: TasksChanged (server→client)
+	// Locked-mode control: local unix-socket only. remoteDispatch rejects every
+	// lock.* method, so only the CLI (which dials the unix socket) can invoke these.
+	MethodLockPin          = "lock.pin"          // request: LockPinParams; result: nil
+	MethodLockUnpin        = "lock.unpin"        // request: no params; result: nil
+	MethodLockLocalDisable = "lock.localDisable" // request: no params; result: nil
+	MethodLockStatus       = "lock.status"       // request: no params; result: LockStatusResult
+	MethodLockLog          = "lock.log"          // request: no params; result: LockLogResult
 )
 
 // ChangedFile is one entry in a session working directory's git status.
@@ -656,4 +663,51 @@ const (
 type NodeEvent struct {
 	Type string         `json:"type"` // added | online | offline | removed | trust-changed
 	Node NodeDescriptor `json:"node"`
+}
+
+// LockPinParams pins a node to a trust-log genesis hash.
+type LockPinParams struct {
+	Genesis []byte `json:"genesis"`
+}
+
+// LockLogEntry summarises one entry in the trust-log chain, as returned by lock.log.
+type LockLogEntry struct {
+	Index       int      `json:"index"`
+	Kind        string   `json:"kind"`                   // genesis|add-signer|remove-signer|authorize-device|revoke-device|revoke-signer|disable
+	Hash        []byte   `json:"hash,omitempty"`         // this entry's chain hash; entry 0's is the genesis
+	Target      []byte   `json:"target,omitempty"`       // single-key entries: the target pubkey
+	Signers     [][]byte `json:"signers,omitempty"`      // genesis: initial signer set
+	Revoked     [][]byte `json:"revoked,omitempty"`      // revoke-signer: revoked signer pubkeys
+	Replaces    [][]byte `json:"replaces,omitempty"`     // revoke-signer: replacement signer pubkeys
+	CoSignCount int      `json:"cosign_count,omitempty"` // revoke-signer: number of co-signs
+}
+
+// LockLogResult is the reply to lock.log.
+type LockLogResult struct {
+	Entries []LockLogEntry `json:"entries"`
+	Tip     []byte         `json:"tip,omitempty"`
+	Signers [][]byte       `json:"signers,omitempty"` // current trusted signer set (for fingerprint computation)
+}
+
+// LockStatusResult is the audit view of a node's locked state.
+type LockStatusResult struct {
+	Enabled     bool     `json:"enabled"`
+	Tip         []byte   `json:"tip,omitempty"`
+	Signers     [][]byte `json:"signers,omitempty"`
+	DeviceCount int      `json:"device_count"`
+	// Devices is the authorized set. A non-zero DeviceCount with no Devices means the
+	// running daemon predates this field — upgraded binary, not yet restarted.
+	Devices        [][]byte `json:"devices,omitempty"`
+	Length         int      `json:"length,omitempty"`
+	SignerTrusted  bool     `json:"signer_trusted"`
+	Authorized     bool     `json:"authorized"`
+	SignerPubKey   []byte   `json:"signer_pubkey,omitempty"`
+	IdentityPubKey []byte   `json:"identity_pubkey,omitempty"`
+	Disabled       bool     `json:"disabled,omitempty"`
+	LocalDisabled  bool     `json:"local_disabled,omitempty"`
+	Pinned         bool     `json:"pinned,omitempty"`
+	PinGenesis     []byte   `json:"pin_genesis,omitempty"`  // this device's own pin
+	SeenGenesis    []byte   `json:"seen_genesis,omitempty"` // genesis observed by a tripped quarantine gate
+	PinSource      string   `json:"pin_source,omitempty"`   // "config" or "file"
+	Quarantined    bool     `json:"quarantined,omitempty"`
 }

--- a/internal/e2etest/lock_cli_recovery_e2e_test.go
+++ b/internal/e2etest/lock_cli_recovery_e2e_test.go
@@ -1,0 +1,318 @@
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+// TestLockCLIRecovery is the PR 6a acceptance test: recovery over the local
+// unix socket (the CLI path). An unpinned node on a locked network quarantines;
+// lock.pin over the local socket clears it; lock.status reports the enforcing
+// state; lock.local-disable is the escape hatch; and lock.* is refused over the
+// co-located gateway dispatch path (LOCAL-ONLY).
+func TestLockCLIRecovery(t *testing.T) {
+	node.SetTrustSyncIntervalForTest(100 * time.Millisecond)
+	t.Cleanup(func() { node.SetTrustSyncIntervalForTest(5 * time.Minute) })
+	node.SetTriggeredPullIntervalForTest(50 * time.Millisecond)
+	t.Cleanup(node.ResetTriggeredPullIntervalForTest)
+
+	agg := gateway.New(time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	signer, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	authKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("authKP: %v", err)
+	}
+
+	tlog, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+
+	// Pinned node: seeds the gateway's entry store with a non-empty chain.
+	pinnedKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("pinnedKP: %v", err)
+	}
+	// disKP is the local-disable node's identity key. It is authorized here so a
+	// locked client can open a channel to it for the behavioral escape-hatch assertion.
+	disKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("disKP: %v", err)
+	}
+	if err := tlog.AuthorizeDevice(authKP.Public, signer); err != nil {
+		t.Fatalf("AuthorizeDevice(authKP): %v", err)
+	}
+	if err := tlog.AuthorizeDevice(disKP.Public, signer); err != nil {
+		t.Fatalf("AuthorizeDevice(disKP): %v", err)
+	}
+	chain := trustlog.MarshalChain(tlog.Entries())
+
+	dir := t.TempDir()
+	pinnedChainPath := filepath.Join(dir, "pinned-chain")
+	if err := os.WriteFile(pinnedChainPath, chain, 0o600); err != nil {
+		t.Fatalf("write pinned chain: %v", err)
+	}
+	clientChainPath := filepath.Join(dir, "client-chain")
+	if err := os.WriteFile(clientChainPath, chain, 0o600); err != nil {
+		t.Fatalf("write client chain: %v", err)
+	}
+
+	pinnedNode := node.New()
+	pinnedNode.SetIdentity("lcr-pinned", "LCR Pinned Node")
+	pinnedNode.SetVersion("itest")
+	pinnedNode.SetIdentityKey(pinnedKP)
+	pinnedNode.SetE2EE(true)
+	if err := pinnedNode.EnableTrustLog(genesisHash, pinnedChainPath); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	go pinnedNode.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	// Unpinned node: SetTrustChainPath only (no EnableTrustLog) → will quarantine
+	// once the gateway advertises a non-empty chain.
+	unpinnedKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("unpinnedKP: %v", err)
+	}
+	unpinnedChainPath := filepath.Join(dir, "unpinned-chain")
+
+	unpinnedNode := node.New()
+	unpinnedNode.SetIdentity("lcr-unpinned", "LCR Unpinned Node")
+	unpinnedNode.SetVersion("itest")
+	unpinnedNode.SetIdentityKey(unpinnedKP)
+	unpinnedNode.SetE2EE(true)
+	unpinnedNode.SetTrustChainPath(unpinnedChainPath)
+	go unpinnedNode.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	socketPath := filepath.Join(dir, "unpinned.sock")
+	sockCtx, sockCancel := context.WithCancel(ctx)
+	defer sockCancel()
+	sockDone := make(chan error, 1)
+	go func() { sockDone <- unpinnedNode.Run(sockCtx, socketPath) }()
+	t.Cleanup(func() {
+		sockCancel()
+		<-sockDone
+	})
+
+	waitFor(t, "unix socket ready", func() bool {
+		_, err := os.Stat(socketPath)
+		return err == nil
+	})
+
+	pollConn, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	if err != nil {
+		t.Fatalf("poll dial: %v", err)
+	}
+	poll := api.NewClient(pollConn)
+	waitFor(t, "both lcr nodes online", func() bool {
+		var r api.NodesListResult
+		if poll.Call(api.MethodNodesList, nil, &r) != nil {
+			return false
+		}
+		pinned, unpinned := false, false
+		for _, nd := range r.Nodes {
+			switch {
+			case nd.ID == "lcr-pinned" && nd.IdentityPubKey != "" && nd.Online:
+				pinned = true
+			case nd.ID == "lcr-unpinned" && nd.IdentityPubKey != "" && nd.Online:
+				unpinned = true
+			}
+		}
+		return pinned && unpinned
+	})
+	poll.Close()
+
+	waitFor(t, "lcr-unpinned quarantined", func() bool {
+		return unpinnedNode.Quarantined()
+	})
+
+	t.Run("default", func(t *testing.T) {
+		// A node with no trust state configured: lock.status reports not-enabled.
+		bareNode := node.New()
+		bareNode.SetIdentity("lcr-bare", "LCR Bare")
+		bareNode.SetVersion("itest")
+
+		// dir is the outer t.TempDir(), whose path is short enough for a unix socket.
+		bareSocketPath := filepath.Join(dir, "bare.sock")
+		bareCtx, bareCancel := context.WithCancel(ctx)
+		defer bareCancel()
+		bareDone := make(chan error, 1)
+		go func() { bareDone <- bareNode.Run(bareCtx, bareSocketPath) }()
+		t.Cleanup(func() {
+			bareCancel()
+			<-bareDone
+		})
+		waitFor(t, "bare socket ready", func() bool {
+			_, err := os.Stat(bareSocketPath)
+			return err == nil
+		})
+
+		lc, err := api.Dial(bareSocketPath)
+		if err != nil {
+			t.Fatalf("dial bare socket: %v", err)
+		}
+		defer lc.Close()
+
+		var st api.LockStatusResult
+		if err := lc.Call(api.MethodLockStatus, nil, &st); err != nil {
+			t.Fatalf("lock.status: %v", err)
+		}
+		if st.Enabled {
+			t.Error("Enabled must be false when no trust genesis configured")
+		}
+		if st.Quarantined {
+			t.Error("Quarantined must be false in TOFU mode")
+		}
+	})
+
+	t.Run("pin", func(t *testing.T) {
+		lc, err := api.Dial(socketPath)
+		if err != nil {
+			t.Fatalf("dial local socket: %v", err)
+		}
+		defer lc.Close()
+
+		if err := lc.Call(api.MethodLockPin, api.LockPinParams{Genesis: genesisHash}, nil); err != nil {
+			t.Fatalf("lock.pin: %v", err)
+		}
+		waitFor(t, "lock.pin clears quarantine", func() bool {
+			return !unpinnedNode.Quarantined()
+		})
+
+		var st api.LockStatusResult
+		if err := lc.Call(api.MethodLockStatus, nil, &st); err != nil {
+			t.Fatalf("lock.status after pin: %v", err)
+		}
+		if !st.Enabled {
+			t.Error("Enabled must be true after pin")
+		}
+		if !st.Pinned {
+			t.Error("Pinned must be true after lock.pin")
+		}
+		if !bytes.Equal(st.PinGenesis, genesisHash) {
+			t.Errorf("PinGenesis = %x, want %x", st.PinGenesis, genesisHash)
+		}
+		if st.Quarantined {
+			t.Error("Quarantined must be false after recovery")
+		}
+	})
+
+	t.Run("local-disable", func(t *testing.T) {
+		// Re-quarantine a fresh unpinned node on the same gateway. disKP is authorized
+		// in the chain so a locked client can open a channel to it for the behavioral
+		// escape-hatch assertion after lock.local-disable.
+		// Chain state in t.TempDir(); socket in the outer dir to keep the path
+		// short enough for macOS's 104-byte sockaddr_un limit.
+		disChainDir := t.TempDir()
+		disNode := node.New()
+		disNode.SetIdentity("lcr-dis", "LCR Disable")
+		disNode.SetVersion("itest")
+		disNode.SetIdentityKey(disKP)
+		disNode.SetE2EE(true)
+		disNode.SetTrustChainPath(filepath.Join(disChainDir, "dis-chain"))
+		go disNode.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+		// dir is the outer t.TempDir(), whose path is short enough for a unix socket.
+		disSocket := filepath.Join(dir, "dis.sock")
+		disCtx, disCancel := context.WithCancel(ctx)
+		defer disCancel()
+		disDone := make(chan error, 1)
+		go func() { disDone <- disNode.Run(disCtx, disSocket) }()
+		t.Cleanup(func() {
+			disCancel()
+			<-disDone
+		})
+		waitFor(t, "dis socket ready", func() bool {
+			_, err := os.Stat(disSocket)
+			return err == nil
+		})
+		waitFor(t, "lcr-dis quarantined", func() bool {
+			return disNode.Quarantined()
+		})
+
+		lc, err := api.Dial(disSocket)
+		if err != nil {
+			t.Fatalf("dial dis socket: %v", err)
+		}
+		defer lc.Close()
+
+		if err := lc.Call(api.MethodLockLocalDisable, nil, nil); err != nil {
+			t.Fatalf("lock.local-disable: %v", err)
+		}
+
+		var st api.LockStatusResult
+		if err := lc.Call(api.MethodLockStatus, nil, &st); err != nil {
+			t.Fatalf("lock.status after local-disable: %v", err)
+		}
+		if !st.LocalDisabled {
+			t.Error("LocalDisabled must be true after lock.local-disable")
+		}
+
+		// Behavioral assertion: the escape hatch must allow real channels through the
+		// gateway even though the quarantine gate is still tripped. disNode has no
+		// trust store (unpinned/trust-nil), so after local-disable it accepts any
+		// channel. The client uses the pinned path (locked client) so it can see the
+		// network's trust log without quarantining and will open a channel to lcr-dis
+		// (disKP.Public is authorized in the chain). agents.list must succeed.
+		gwDial := func(ctx context.Context) (net.Conn, error) {
+			return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		}
+		c, err := client.NewReconnectingE2EClientLocked(ctx, gwDial, genesisHash, authKP, clientChainPath)
+		if err != nil {
+			t.Fatalf("NewReconnectingE2EClientLocked: %v", err)
+		}
+		defer c.Close()
+
+		var agents api.AgentsListResult
+		if err := c.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "lcr-dis"}, &agents); err != nil {
+			t.Fatalf("local-disable escape hatch: agents.list to quarantine-gated node failed: %v", err)
+		}
+	})
+
+	t.Run("local-only", func(t *testing.T) {
+		// lock.* must be rejected by the co-located gateway dispatch path.
+		dispatch := unpinnedNode.DispatchFunc()
+		ctx2 := context.Background()
+
+		_, err := dispatch(ctx2, api.MethodLockPin, nil)
+		if err == nil {
+			t.Fatal("DispatchFunc must reject lock.pin")
+		}
+		rpcErr, ok := err.(*api.RPCError)
+		if !ok || rpcErr.Code != api.CodeMethodNotFound {
+			t.Errorf("want CodeMethodNotFound for lock.pin via DispatchFunc, got %v", err)
+		}
+
+		_, err = dispatch(ctx2, api.MethodLockStatus, nil)
+		if err == nil {
+			t.Fatal("DispatchFunc must reject lock.status")
+		}
+		rpcErr, ok = err.(*api.RPCError)
+		if !ok || rpcErr.Code != api.CodeMethodNotFound {
+			t.Errorf("want CodeMethodNotFound for lock.status via DispatchFunc, got %v", err)
+		}
+	})
+}

--- a/internal/node/handlers.go
+++ b/internal/node/handlers.go
@@ -44,4 +44,9 @@ func (d *Node) registerHandlers(srv *api.Server) {
 	srv.Handle(api.MethodSessionCommits, d.handleCommits)
 	srv.Handle(api.MethodSessionCommitFiles, d.handleCommitFiles)
 	srv.Handle(api.MethodSessionTasks, d.handleTasks)
+	srv.Handle(api.MethodLockPin, d.handleLockPin)
+	srv.Handle(api.MethodLockUnpin, d.handleLockUnpin)
+	srv.Handle(api.MethodLockLocalDisable, d.handleLockLocalDisable)
+	srv.Handle(api.MethodLockStatus, d.handleLockStatus)
+	srv.Handle(api.MethodLockLog, d.handleLockLog)
 }

--- a/internal/node/handlers_lock.go
+++ b/internal/node/handlers_lock.go
@@ -1,0 +1,164 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+func loadCurrentLog(st *trustlog.SyncStore) ([]trustlog.Entry, *trustlog.Log, error) {
+	chain := st.Bytes()
+	if chain == nil {
+		return nil, nil, &api.RPCError{Code: api.CodeInternalError, Message: "no chain in trust store"}
+	}
+	entries, err := trustlog.UnmarshalChain(chain)
+	if err != nil {
+		return nil, nil, &api.RPCError{Code: api.CodeInternalError, Message: "unmarshal chain: " + err.Error()}
+	}
+	log, err := trustlog.Load(entries)
+	if err != nil {
+		return nil, nil, &api.RPCError{Code: api.CodeInternalError, Message: "load log: " + err.Error()}
+	}
+	return entries, log, nil
+}
+
+func kindString(k trustlog.Kind) string {
+	switch k {
+	case trustlog.KindGenesis:
+		return "genesis"
+	case trustlog.KindAddSigner:
+		return "add-signer"
+	case trustlog.KindRemoveSigner:
+		return "remove-signer"
+	case trustlog.KindAuthorizeDevice:
+		return "authorize-device"
+	case trustlog.KindRevokeDevice:
+		return "revoke-device"
+	case trustlog.KindRevokeSigner:
+		return "revoke-signer"
+	case trustlog.KindDisable:
+		return "disable"
+	default:
+		return fmt.Sprintf("kind(%d)", k)
+	}
+}
+
+// readPinState fills the pin/quarantine fields of a status result under pinMu.
+func (d *Node) readPinState(res *api.LockStatusResult) {
+	d.pinMu.Lock()
+	defer d.pinMu.Unlock()
+	res.Quarantined = d.trustGate.Tripped()
+	res.Pinned = len(d.pinGenesis) > 0
+	if res.Pinned {
+		res.PinGenesis = append([]byte(nil), d.pinGenesis...)
+		res.PinSource = d.pinSource
+	}
+	if res.Quarantined {
+		res.SeenGenesis = d.trustGate.Genesis()
+	}
+}
+
+func (d *Node) handleLockPin(_ context.Context, raw json.RawMessage) (any, error) {
+	var p api.LockPinParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "invalid params: " + err.Error()}
+		}
+	}
+	if err := d.AdoptPin(p.Genesis); err != nil {
+		code := api.CodeInternalError
+		if errors.Is(err, ErrPinGenesisLen) || errors.Is(err, ErrPinConflict) {
+			code = api.CodeInvalidRequest
+		}
+		return nil, &api.RPCError{Code: code, Message: err.Error()}
+	}
+	return nil, nil
+}
+
+func (d *Node) handleLockUnpin(_ context.Context, _ json.RawMessage) (any, error) {
+	if err := d.DropPin(); err != nil {
+		return nil, &api.RPCError{Code: api.CodeInternalError, Message: err.Error()}
+	}
+	return nil, nil
+}
+
+func (d *Node) handleLockLocalDisable(_ context.Context, _ json.RawMessage) (any, error) {
+	if err := d.LocalDisable(); err != nil {
+		return nil, &api.RPCError{Code: api.CodeInternalError, Message: err.Error()}
+	}
+	return nil, nil
+}
+
+func (d *Node) handleLockStatus(_ context.Context, _ json.RawMessage) (any, error) {
+	signerPub := d.SignerPublic()
+	res := api.LockStatusResult{
+		SignerPubKey:   signerPub,
+		IdentityPubKey: append([]byte(nil), d.identity.Public...),
+		LocalDisabled:  d.localDisabled(),
+	}
+	d.readPinState(&res)
+	st := d.trust.Load()
+	if st == nil {
+		return res, nil
+	}
+	res.Enabled = true
+	res.Tip = st.Tip()
+	res.Signers = st.Signers()
+	devices := st.Devices()
+	res.DeviceCount = len(devices)
+	res.Devices = devices
+	res.Length = st.Length()
+	if len(signerPub) > 0 {
+		res.SignerTrusted = st.SignerTrusted(signerPub)
+	}
+	if len(d.identity.Public) > 0 {
+		res.Authorized = st.DeviceAuthorized(d.identity.Public)
+	}
+	res.Disabled = st.Disabled()
+	return res, nil
+}
+
+func (d *Node) handleLockLog(_ context.Context, _ json.RawMessage) (any, error) {
+	st := d.trust.Load()
+	if st == nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "locked mode not enabled"}
+	}
+	entries, log, err := loadCurrentLog(st)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]api.LockLogEntry, len(entries))
+	for i, e := range entries {
+		le := api.LockLogEntry{Index: i, Kind: kindString(e.Kind), Hash: trustlog.HashEntry(&entries[i])}
+		switch e.Kind {
+		case trustlog.KindGenesis:
+			le.Signers = make([][]byte, len(e.Signers))
+			for j, s := range e.Signers {
+				le.Signers[j] = append([]byte(nil), s...)
+			}
+		case trustlog.KindAddSigner, trustlog.KindRemoveSigner,
+			trustlog.KindAuthorizeDevice, trustlog.KindRevokeDevice:
+			le.Target = append([]byte(nil), e.Key...)
+		case trustlog.KindRevokeSigner:
+			le.Revoked = make([][]byte, len(e.Signers))
+			for j, s := range e.Signers {
+				le.Revoked[j] = append([]byte(nil), s...)
+			}
+			le.Replaces = make([][]byte, len(e.Replaces))
+			for j, s := range e.Replaces {
+				le.Replaces[j] = append([]byte(nil), s...)
+			}
+			le.CoSignCount = len(e.CoSigns)
+		}
+		out[i] = le
+	}
+	return api.LockLogResult{
+		Entries: out,
+		Tip:     st.Tip(),
+		Signers: log.Signers(),
+	}, nil
+}

--- a/internal/node/handlers_lock_errcode_test.go
+++ b/internal/node/handlers_lock_errcode_test.go
@@ -1,0 +1,41 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+)
+
+func TestHandleLockPinBadGenesisIsInvalidRequest(t *testing.T) {
+	d, _ := newLockNode(t)
+	raw, _ := json.Marshal(api.LockPinParams{Genesis: []byte{1, 2, 3}})
+
+	_, err := d.handleLockPin(context.Background(), raw)
+
+	var rpcErr *api.RPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("want *api.RPCError, got %v", err)
+	}
+	if rpcErr.Code != api.CodeInvalidRequest {
+		t.Fatalf("bad genesis: want CodeInvalidRequest, got %d", rpcErr.Code)
+	}
+}
+
+func TestHandleLockPinInternalErrorMapsToInternal(t *testing.T) {
+	d := New() // no trust chain path configured -> AdoptPin hits an internal error
+	_, genesis, _ := buildGenesisChain(t)
+	raw, _ := json.Marshal(api.LockPinParams{Genesis: genesis})
+
+	_, err := d.handleLockPin(context.Background(), raw)
+
+	var rpcErr *api.RPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("want *api.RPCError, got %v", err)
+	}
+	if rpcErr.Code != api.CodeInternalError {
+		t.Fatalf("path unset: want CodeInternalError, got %d", rpcErr.Code)
+	}
+}

--- a/internal/node/handlers_lock_test.go
+++ b/internal/node/handlers_lock_test.go
@@ -1,0 +1,326 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+func newLockNode(t *testing.T) (*Node, string) {
+	t.Helper()
+	d := New()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trustlog-chain")
+	d.SetTrustChainPath(path)
+	return d, path
+}
+
+func buildGenesisChain(t *testing.T) ([]byte, []byte, trustlog.SignerKey) {
+	t.Helper()
+	sk, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	log, err := trustlog.NewGenesis([][]byte{sk.Public}, sk, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesis := log.Tip()
+	return trustlog.MarshalChain(log.Entries()), genesis, sk
+}
+
+func TestHandleLockPin(t *testing.T) {
+	chain, genesis, _ := buildGenesisChain(t)
+	d, path := newLockNode(t)
+	d.SetTrustChainPath(path)
+
+	// Serve the chain via a fake peer so the retained store has entries.
+	d.pullTrustOnce(&fakePeer{pullChain: chain})
+	if !d.Quarantined() {
+		t.Fatal("expected quarantine before pin")
+	}
+
+	raw, _ := json.Marshal(api.LockPinParams{Genesis: genesis})
+	if _, err := d.handleLockPin(context.Background(), raw); err != nil {
+		t.Fatalf("handleLockPin: %v", err)
+	}
+	if d.TrustStore() == nil {
+		t.Fatal("TrustStore must be non-nil after pin")
+	}
+	if d.Quarantined() {
+		t.Fatal("must not be quarantined after adopting pin")
+	}
+}
+
+func TestHandleLockUnpin(t *testing.T) {
+	chain, genesis, _ := buildGenesisChain(t)
+	d, path := newLockNode(t)
+	if err := d.EnableTrustLog(genesis, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	d.syncTrustOnce(&fakePeer{pullChain: chain})
+
+	if _, err := d.handleLockUnpin(context.Background(), nil); err != nil {
+		t.Fatalf("handleLockUnpin: %v", err)
+	}
+	if d.TrustStore() != nil {
+		t.Fatal("TrustStore must be nil after unpin")
+	}
+}
+
+func TestHandleLockLocalDisable(t *testing.T) {
+	d, path := newLockNode(t)
+	_ = path
+	if d.localDisabled() {
+		t.Fatal("should not be locally disabled initially")
+	}
+	if _, err := d.handleLockLocalDisable(context.Background(), nil); err != nil {
+		t.Fatalf("handleLockLocalDisable: %v", err)
+	}
+	if !d.localDisabled() {
+		t.Fatal("localDisabled must be true after handleLockLocalDisable")
+	}
+}
+
+func TestHandleLockStatus_NotEnabled(t *testing.T) {
+	d, _ := newLockNode(t)
+
+	res, err := d.handleLockStatus(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleLockStatus: %v", err)
+	}
+	st := res.(api.LockStatusResult)
+	if st.Enabled {
+		t.Error("Enabled must be false when trust is nil")
+	}
+	if st.Disabled {
+		t.Error("Disabled must be false when not enabled")
+	}
+	if len(st.SignerPubKey) != 0 {
+		t.Errorf("SignerPubKey must be empty when no signer set, got %x", st.SignerPubKey)
+	}
+}
+
+func TestHandleLockStatus_Enforcing(t *testing.T) {
+	chain, genesis, _ := buildGenesisChain(t)
+	d, path := newLockNode(t)
+	if err := d.EnableTrustLog(genesis, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	d.syncTrustOnce(&fakePeer{pullChain: chain})
+
+	res, err := d.handleLockStatus(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleLockStatus: %v", err)
+	}
+	st := res.(api.LockStatusResult)
+	if !st.Enabled {
+		t.Error("Enabled must be true when trust store is active")
+	}
+	if st.Disabled {
+		t.Error("Disabled must be false when chain is not disabled")
+	}
+	if len(st.SignerPubKey) != 0 {
+		t.Errorf("SignerPubKey must be empty when no signer loaded in 6a, got %x", st.SignerPubKey)
+	}
+}
+
+func TestHandleLockStatus_SignerEmpty(t *testing.T) {
+	d, _ := newLockNode(t)
+	// No SetSignerKey call — signer stays zero.
+	res, err := d.handleLockStatus(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleLockStatus: %v", err)
+	}
+	st := res.(api.LockStatusResult)
+	if len(st.SignerPubKey) != 0 {
+		t.Errorf("SignerPubKey must be nil/empty when signer unset; got len=%d", len(st.SignerPubKey))
+	}
+}
+
+func TestHandleLockLog(t *testing.T) {
+	chain, genesis, _ := buildGenesisChain(t)
+	d, path := newLockNode(t)
+	if err := d.EnableTrustLog(genesis, path); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	d.syncTrustOnce(&fakePeer{pullChain: chain})
+
+	res, err := d.handleLockLog(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleLockLog: %v", err)
+	}
+	lr := res.(api.LockLogResult)
+	if len(lr.Entries) == 0 {
+		t.Fatal("expected at least one log entry (genesis)")
+	}
+	if lr.Entries[0].Kind != "genesis" {
+		t.Errorf("first entry kind = %q, want genesis", lr.Entries[0].Kind)
+	}
+	if len(lr.Signers) == 0 {
+		t.Error("expected non-empty signers in log result")
+	}
+}
+
+func TestHandleLockLog_NotEnabled(t *testing.T) {
+	d, _ := newLockNode(t)
+	_, err := d.handleLockLog(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when locked mode not enabled")
+	}
+	var rpcErr *api.RPCError
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeInvalidRequest {
+		t.Errorf("expected CodeInvalidRequest, got %v", err)
+	}
+}
+
+func asRPCError(err error, target **api.RPCError) bool {
+	if e, ok := err.(*api.RPCError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+func TestDispatchFuncFiltersLockMethods(t *testing.T) {
+	d, _ := newLockNode(t)
+	dispatch := d.DispatchFunc()
+	ctx := context.Background()
+
+	raw, _ := json.Marshal(api.LockPinParams{Genesis: make([]byte, 32)})
+	_, err := dispatch(ctx, api.MethodLockPin, raw)
+	if err == nil {
+		t.Fatal("DispatchFunc must reject lock.pin")
+	}
+	if !strings.Contains(err.Error(), "method not found") {
+		t.Errorf("want method-not-found error, got: %v", err)
+	}
+	var rpcErr *api.RPCError
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeMethodNotFound {
+		t.Errorf("want CodeMethodNotFound, got %v", err)
+	}
+
+	_, err = dispatch(ctx, api.MethodLockStatus, nil)
+	if err == nil {
+		t.Fatal("DispatchFunc must reject lock.status")
+	}
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeMethodNotFound {
+		t.Errorf("want CodeMethodNotFound for lock.status, got %v", err)
+	}
+
+	_, err = dispatch(ctx, api.MethodPing, nil)
+	if err != nil {
+		t.Errorf("ping must dispatch normally via DispatchFunc, got %v", err)
+	}
+}
+
+func TestHandleLockPinAndUnpin(t *testing.T) {
+	chain, genesis, _ := buildGenesisChain(t)
+	d, path := newLockNode(t)
+	d.SetTrustChainPath(path)
+
+	d.pullTrustOnce(&fakePeer{pullChain: chain})
+
+	// Pin.
+	raw, _ := json.Marshal(api.LockPinParams{Genesis: genesis})
+	if _, err := d.handleLockPin(context.Background(), raw); err != nil {
+		t.Fatalf("handleLockPin: %v", err)
+	}
+	if d.TrustStore() == nil {
+		t.Fatal("TrustStore must be set after pin")
+	}
+
+	// Unpin.
+	if _, err := d.handleLockUnpin(context.Background(), nil); err != nil {
+		t.Fatalf("handleLockUnpin: %v", err)
+	}
+	if d.TrustStore() != nil {
+		t.Fatal("TrustStore must be nil after unpin")
+	}
+}
+
+// TestRemoteDispatchFiltersLockMethods verifies that remoteDispatch — used by
+// both DispatchFunc (co-located gateway) and the plaintext uplink — rejects
+// lock.* while passing non-lock methods through.
+func TestRemoteDispatchFiltersLockMethods(t *testing.T) {
+	d, _ := newLockNode(t)
+	dispatch := d.remoteDispatch()
+	ctx := context.Background()
+
+	raw, _ := json.Marshal(api.LockPinParams{Genesis: make([]byte, 32)})
+	_, err := dispatch(ctx, api.MethodLockPin, raw)
+	if err == nil {
+		t.Fatal("remoteDispatch must reject lock.pin")
+	}
+	var rpcErr *api.RPCError
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeMethodNotFound {
+		t.Errorf("want CodeMethodNotFound for lock.pin, got %v", err)
+	}
+
+	_, err = dispatch(ctx, api.MethodLockStatus, nil)
+	if err == nil {
+		t.Fatal("remoteDispatch must reject lock.status")
+	}
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeMethodNotFound {
+		t.Errorf("want CodeMethodNotFound for lock.status, got %v", err)
+	}
+
+	if _, err := dispatch(ctx, api.MethodPing, nil); err != nil {
+		t.Errorf("ping must pass through remoteDispatch, got %v", err)
+	}
+}
+
+func TestKindString(t *testing.T) {
+	cases := []struct {
+		k    trustlog.Kind
+		want string
+	}{
+		{trustlog.KindGenesis, "genesis"},
+		{trustlog.KindAddSigner, "add-signer"},
+		{trustlog.KindRemoveSigner, "remove-signer"},
+		{trustlog.KindAuthorizeDevice, "authorize-device"},
+		{trustlog.KindRevokeDevice, "revoke-device"},
+		{trustlog.KindRevokeSigner, "revoke-signer"},
+		{trustlog.KindDisable, "disable"},
+	}
+	for _, c := range cases {
+		if got := kindString(c.k); got != c.want {
+			t.Errorf("kindString(%d) = %q, want %q", c.k, got, c.want)
+		}
+	}
+	if s := kindString(trustlog.Kind(99)); !strings.HasPrefix(s, "kind(") {
+		t.Errorf("unexpected fallback: %q", s)
+	}
+}
+
+func TestSignerPublicNilSafe(t *testing.T) {
+	d := New()
+	if pub := d.SignerPublic(); pub != nil {
+		t.Errorf("SignerPublic with no key set must return nil, got %x", pub)
+	}
+	if key := d.SignerPubKey(); key != "" {
+		t.Errorf("SignerPubKey with no key set must return empty, got %q", key)
+	}
+}
+
+func TestSetSignerKey(t *testing.T) {
+	sk, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	d := New()
+	d.SetSignerKey(sk)
+	if pub := d.SignerPublic(); len(pub) == 0 {
+		t.Error("SignerPublic must be non-empty after SetSignerKey")
+	}
+	if key := d.SignerPubKey(); key == "" {
+		t.Error("SignerPubKey must be non-empty after SetSignerKey")
+	}
+	_ = os.RemoveAll(t.TempDir())
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -48,6 +48,9 @@ type Node struct {
 	identityPubB64 string      // base64 public half, announced to the gateway
 	e2ee           bool
 
+	signer       trustlog.SignerKey // node's Ed25519 signer keypair (locked-mode trust log); zero when unset
+	signerPubB64 string             // base64 public half, announced to the gateway roster
+
 	// Locked-mode trust state: nil/zero in TOFU mode; enforcement engages only once
 	// a trust store is loaded via EnableTrustLog.
 	trust             atomic.Pointer[trustlog.SyncStore] // locked-mode trust store; nil when off
@@ -170,6 +173,23 @@ func (d *Node) SetIdentityKey(kp e2e.KeyPair) {
 // SetE2EE toggles the blind-relay uplink; default false uses the plaintext uplink. Call before ConnectGateway.
 func (d *Node) SetE2EE(enabled bool) { d.e2ee = enabled }
 
+// SetSignerKey sets the node's Ed25519 signer keypair. Call before Run.
+func (d *Node) SetSignerKey(kp trustlog.SignerKey) {
+	d.signer = kp
+	d.signerPubB64 = base64.StdEncoding.EncodeToString(kp.Public)
+}
+
+// SignerPubKey returns the base64 Ed25519 signer public half, or "" if unset.
+func (d *Node) SignerPubKey() string { return d.signerPubB64 }
+
+// SignerPublic returns a copy of the raw Ed25519 signer public half, or nil if unset.
+func (d *Node) SignerPublic() []byte {
+	if len(d.signer.Public) == 0 {
+		return nil
+	}
+	return append([]byte(nil), d.signer.Public...)
+}
+
 // Quarantined reports whether this node is quarantined on a locked network it
 // cannot pin. In TOFU mode (nil trust store) this is always false.
 func (d *Node) Quarantined() bool { return d.trustGate.Tripped() }
@@ -252,10 +272,10 @@ func (d *Node) Capabilities() api.NodeCapabilities { return d.caps }
 func (d *Node) Registry() *registry.Registry { return d.reg }
 
 // DispatchFunc exposes the local engine to a co-located gateway's in-process
-// source without a network hop. It stays the raw dispatch so the plaintext
-// (e2ee-off) path is byte-for-byte identical to before; lock.* filtering for
-// remote-reachable surfaces is added with the lock CLI (later slice).
-func (d *Node) DispatchFunc() api.DispatchFunc { return d.server.DispatchFunc() }
+// source without a network hop. It returns remoteDispatch so that lock.* methods
+// registered on d.server are never reachable from a co-located gateway; only the
+// local unix socket (CLI) can invoke them.
+func (d *Node) DispatchFunc() api.DispatchFunc { return d.remoteDispatch() }
 
 // clientFor returns the tmux client for a session's server.
 func (d *Node) clientFor(s session.Session) (*tmux.Client, error) {

--- a/internal/node/trustlog.go
+++ b/internal/node/trustlog.go
@@ -480,9 +480,16 @@ func (d *Node) setTriggerPeerForTest(p trustCaller) { d.testTriggerPeer.Store(&p
 //
 // Re-pinning the same genesis is a no-op; a different one is refused unless the
 // current chain is disabled (stale pin that no longer guards anything).
+// AdoptPin validation errors, wrapped so a handler can map them to a
+// client-facing invalid-request code; every other AdoptPin failure is internal.
+var (
+	ErrPinGenesisLen = errors.New("node: genesis length invalid")
+	ErrPinConflict   = errors.New("node: already pinned to a different genesis")
+)
+
 func (d *Node) AdoptPin(genesis []byte) error {
 	if len(genesis) != trustpin.GenesisLen {
-		return fmt.Errorf("node: genesis is %d bytes, want %d", len(genesis), trustpin.GenesisLen)
+		return fmt.Errorf("%w: got %d bytes, want %d", ErrPinGenesisLen, len(genesis), trustpin.GenesisLen)
 	}
 	if err := func() error {
 		d.pinMu.Lock()
@@ -494,7 +501,7 @@ func (d *Node) AdoptPin(genesis []byte) error {
 			// A disabled chain enforces nothing and can never be re-enabled, so the pin
 			// holding it is stale rather than conflicting — replacing it is safe.
 			if st := d.trust.Load(); st == nil || !st.Disabled() {
-				return errors.New("node: already pinned to a different genesis; run `argus lock unpin` first")
+				return fmt.Errorf("%w; run `argus lock unpin` first", ErrPinConflict)
 			}
 			if err := os.Remove(d.trustPath); err != nil && !os.IsNotExist(err) {
 				return err

--- a/internal/node/uplink.go
+++ b/internal/node/uplink.go
@@ -55,8 +55,9 @@ func (d *Node) runUplink(ctx context.Context, url, token string, httpClient *htt
 func (d *Node) runUplinkPlain(ctx context.Context, url, token string, httpClient *http.Client) (connected bool) {
 	peer, err := api.DialWSPeer(ctx, url, token, httpClient, api.PeerOptions{
 		// The gateway issues control requests (capture/input/respond/...) down this
-		// link; serve them through the same handlers local clients use.
-		Dispatch: d.server.DispatchFunc(),
+		// link. remoteDispatch filters lock.* so lock handlers are never reachable
+		// from the network — local unix socket only.
+		Dispatch: d.remoteDispatch(),
 	})
 	if err != nil {
 		if ctx.Err() == nil {


### PR DESCRIPTION
> **⚠️ Updated (beacon → tip cross-check).** The anti-equivocation *beacon* mechanism referenced below was removed stack-wide and replaced by an authenticated tip cross-check: the client reads each node's trust-log tip over its already-authenticated Noise channel (via `node.identify`) and compares tips against its resolved chain — no per-node beacon key, no gateway-supplied verification input. See PR #44 and `docs/superpowers/plans/2026-09-02-beacon-to-tip-crosscheck.md`. Any "beacon"/"equivocation" wording below is historical.

---

Eighth stacked PR (base: `pr/05b-quarantine-recovery`). The `lock` CLI subcommands that need no signer key — **this unblocks the PR 5b quarantine banner (`argus lock pin`)**.

**Commands (local unix socket only):** `lock pin`→AdoptPin, `lock unpin`→DropPin, `lock local-disable`→LocalDisable (recovery); `lock status`, `lock log` (visibility).

**Security — lock.* is local-only, self-enforced on every link:** `lock.*` handlers register on the shared `d.server`; every network surface (co-located plaintext gateway via `DispatchFunc`, the plaintext uplink, the blind uplink, the E2E responder) routes through `remoteDispatch` which strips the `lock.` prefix → method-not-found. The `DispatchFunc()`→`remoteDispatch()` flip (deferred PR-3 action) lands here, plus the plaintext-uplink flip (defense-in-depth from final review). The gateway client-server also has no `lock.*` handler + whitelisted routing (second layer). No remote client can reach `lock.*`.

**Scope:** signing (init/sign/revoke-device/add/remove-signer/disable) is **PR 6b**; the revoke-signer ceremony + docs are **PR 6c**; beacon `Equivocation` is PR 7. An empty signer field is added for status display only (no key load). Default (e2ee off / no genesis) unchanged.

**Test:** `lock pin` over the local socket clears a quarantined node → enforcing; local-disable escape hatch proven behaviorally (client round-trips through the gateway to the local-disabled node); `lock.*` rejected via the co-located gateway path. Full `go test -short ./...` green. See `docs/superpowers/specs/2026-08-08-incremental-e2e-merge-plan-design.md` (PR 6a).
