### PR TITLE
pr/06c revoke signer ceremony

### DIFF
--- a/cmd/argus/config_guard_test.go
+++ b/cmd/argus/config_guard_test.go
@@ -29,6 +29,10 @@ func TestFlagsAreMappedToConfigKeys(t *testing.T) {
 		"redact":           true, // `view` only: offline viewer flag, not a node/client setting
 		"gen-disablements": true, // `lock init` only: one-shot count, not a persistent config key
 		"confirm":          true, // `lock init` only: must never be config-backed — a stored true would silently re-arm the destructive path
+		"cosign":           true, // `lock revoke-signer` only: ceremony blob, not a config key
+		"finish":           true, // `lock revoke-signer` only: ceremony blob, not a config key
+		"replacement":      true, // `lock revoke-signer` only: ceremony argument, not a config key
+		"fork-from":        true, // `lock revoke-signer` only: ceremony argument, not a config key
 	}
 
 	seen := map[string]bool{}

--- a/cmd/argus/lock.go
+++ b/cmd/argus/lock.go
@@ -26,7 +26,7 @@ func newLockCmd() *cobra.Command {
 		Use:   "lock",
 		Short: "Manage locked mode (network trust log)",
 	}
-	cmd.AddCommand(newLockInitCmd(), newLockStatusCmd(), newLockLogCmd(), newLockSignCmd(), newLockRevokeCmd(), newLockAddSignerCmd(), newLockRemoveSignerCmd(), newLockDisableCmd(), newLockLocalDisableCmd(), newLockPinCmd(), newLockUnpinCmd())
+	cmd.AddCommand(newLockInitCmd(), newLockStatusCmd(), newLockLogCmd(), newLockSignCmd(), newLockRevokeCmd(), newLockAddSignerCmd(), newLockRemoveSignerCmd(), newLockRevokeSignerCmd(), newLockDisableCmd(), newLockLocalDisableCmd(), newLockPinCmd(), newLockUnpinCmd())
 	return cmd
 }
 
@@ -714,6 +714,149 @@ func newLockSignerCmd(use, short, method string) *cobra.Command {
 
 func lockSignerOnNode(ctx context.Context, cfg *config.Config, method string, signer []byte) (api.LockDeviceResult, error) {
 	return callLocal[api.LockDeviceResult](ctx, cfg, method, api.LockSignerParams{Signer: signer})
+}
+
+func signerCountAfterRevoke(current, revoked [][]byte) int {
+	revokedSet := make(map[string]bool, len(revoked))
+	for _, r := range revoked {
+		revokedSet[string(r)] = true
+	}
+	remaining := 0
+	for _, c := range current {
+		if !revokedSet[string(c)] {
+			remaining++
+		}
+	}
+	return remaining
+}
+
+func revokeSignerStartOnNode(ctx context.Context, cfg *config.Config, p api.LockRevokeSignerStartParams) (api.LockRevokeSignerBlobResult, error) {
+	return callLocal[api.LockRevokeSignerBlobResult](ctx, cfg, api.MethodLockRevokeSignerStart, p)
+}
+
+func revokeSignerCosignOnNode(ctx context.Context, cfg *config.Config, blob []byte) (api.LockRevokeSignerBlobResult, error) {
+	return callLocal[api.LockRevokeSignerBlobResult](ctx, cfg, api.MethodLockRevokeSignerCosign, api.LockRevokeSignerCosignParams{Blob: blob})
+}
+
+func revokeSignerFinishOnNode(ctx context.Context, cfg *config.Config, blob []byte) (api.LockRevokeSignerFinishResult, error) {
+	return callLocal[api.LockRevokeSignerFinishResult](ctx, cfg, api.MethodLockRevokeSignerFinish, api.LockRevokeSignerFinishParams{Blob: blob})
+}
+
+func newLockRevokeSignerCmd() *cobra.Command {
+	var cosignBlob string
+	var finishBlob string
+	var replacements []string
+	var forkFrom string
+
+	cmd := &cobra.Command{
+		Use:           "revoke-signer",
+		Short:         "Revoke a signer via co-signing ceremony (start / --cosign / --finish)",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cosignBlob != "" && finishBlob != "" {
+				return fail(cmd, fmt.Errorf("--cosign and --finish are mutually exclusive"))
+			}
+			cfg, err := resolveConfig(cmd)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if finishBlob != "" {
+				if len(args) > 0 {
+					return fail(cmd, fmt.Errorf("--finish does not take positional arguments"))
+				}
+				blob, berr := base64.StdEncoding.DecodeString(finishBlob)
+				if berr != nil {
+					return fail(cmd, fmt.Errorf("--finish: invalid base64 blob: %w", berr))
+				}
+				res, ferr := revokeSignerFinishOnNode(ctx, cfg, blob)
+				if ferr != nil {
+					return fail(cmd, ferr)
+				}
+				shell.StdOutF("revocation applied\n  new tip (audit): %s\n", keyfmt.Tip.Encode(res.Tip))
+				shell.StdErrF("\nRevocation propagates to the network within ~30s.\n")
+				return nil
+			}
+
+			if cosignBlob != "" {
+				if len(args) > 0 {
+					return fail(cmd, fmt.Errorf("--cosign does not take positional arguments"))
+				}
+				blob, berr := base64.StdEncoding.DecodeString(cosignBlob)
+				if berr != nil {
+					return fail(cmd, fmt.Errorf("--cosign: invalid base64 blob: %w", berr))
+				}
+				res, cerr := revokeSignerCosignOnNode(ctx, cfg, blob)
+				if cerr != nil {
+					return fail(cmd, cerr)
+				}
+				blobStr := base64.StdEncoding.EncodeToString(res.Blob)
+				shell.StdOutF("co-signed\n  blob: %s\n", blobStr)
+				shell.StdErrF("\nIf more co-signs are needed, run on another signer node:\n  argus lock revoke-signer --cosign %s\n", blobStr)
+				shell.StdErrF("When you have enough co-signs, run on any signer node:\n  argus lock revoke-signer --finish %s\n", blobStr)
+				return nil
+			}
+
+			if len(args) == 0 {
+				return fail(cmd, fmt.Errorf("revoke-signer: specify signer(s) to revoke, or use --cosign / --finish"))
+			}
+			revoked, err := parseSignerKeys(args)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			if len(replacements) == 0 {
+				if st, serr := lockStatusOnNode(ctx, cfg); serr == nil && st.Enabled {
+					remaining := signerCountAfterRevoke(st.Signers, revoked)
+					if remaining < 1 {
+						return fail(cmd, fmt.Errorf(
+							"revocation would remove all signers and leave the log unrecoverable\n"+
+								"  use --replacement sigpub:<hex> to atomically add a successor signer, or\n"+
+								"  'argus lock disable <secret>' + reinit to abandon locked mode"))
+					}
+					if w := lockInitFewSignersWarning(remaining); w != "" {
+						shell.StdErrF("%s", w)
+					}
+				}
+			}
+			var replaces [][]byte
+			if len(replacements) > 0 {
+				replaces, err = parseSignerKeys(replacements)
+				if err != nil {
+					return fail(cmd, fmt.Errorf("--replacement: %w", err))
+				}
+			}
+			var forkFromBytes []byte
+			if forkFrom != "" {
+				forkFromBytes, err = keyfmt.DecodeAny(forkFrom, keyfmt.Tip, keyfmt.Genesis)
+				if err != nil {
+					return fail(cmd, fmt.Errorf("--fork-from: %w", err))
+				}
+			}
+			res, serr := revokeSignerStartOnNode(ctx, cfg, api.LockRevokeSignerStartParams{
+				Revoked:  revoked,
+				Replaces: replaces,
+				ForkFrom: forkFromBytes,
+			})
+			if serr != nil {
+				return fail(cmd, serr)
+			}
+			blobStr := base64.StdEncoding.EncodeToString(res.Blob)
+			shell.StdOutF("revoke-signer started\n  blob: %s\n", blobStr)
+			shell.StdErrF("\nNext: run on another signer node:\n  argus lock revoke-signer --cosign %s\n", blobStr)
+			shell.StdErrF("After collecting enough co-signs, run on any signer node:\n  argus lock revoke-signer --finish <blob>\n")
+			shell.StdErrF("\nNote: all entries after the fork point are erased, not only the revoked signer's; honest entries after it must be re-created.\n")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cosignBlob, "cosign", "", "add this node's co-sign to a ceremony blob (from start or a prior --cosign)")
+	cmd.Flags().StringVar(&finishBlob, "finish", "", "finalize a completed ceremony blob and apply the revocation")
+	cmd.Flags().StringArrayVar(&replacements, "replacement", nil, "replacement signer key (sigpub:<hex>); repeatable")
+	cmd.Flags().StringVar(&forkFrom, "fork-from", "", "override the fork point (tip: or gen:); default: parent of revoked signer's earliest entry")
+	addClientFlags(cmd.Flags())
+	return cmd
 }
 
 func newLockDisableCmd() *cobra.Command {

--- a/cmd/argus/lock_revoke_signer_test.go
+++ b/cmd/argus/lock_revoke_signer_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/keyfmt"
+)
+
+func TestRevokeSignerStartRoutesToRPC(t *testing.T) {
+	s1 := bytes.Repeat([]byte{0x11}, 32)
+	s2 := bytes.Repeat([]byte{0x22}, 32)
+	s3 := bytes.Repeat([]byte{0x33}, 32)
+
+	called := false
+	sock := serveFakeNode(t, map[string]api.HandlerFunc{
+		api.MethodLockStatus: func(_ context.Context, _ json.RawMessage) (any, error) {
+			return api.LockStatusResult{Enabled: true, Signers: [][]byte{s1, s2, s3}}, nil
+		},
+		api.MethodLockRevokeSignerStart: func(_ context.Context, _ json.RawMessage) (any, error) {
+			called = true
+			return api.LockRevokeSignerBlobResult{Blob: []byte("startblob")}, nil
+		},
+	})
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--socket", sock, keyfmt.SignerKey.Encode(s1)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("revoke-signer start: %v", err)
+	}
+	if !called {
+		t.Fatal("lock.revokeSignerStart was not called")
+	}
+}
+
+func TestRevokeSignerCosignRoutesToRPC(t *testing.T) {
+	fakeBlob := base64.StdEncoding.EncodeToString([]byte("cosignblob"))
+	called := false
+	sock := serveFakeNode(t, map[string]api.HandlerFunc{
+		api.MethodLockRevokeSignerCosign: func(_ context.Context, _ json.RawMessage) (any, error) {
+			called = true
+			return api.LockRevokeSignerBlobResult{Blob: []byte("cosignedblob")}, nil
+		},
+	})
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--socket", sock, "--cosign", fakeBlob})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("revoke-signer --cosign: %v", err)
+	}
+	if !called {
+		t.Fatal("lock.revokeSignerCosign was not called")
+	}
+}
+
+func TestRevokeSignerFinishRoutesToRPC(t *testing.T) {
+	fakeBlob := base64.StdEncoding.EncodeToString([]byte("finishblob"))
+	called := false
+	sock := serveFakeNode(t, map[string]api.HandlerFunc{
+		api.MethodLockRevokeSignerFinish: func(_ context.Context, _ json.RawMessage) (any, error) {
+			called = true
+			return api.LockRevokeSignerFinishResult{Tip: bytes.Repeat([]byte{0xFF}, 32)}, nil
+		},
+	})
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--socket", sock, "--finish", fakeBlob})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("revoke-signer --finish: %v", err)
+	}
+	if !called {
+		t.Fatal("lock.revokeSignerFinish was not called")
+	}
+}
+
+func TestRevokeSignerCosignFinishMutualExclusion(t *testing.T) {
+	blob := base64.StdEncoding.EncodeToString([]byte("blob"))
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--cosign", blob, "--finish", blob})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("--cosign and --finish together must be rejected")
+	}
+}
+
+func TestRevokeSignerCosignRejectsInvalidBase64(t *testing.T) {
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--cosign", "not!!valid-base64"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("invalid --cosign blob must fail")
+	}
+}
+
+func TestRevokeSignerFinishRejectsInvalidBase64(t *testing.T) {
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--finish", "not!!valid-base64"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("invalid --finish blob must fail")
+	}
+}
+
+func TestRevokeSignerCosignRejectsPositionalArgs(t *testing.T) {
+	blob := base64.StdEncoding.EncodeToString([]byte("blob"))
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--cosign", blob, keyfmt.SignerKey.Encode(bytes.Repeat([]byte{0x01}, 32))})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("--cosign with positional args must be rejected")
+	}
+}
+
+func TestRevokeSignerFinishRejectsPositionalArgs(t *testing.T) {
+	blob := base64.StdEncoding.EncodeToString([]byte("blob"))
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{"--finish", blob, keyfmt.SignerKey.Encode(bytes.Repeat([]byte{0x01}, 32))})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("--finish with positional args must be rejected")
+	}
+}
+
+func TestRevokeSignerRejectsWrongKeyPrefixOnCompromised(t *testing.T) {
+	badKey := keyfmt.DeviceKey.Encode(bytes.Repeat([]byte{0x01}, 32))
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{badKey})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("a device key passed as compromised signer must be rejected")
+	}
+}
+
+func TestRevokeSignerRejectsWrongKeyPrefixOnReplacement(t *testing.T) {
+	validKey := keyfmt.SignerKey.Encode(bytes.Repeat([]byte{0x01}, 32))
+	badReplacement := keyfmt.DeviceKey.Encode(bytes.Repeat([]byte{0x02}, 32))
+	cmd := newLockRevokeSignerCmd()
+	cmd.SetArgs([]string{validKey, "--replacement", badReplacement})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("a device key passed as --replacement must be rejected")
+	}
+}

--- a/cmd/argus/lock_test.go
+++ b/cmd/argus/lock_test.go
@@ -16,7 +16,7 @@ func TestLockCmdRegistersExpectedSubcommands(t *testing.T) {
 
 	want := []string{
 		"local-disable", "log", "pin", "status", "unpin",
-		"init", "sign", "revoke-device", "add-signer", "remove-signer", "disable",
+		"init", "sign", "revoke-device", "add-signer", "remove-signer", "revoke-signer", "disable",
 	}
 	if len(subs) != len(want) {
 		names := make([]string, len(subs))
@@ -38,12 +38,27 @@ func TestLockCmdRegistersExpectedSubcommands(t *testing.T) {
 			t.Errorf("expected subcommand %q not registered", name)
 		}
 	}
+}
 
-	// revoke-signer (6c ceremony) must not be registered yet.
-	for _, c := range subs {
-		if c.Name() == "revoke-signer" {
-			t.Errorf("ceremony command %q must not be registered until 6c", c.Name())
-		}
+func TestSoleRootGuardDetectsZeroSigners(t *testing.T) {
+	s1 := bytes.Repeat([]byte{0x01}, 32)
+	s2 := bytes.Repeat([]byte{0x02}, 32)
+	s3 := bytes.Repeat([]byte{0x03}, 32)
+
+	if n := signerCountAfterRevoke([][]byte{s1}, [][]byte{s1}); n != 0 {
+		t.Fatalf("sole-root: got %d, want 0", n)
+	}
+	if n := signerCountAfterRevoke([][]byte{s1, s2}, [][]byte{s1}); n != 1 {
+		t.Fatalf("one-of-two: got %d, want 1", n)
+	}
+	if n := signerCountAfterRevoke([][]byte{s1, s2}, [][]byte{s1, s2}); n != 0 {
+		t.Fatalf("both-of-two: got %d, want 0", n)
+	}
+	if n := signerCountAfterRevoke([][]byte{s1, s2}, [][]byte{s3}); n != 2 {
+		t.Fatalf("non-member: got %d, want 2", n)
+	}
+	if n := signerCountAfterRevoke(nil, [][]byte{s1}); n != 0 {
+		t.Fatalf("nil current: got %d, want 0", n)
 	}
 }
 

--- a/docs/guide/locked-mode.md
+++ b/docs/guide/locked-mode.md
@@ -1,0 +1,252 @@
+# Locked Mode
+
+Locked mode lets you cryptographically control which devices and nodes can connect
+to your Argus network. Once enabled, every connection is gated by a trust log — a
+signed append-only chain that records who is allowed. The gateway never sees or
+validates the chain contents; it relays the bytes opaquely so only your nodes and
+clients can read and verify them.
+
+## Quickstart
+
+```sh
+# on the node that will hold the first signer key (list every signer, this one included).
+# without --confirm this only prints what it would create:
+argus lock init sigpub:<this-node> [sigpub:<other-node>...]
+argus lock init --confirm sigpub:<this-node> [sigpub:<other-node>...]
+
+# check the state of this node:
+argus lock status
+
+# authorize another device (node label, or a devpub: key):
+argus lock sign <device>
+
+# view the full trust-log history:
+argus lock log
+```
+
+## Key formats
+
+Everything locked mode asks you to copy between machines is 32 bytes, so each kind
+carries a prefix that says what it is:
+
+| Prefix | What it is | Where it comes from |
+| --- | --- | --- |
+| `sigpub:` | signer key | `argus lock status` on the signing node |
+| `devpub:` | device (identity) key | `argus lock status` on that device |
+| `gen:` | genesis hash — the trust root | `argus lock init`, or `argus lock pin` |
+| `dis:` | disablement secret | `argus lock init`, shown once |
+| `tip:` | current chain tip, for audit | `argus lock status` / `argus lock log` |
+
+Commands reject a value of the wrong kind by name rather than accepting it because
+the length matches, so pasting a genesis hash where a device key belongs fails
+instead of silently authorizing something that does not exist:
+
+```
+$ argus lock sign gen:4f3a9c1e...
+error: device "gen:4f3a9c1e..." : expected a device key (devpub:), got a genesis hash (gen:)
+```
+
+Device commands (`lock sign`, `lock revoke-device`) take either a node label/id or a
+`devpub:` key. Every **signer** input — `lock init`, `lock add-signer`,
+`lock remove-signer`, `lock revoke-signer` and its `--replacement` — takes **only** a
+`sigpub:` key. A label can only become a key by way of the roster the **gateway** serves. At init
+that lets a hostile gateway seat its own key in the genesis; afterwards it lets one
+decide which key you actually added, removed or revoked — revoking "node-b" by name
+could leave the compromised key in place and remove an honest one instead. A key read
+off `argus lock status` on the node itself never passes through the gateway.
+
+`lock init` takes the signer keys as positional arguments, and they are the
+**complete** set the new log will trust — including the key of the node you run it
+on, which must be listed like any other. Nothing is added implicitly, so the command
+you ran is a full record of who can sign in the network it created. `lock init` also does nothing until you pass `--confirm`. On its own it prints the
+signer set, the number of disablement secrets, and the devices it would authorize
+from the gateway's roster — then exits having created nothing. Read that list before
+confirming: those identity keys come from the gateway, and at this point nothing has
+verified them.
+
+Omit your own key and the command refuses, printing it for you to paste back:
+
+```
+$ argus lock init sigpub:8b2d7e05...
+error: this node's own signer key must be listed explicitly:
+  argus lock init sigpub:4f3a9c1e... sigpub:8b2d7e05...
+```
+
+## Key concepts
+
+**Signer key** — each node generates an Ed25519 key (`~/.config/argus/signer.json`
+or the path configured by `signer_path`). The trust log lists which signer pubkeys
+are trusted; entries must be signed by a currently trusted key to be accepted.
+
+**Identity key** — a Curve25519 Noise static key (`client-identity.json`) used to
+open E2E channels. A device must be authorized (its identity pubkey listed in the
+trust log) to pass the locked-mode gate.
+
+**Disablement secret** — a random break-glass credential generated at `lock init`.
+Presenting the secret disables locked mode network-wide without requiring any signer
+key. Store it securely and offline. It does **not** release a quarantined device: a
+device with no pin cannot tell whether the chain carrying the disable entry is the
+real one, so it keeps refusing channels. Recover a quarantined node with
+`argus lock pin` or `argus lock local-disable`, not with `lock disable`.
+
+A disabled log is terminal — it can never be re-enabled. To lock the network again,
+run `argus lock init` once more: it creates a **new** genesis over the disabled one.
+That is a new trust root, so every device pinned to the old one quarantines as soon
+as it sees the new root — the same fail-closed behaviour as a device that has never
+been pinned — and recovers with a single `argus lock pin`. A pin to a disabled chain
+is stale rather than conflicting: it protects nothing, because the chain it names
+authorizes nobody and can never be re-enabled, so `lock pin` replaces it without an
+`unpin`. The machine you run `lock init` on repins both of its roles automatically.
+A device pinned by `lock.genesis` in its config is never repinned for you — edit the
+config there.
+
+Client (TUI) identities are **not** carried into the new genesis: `lock init` only
+authorizes the node identities on the gateway roster. Re-authorize each client with
+`argus lock sign devpub:<identity>` on a signer node, exactly as you did the first
+time. Carrying them forward would re-authorize anything a compromised signer had
+authorized in the old chain.
+
+## Pinning the genesis
+
+The **genesis pin** is a 32-byte hash that tells a device which trust log it belongs to. A device pinned by `lock.genesis` in its config loads that trust root at boot. It then refuses every unauthorized E2E channel, independent of the gateway — the reliable fail-closed posture. A device with no pin refuses channels only after it sees, through the gateway, that the network is locked (see quarantine below). A gateway that withholds the chain can keep an unpinned device from noticing, so pin every device you rely on.
+
+`lock init` pins both roles on the machine it runs on: the node (which created the genesis) and that machine's TUI client, which is a separate role with its own pin file. Every other device — additional nodes and TUI clients — must be pinned separately.
+
+### Pinning a new device
+
+Run on the device you want to pin:
+
+```sh
+argus lock pin
+```
+
+The command connects to the gateway, reads the offered trust-log branches, and shows you the genesis **word fingerprint** — a 24-word BIP39 phrase that encodes the full genesis hash (not a truncated prefix):
+
+```
+genesis offered by this network:
+  gen:4f3a9c1e2d7b06a5f81c3e94d2b0a7c6e5194f8d3a2c7b60e91d48a2e5c3b7d1
+  [omit flavor casino ticket elite odor toss gown gloom dog moment alter buddy perfect boost drip giggle talent spoil coyote refuse bird witness cover]
+
+Compare these words against `argus lock status` on a node you trust.
+Pin this device to it? [y/N]:
+```
+
+Before typing `y`, compare those words against the fingerprint shown by `argus lock status` (the `pin:` line) on a node you already trust — over the phone, in a chat, or any out-of-band channel. The 24 words encode the entire 256-bit genesis hash, so a full match is a full-strength check that you are pinning to the same trust root that node is already enforcing. Note that `pin:` (the genesis fingerprint) and the `fingerprint:` line under `signers` (the signer-set fingerprint) are different hashes. Compare `pin:` against `pin:`.
+
+If you already know the genesis (for example, from `lock init` output), you can pin without a prompt:
+
+```sh
+argus lock pin gen:<hex>
+```
+
+An unpinned device on a locked network enters **quarantine** once it sees an offered genesis chain. It can read the roster and that chain, but refuses all E2E channels until pinned. Quarantine depends on the gateway offering the chain. A hostile gateway can force quarantine by offering a fabricated genesis — which is why you compare the fingerprint out-of-band before accepting. A hostile gateway can also withhold the chain: then the device never quarantines and stays open. Quarantine is therefore best-effort. The reliable, gateway-independent fail-closed boundary is a `lock.genesis` config pin.
+
+`argus lock status` opens with one of three states:
+
+| Headline | Meaning |
+|---|---|
+| `locked mode: not enabled` | this device has no trust log |
+| `locked mode: enforcing` | normal locked operation |
+| `locked mode: disabled network-wide` | break-glass was used; nothing is enforced, permanently |
+
+It reports quarantine for both roles on the machine it runs on:
+
+- `pin: none — QUARANTINED (chain seen: …)` is the **node** on this machine.
+- `client pin: none — QUARANTINED (chain seen: …)` is this machine's **TUI client**.
+- `pin: … — SUPERSEDED: the network now uses …` is a device whose own root was
+  disabled while the network moved to a new one. It refuses all channels until
+  `argus lock pin`.
+
+The two are pinned independently, so one can be quarantined while the other is not.
+
+Pinning recovers a quarantined node live over its local socket — no restart. A quarantined **client** is different: the running TUI process read its pin at startup, so after `argus lock pin` you must restart `argus` for the dashboard to come back. The client has no `local-disable` equivalent either; `lock pin` plus a restart is its only escape.
+
+### What quarantine does *not* prove
+
+Quarantine triggers when a device sees a chain it cannot verify. Detection therefore depends on the gateway actually relaying a chain to that device. A malicious gateway can simply serve no chain to an unpinned device, and that device stays open — it never learns the network is locked. **A device that is not quarantined is not evidence that the network is unlocked.** The only positive assurance is a pin you placed yourself after comparing the fingerprint out-of-band. Pin every device; do not treat "no quarantine warning" as an all-clear.
+
+### Unpinning a device
+
+```sh
+argus lock unpin
+```
+
+This clears the pin and removes the local chain file (a chain from the old genesis can never be used again). A node that had actually synced the chain quarantines immediately — it does not stay open until the next sync tick — and its live channels are dropped, so the documented `unpin` + `pin` rotation never opens a window where any key the gateway introduces is accepted.
+
+`unpin` and `lock local-disable` are independent: neither reads or writes the other's state. Unpinning never lifts a local-disable, and a local-disable never drops the pin.
+
+On a device pinned by `lock.genesis` in its config, `lock pin` refuses to write a different genesis: the config outranks the pin file, so remove `lock.genesis` from the config first.
+
+`lock unpin` is allowed there, and clears only the persisted pin — the device stays pinned to `lock.genesis` and keeps enforcing. The command says so explicitly instead of claiming the device has no trust root.
+
+### Recovering from a genesis pin conflict
+
+If `lock.genesis` in the config and the persisted pin file name **different** genesis hashes, `argus` refuses to start:
+
+```
+genesis pin conflict: lock.genesis is gen:<X> but <path> holds gen:<Y>; run `argus lock unpin` to drop the persisted pin
+```
+
+Run that command on the affected device:
+
+```sh
+argus lock unpin
+```
+
+It clears both roles' persisted pins — the client's directly, and the node's over its socket, or from disk when the node cannot start. The device is left pinned to `lock.genesis` alone, so it never comes back open. If it was `lock.genesis` that was wrong, remove it from the config instead and re-run `argus lock pin`.
+
+## The word-fingerprint backstop
+
+`argus lock status` shows two fingerprints — short sequences of English words.
+Under the `chain` section, the second line of `tip:` is the **tip fingerprint**,
+derived from the chain head that node currently holds:
+
+```
+chain
+  genesis: gen:<hex>
+           [words for genesis]
+  tip:     tip:<hex>
+           [sawdust scenic seabird select shadow skydive solo sugar]
+  length:  4 entries
+```
+
+Under `signers (N)`, `fingerprint:` gives the signer-set fingerprint, which changes
+only when signers are added or revoked.
+
+If you suspect equivocation, compare the **tip fingerprint** (the second line of
+`tip:` in the `chain` section) across all your nodes out-of-band (phone call, chat,
+or another trusted channel). Matching words on all nodes mean they all see the same
+chain state. A mismatch, or an `⚠ equivocation detected` warning in the status
+output, means the gateway may be showing split views and the gateway operator should
+be investigated.
+
+## Signer revocation
+
+If a signer key is compromised you can revoke it via a co-signing ceremony that
+requires the remaining trusted signers to out-vote the compromised one:
+
+```sh
+# start (on the initiating signer node):
+argus lock revoke-signer sigpub:<compromised> --replacement sigpub:<successor>
+
+# co-sign (on another signer node):
+argus lock revoke-signer --cosign <blob>
+
+# finalize (once quorum is reached):
+argus lock revoke-signer --finish <blob>
+```
+
+The ceremony forks the chain from the point just before the revoked signer's
+earliest action. All entries after that fork point are erased, not only the ones
+the revoked signer made. Honest entries from other signers after the fork point
+(device authorizations, signer changes, later revocations) are also erased and
+must be re-created. You need at least 3 signers to out-vote one; with fewer, use
+`argus lock disable <secret>` + reinit as the recovery path.
+
+Only signers trusted at the fork point can initiate or co-sign the ceremony, and
+quorum is measured against that fork-point signer set, not the current one. A
+signer added after the fork point is therefore not eligible. If a newer signer
+must take part, use `--fork-from` to select a later fork point at which that
+signer is already trusted. A later fork point preserves more of the revoked
+signer's entries, so this is a trade-off between full erasure and having enough
+eligible co-signers.

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -99,17 +99,20 @@ const (
 	MethodTasksChanged    = "tasks.changed"    // notification: TasksChanged (server→client)
 	// Locked-mode control: local unix-socket only. remoteDispatch rejects every
 	// lock.* method, so only the CLI (which dials the unix socket) can invoke these.
-	MethodLockInit         = "lock.init"         // request: LockInitParams; result: LockInitResult
-	MethodLockSign         = "lock.sign"         // request: LockDeviceParams; result: LockDeviceResult
-	MethodLockRevoke       = "lock.revoke"       // request: LockDeviceParams; result: LockDeviceResult
-	MethodLockAddSigner    = "lock.addSigner"    // request: LockSignerParams; result: LockDeviceResult
-	MethodLockRemoveSigner = "lock.removeSigner" // request: LockSignerParams; result: LockDeviceResult
-	MethodLockDisable      = "lock.disable"      // request: LockDisableParams; result: LockDisableResult
-	MethodLockPin          = "lock.pin"          // request: LockPinParams; result: nil
-	MethodLockUnpin        = "lock.unpin"        // request: no params; result: nil
-	MethodLockLocalDisable = "lock.localDisable" // request: no params; result: nil
-	MethodLockStatus       = "lock.status"       // request: no params; result: LockStatusResult
-	MethodLockLog          = "lock.log"          // request: no params; result: LockLogResult
+	MethodLockInit               = "lock.init"               // request: LockInitParams; result: LockInitResult
+	MethodLockSign               = "lock.sign"               // request: LockDeviceParams; result: LockDeviceResult
+	MethodLockRevoke             = "lock.revoke"             // request: LockDeviceParams; result: LockDeviceResult
+	MethodLockAddSigner          = "lock.addSigner"          // request: LockSignerParams; result: LockDeviceResult
+	MethodLockRemoveSigner       = "lock.removeSigner"       // request: LockSignerParams; result: LockDeviceResult
+	MethodLockDisable            = "lock.disable"            // request: LockDisableParams; result: LockDisableResult
+	MethodLockPin                = "lock.pin"                // request: LockPinParams; result: nil
+	MethodLockUnpin              = "lock.unpin"              // request: no params; result: nil
+	MethodLockLocalDisable       = "lock.localDisable"       // request: no params; result: nil
+	MethodLockStatus             = "lock.status"             // request: no params; result: LockStatusResult
+	MethodLockLog                = "lock.log"                // request: no params; result: LockLogResult
+	MethodLockRevokeSignerStart  = "lock.revokeSignerStart"  // request: LockRevokeSignerStartParams; result: LockRevokeSignerBlobResult
+	MethodLockRevokeSignerCosign = "lock.revokeSignerCosign" // request: LockRevokeSignerCosignParams; result: LockRevokeSignerBlobResult
+	MethodLockRevokeSignerFinish = "lock.revokeSignerFinish" // request: LockRevokeSignerFinishParams; result: LockRevokeSignerFinishResult
 )
 
 // ChangedFile is one entry in a session working directory's git status.
@@ -714,6 +717,32 @@ type LockDisableParams struct {
 type LockDisableResult struct {
 	Tip      []byte `json:"tip"`
 	Disabled bool   `json:"disabled"`
+}
+
+// Revoked is the list of signer pubkeys to revoke (required, non-empty).
+// Replaces is an optional list of replacement signer pubkeys added atomically.
+// ForkFrom overrides the fork-point hash; nil = auto-select (parent of the revoked
+// signer's earliest action, erasing it from the chain).
+type LockRevokeSignerStartParams struct {
+	Revoked  [][]byte `json:"revoked"`
+	Replaces [][]byte `json:"replaces,omitempty"`
+	ForkFrom []byte   `json:"fork_from,omitempty"`
+}
+
+type LockRevokeSignerBlobResult struct {
+	Blob []byte `json:"blob"`
+}
+
+type LockRevokeSignerCosignParams struct {
+	Blob []byte `json:"blob"`
+}
+
+type LockRevokeSignerFinishParams struct {
+	Blob []byte `json:"blob"`
+}
+
+type LockRevokeSignerFinishResult struct {
+	Tip []byte `json:"tip"`
 }
 
 // LockPinParams pins a node to a trust-log genesis hash.

--- a/internal/e2etest/lock_revokesigner_e2e_test.go
+++ b/internal/e2etest/lock_revokesigner_e2e_test.go
@@ -1,0 +1,184 @@
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+func TestLockRevokeSigner(t *testing.T) {
+	skA, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner A: %v", err)
+	}
+	skB, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner B: %v", err)
+	}
+	skC, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner C: %v", err)
+	}
+	skD, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner D: %v", err)
+	}
+
+	tlog, err := trustlog.NewGenesis([][]byte{skA.Public, skB.Public, skC.Public}, skA, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+
+	// C authorizes a device before the ceremony. The revoke-signer fork point is set
+	// before C's first action, so this authorization is erased after the ceremony.
+	cDevice := bytes.Repeat([]byte{0xCC}, 32)
+	if err := tlog.AuthorizeDevice(cDevice, skC); err != nil {
+		t.Fatalf("AuthorizeDevice by C: %v", err)
+	}
+	chain := trustlog.MarshalChain(tlog.Entries())
+
+	// dir is the outer TempDir whose path is short enough for macOS's 104-byte
+	// sockaddr_un limit.
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startNode := func(label, sockName string, sk trustlog.SignerKey) (sockPath string, lc *api.Client) {
+		t.Helper()
+		chainPath := filepath.Join(t.TempDir(), "chain-"+label)
+		if err := os.WriteFile(chainPath, chain, 0o600); err != nil {
+			t.Fatalf("write chain %s: %v", label, err)
+		}
+		n := node.New()
+		n.SetIdentity("rs-"+label, "RS "+label)
+		n.SetVersion("itest")
+		n.SetSignerKey(sk)
+		if err := n.EnableTrustLog(genesisHash, chainPath); err != nil {
+			t.Fatalf("EnableTrustLog %s: %v", label, err)
+		}
+		sock := filepath.Join(dir, sockName+".sock")
+		sockCtx, sockCancel := context.WithCancel(ctx)
+		done := make(chan error, 1)
+		go func() { done <- n.Run(sockCtx, sock) }()
+		t.Cleanup(func() { sockCancel(); <-done })
+		waitFor(t, label+" socket ready", func() bool {
+			_, err := os.Stat(sock)
+			return err == nil
+		})
+		c, err := api.Dial(sock)
+		if err != nil {
+			t.Fatalf("dial %s socket: %v", label, err)
+		}
+		t.Cleanup(func() { c.Close() })
+		return sock, c
+	}
+
+	_, lcA := startNode("A", "a", skA)
+	_, lcB := startNode("B", "b", skB)
+
+	var stBefore api.LockStatusResult
+	if err := lcA.Call(api.MethodLockStatus, nil, &stBefore); err != nil {
+		t.Fatalf("lock.status before ceremony: %v", err)
+	}
+	if !stBefore.Enabled {
+		t.Fatal("lock must be enabled on node A before ceremony")
+	}
+	if !stBefore.SignerTrusted {
+		t.Fatal("signer A must be trusted before ceremony")
+	}
+	signerSet := func(status api.LockStatusResult) map[string]bool {
+		m := make(map[string]bool, len(status.Signers))
+		for _, s := range status.Signers {
+			m[string(s)] = true
+		}
+		return m
+	}
+	before := signerSet(stBefore)
+	if !before[string(skC.Public)] {
+		t.Fatal("C must be trusted before ceremony")
+	}
+
+	var startRes api.LockRevokeSignerBlobResult
+	if err := lcA.Call(api.MethodLockRevokeSignerStart, api.LockRevokeSignerStartParams{
+		Revoked:  [][]byte{skC.Public},
+		Replaces: [][]byte{skD.Public},
+	}, &startRes); err != nil {
+		t.Fatalf("revokeSignerStart (A): %v", err)
+	}
+	if len(startRes.Blob) == 0 {
+		t.Fatal("start: blob must not be empty")
+	}
+
+	// 1 co-sign is not enough to out-vote 1 revoked signer.
+	pr1, err := trustlog.UnmarshalPendingRevoke(startRes.Blob)
+	if err != nil {
+		t.Fatalf("UnmarshalPendingRevoke blob1: %v", err)
+	}
+	if trustlog.Complete(pr1, tlog) {
+		t.Fatal("quorum must not be reached after 1 co-sign (need > 1 to out-vote 1 revoked)")
+	}
+
+	var cosignRes api.LockRevokeSignerBlobResult
+	if err := lcB.Call(api.MethodLockRevokeSignerCosign, api.LockRevokeSignerCosignParams{
+		Blob: startRes.Blob,
+	}, &cosignRes); err != nil {
+		t.Fatalf("revokeSignerCosign (B): %v", err)
+	}
+	if len(cosignRes.Blob) == 0 {
+		t.Fatal("cosign: blob must not be empty")
+	}
+
+	// 2 co-signs out-vote 1 revoked signer.
+	pr2, err := trustlog.UnmarshalPendingRevoke(cosignRes.Blob)
+	if err != nil {
+		t.Fatalf("UnmarshalPendingRevoke blob2: %v", err)
+	}
+	if !trustlog.Complete(pr2, tlog) {
+		t.Fatal("quorum must be reached with 2 co-signs for 1 revoked signer")
+	}
+
+	var finishRes api.LockRevokeSignerFinishResult
+	if err := lcA.Call(api.MethodLockRevokeSignerFinish, api.LockRevokeSignerFinishParams{
+		Blob: cosignRes.Blob,
+	}, &finishRes); err != nil {
+		t.Fatalf("revokeSignerFinish (A): %v", err)
+	}
+	if len(finishRes.Tip) == 0 {
+		t.Fatal("finish: tip must not be empty")
+	}
+
+	var stAfter api.LockStatusResult
+	if err := lcA.Call(api.MethodLockStatus, nil, &stAfter); err != nil {
+		t.Fatalf("lock.status after ceremony: %v", err)
+	}
+	after := signerSet(stAfter)
+	if after[string(skC.Public)] {
+		t.Error("C must not be trusted after revoke-signer ceremony")
+	}
+	if !after[string(skD.Public)] {
+		t.Error("replacement D must be trusted after ceremony")
+	}
+	if !after[string(skA.Public)] {
+		t.Error("A must remain trusted after ceremony")
+	}
+	if !after[string(skB.Public)] {
+		t.Error("B must remain trusted after ceremony")
+	}
+
+	// C's device was authorized by C before the fork point; the fork erases that action.
+	authorizedDevices := make(map[string]bool, len(stAfter.Devices))
+	for _, d := range stAfter.Devices {
+		authorizedDevices[string(d)] = true
+	}
+	if authorizedDevices[string(cDevice)] {
+		t.Error("C's device must not be authorized after fork erased C's action")
+	}
+}

--- a/internal/node/handlers.go
+++ b/internal/node/handlers.go
@@ -55,4 +55,7 @@ func (d *Node) registerHandlers(srv *api.Server) {
 	srv.Handle(api.MethodLockLocalDisable, d.handleLockLocalDisable)
 	srv.Handle(api.MethodLockStatus, d.handleLockStatus)
 	srv.Handle(api.MethodLockLog, d.handleLockLog)
+	srv.Handle(api.MethodLockRevokeSignerStart, d.handleLockRevokeSignerStart)
+	srv.Handle(api.MethodLockRevokeSignerCosign, d.handleLockRevokeSignerCosign)
+	srv.Handle(api.MethodLockRevokeSignerFinish, d.handleLockRevokeSignerFinish)
 }

--- a/internal/node/handlers_lock.go
+++ b/internal/node/handlers_lock.go
@@ -298,6 +298,125 @@ func (d *Node) handleLockLocalDisable(_ context.Context, _ json.RawMessage) (any
 	return nil, nil
 }
 
+func (d *Node) handleLockRevokeSignerStart(_ context.Context, params json.RawMessage) (any, error) {
+	st := d.trust.Load()
+	if st == nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "locked mode not enabled"}
+	}
+	if len(d.signer.Private) != ed25519.PrivateKeySize {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "node has no signer key"}
+	}
+	if !st.SignerTrusted(d.signer.Public) {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "this node is not a trusted signer; run on a signer node"}
+	}
+	p, err := api.Decode[api.LockRevokeSignerStartParams](params)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "invalid params: " + err.Error()}
+	}
+	if len(p.Revoked) == 0 {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "revoked must be non-empty"}
+	}
+	_, log, err := loadCurrentLog(st)
+	if err != nil {
+		return nil, err
+	}
+	pr, err := trustlog.StartRevoke(log, p.Revoked, p.Replaces, p.ForkFrom, d.signer)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "start revoke: " + err.Error()}
+	}
+	return api.LockRevokeSignerBlobResult{Blob: pr.Marshal()}, nil
+}
+
+func (d *Node) handleLockRevokeSignerCosign(_ context.Context, params json.RawMessage) (any, error) {
+	st := d.trust.Load()
+	if st == nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "locked mode not enabled"}
+	}
+	if len(d.signer.Private) != ed25519.PrivateKeySize {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "node has no signer key"}
+	}
+	if !st.SignerTrusted(d.signer.Public) {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "this node is not a trusted signer; run on a signer node"}
+	}
+	p, err := api.Decode[api.LockRevokeSignerCosignParams](params)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "invalid params: " + err.Error()}
+	}
+	pr, err := trustlog.UnmarshalPendingRevoke(p.Blob)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "invalid blob: " + err.Error()}
+	}
+	_, log, err := loadCurrentLog(st)
+	if err != nil {
+		return nil, err
+	}
+	pr, err = trustlog.AddCoSign(pr, log, d.signer)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "cosign: " + err.Error()}
+	}
+	return api.LockRevokeSignerBlobResult{Blob: pr.Marshal()}, nil
+}
+
+func (d *Node) handleLockRevokeSignerFinish(_ context.Context, params json.RawMessage) (any, error) {
+	st := d.trust.Load()
+	if st == nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "locked mode not enabled"}
+	}
+	if len(d.signer.Private) != ed25519.PrivateKeySize {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "node has no signer key"}
+	}
+	if !st.SignerTrusted(d.signer.Public) {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "this node is not a trusted signer; run on a signer node"}
+	}
+	p, err := api.Decode[api.LockRevokeSignerFinishParams](params)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "invalid params: " + err.Error()}
+	}
+	pr, err := trustlog.UnmarshalPendingRevoke(p.Blob)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "invalid blob: " + err.Error()}
+	}
+	entries, log, err := loadCurrentLog(st)
+	if err != nil {
+		return nil, err
+	}
+	if !trustlog.Complete(pr, log) {
+		return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "co-sign quorum not yet reached; collect more co-signs"}
+	}
+	newChain, err := trustlog.BuildRevokeChain(pr, entries)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInternalError, Message: "build revoke chain: " + err.Error()}
+	}
+	changed, err := st.Ingest(newChain)
+	if err != nil {
+		return nil, &api.RPCError{Code: api.CodeInternalError, Message: "ingest: " + err.Error()}
+	}
+	// Ingest adopts the chain only if it wins fork-choice. If a revoked signer is
+	// still trusted, the finalized revoke lost fork-choice (e.g. an overlapping
+	// ceremony) and the compromised key is NOT gone — fail rather than report a
+	// false success.
+	if firstStillTrusted(st.SignerTrusted, pr.Revoked()) != nil {
+		return nil, &api.RPCError{Code: api.CodeInternalError, Message: "revocation did not take effect (finalized chain lost fork-choice); re-run --finish"}
+	}
+	if changed {
+		if werr := d.persistTrust(); werr != nil {
+			d.log.Warn("persisting trust-log chain failed", "path", d.trustPath, "err", werr)
+		}
+		d.reevaluateTrustChannels()
+		d.announceTrustChange()
+	}
+	return api.LockRevokeSignerFinishResult{Tip: st.Tip()}, nil
+}
+
+func firstStillTrusted(trusted func(pub []byte) bool, revoked [][]byte) []byte {
+	for _, k := range revoked {
+		if trusted(k) {
+			return k
+		}
+	}
+	return nil
+}
+
 func (d *Node) handleLockStatus(_ context.Context, _ json.RawMessage) (any, error) {
 	signerPub := d.SignerPublic()
 	res := api.LockStatusResult{

--- a/internal/node/handlers_lock_test.go
+++ b/internal/node/handlers_lock_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -576,4 +577,337 @@ func TestSetSignerKey(t *testing.T) {
 		t.Error("SignerPubKey must be non-empty after SetSignerKey")
 	}
 	_ = os.RemoveAll(t.TempDir())
+}
+
+func mustGenSigner(t *testing.T) trustlog.SignerKey {
+	t.Helper()
+	sk, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	return sk
+}
+
+func newRevokeSignerNode(t *testing.T, sk trustlog.SignerKey, genesisHash, chain []byte) *Node {
+	t.Helper()
+	d := New()
+	d.SetSignerKey(sk)
+	d.trustPath = filepath.Join(t.TempDir(), "trustlog-chain")
+	st := trustlog.NewSyncStore(genesisHash)
+	if _, err := st.Ingest(chain); err != nil {
+		t.Fatalf("newRevokeSignerNode Ingest: %v", err)
+	}
+	d.trust.Store(st)
+	return d
+}
+
+func callRevokeSignerStart(t *testing.T, d *Node, p api.LockRevokeSignerStartParams) (api.LockRevokeSignerBlobResult, error) {
+	t.Helper()
+	raw, _ := json.Marshal(p)
+	res, err := d.handleLockRevokeSignerStart(context.Background(), raw)
+	if err != nil {
+		return api.LockRevokeSignerBlobResult{}, err
+	}
+	return res.(api.LockRevokeSignerBlobResult), nil
+}
+
+func callRevokeSignerCosign(t *testing.T, d *Node, blob []byte) (api.LockRevokeSignerBlobResult, error) {
+	t.Helper()
+	raw, _ := json.Marshal(api.LockRevokeSignerCosignParams{Blob: blob})
+	res, err := d.handleLockRevokeSignerCosign(context.Background(), raw)
+	if err != nil {
+		return api.LockRevokeSignerBlobResult{}, err
+	}
+	return res.(api.LockRevokeSignerBlobResult), nil
+}
+
+func callRevokeSignerFinish(t *testing.T, d *Node, blob []byte) (api.LockRevokeSignerFinishResult, error) {
+	t.Helper()
+	raw, _ := json.Marshal(api.LockRevokeSignerFinishParams{Blob: blob})
+	res, err := d.handleLockRevokeSignerFinish(context.Background(), raw)
+	if err != nil {
+		return api.LockRevokeSignerFinishResult{}, err
+	}
+	return res.(api.LockRevokeSignerFinishResult), nil
+}
+
+func TestHandleRevokeSignerCeremony(t *testing.T) {
+	skA, skB, skC, skD := mustGenSigner(t), mustGenSigner(t), mustGenSigner(t), mustGenSigner(t)
+
+	tlog, err := trustlog.NewGenesis([][]byte{skA.Public, skB.Public, skC.Public}, skA, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+
+	// C authorizes a device; the fork will erase this action.
+	cDevice := bytes.Repeat([]byte{0xCC}, 32)
+	if err := tlog.AuthorizeDevice(cDevice, skC); err != nil {
+		t.Fatalf("AuthorizeDevice by C: %v", err)
+	}
+	chain := trustlog.MarshalChain(tlog.Entries())
+
+	dA := newRevokeSignerNode(t, skA, genesisHash, chain)
+	dB := newRevokeSignerNode(t, skB, genesisHash, chain)
+
+	if !dA.TrustStore().SignerTrusted(skC.Public) {
+		t.Fatal("setup: C must be initially trusted")
+	}
+	if !dA.TrustStore().DeviceAuthorized(cDevice) {
+		t.Fatal("setup: C's device must be initially authorized")
+	}
+
+	startRes, err := callRevokeSignerStart(t, dA, api.LockRevokeSignerStartParams{
+		Revoked:  [][]byte{skC.Public},
+		Replaces: [][]byte{skD.Public},
+	})
+	if err != nil {
+		t.Fatalf("revokeSignerStart: %v", err)
+	}
+	blob1 := startRes.Blob
+	if len(blob1) == 0 {
+		t.Fatal("start: blob must not be empty")
+	}
+
+	// 1 co-sign (A) for 1 revoked (C) is not yet complete.
+	pr, err := trustlog.UnmarshalPendingRevoke(blob1)
+	if err != nil {
+		t.Fatalf("blob1 is not a valid PendingRevoke: %v", err)
+	}
+	if trustlog.Complete(pr, tlog) {
+		t.Fatal("should not be complete after only 1 co-sign")
+	}
+
+	cosignRes, err := callRevokeSignerCosign(t, dB, blob1)
+	if err != nil {
+		t.Fatalf("revokeSignerCosign: %v", err)
+	}
+	blob2 := cosignRes.Blob
+
+	pr2, err := trustlog.UnmarshalPendingRevoke(blob2)
+	if err != nil {
+		t.Fatalf("blob2 is not a valid PendingRevoke: %v", err)
+	}
+	if !trustlog.Complete(pr2, tlog) {
+		t.Fatal("should be complete with 2 co-signs for 1 revoked signer")
+	}
+
+	finishRes, err := callRevokeSignerFinish(t, dA, blob2)
+	if err != nil {
+		t.Fatalf("revokeSignerFinish: %v", err)
+	}
+	if len(finishRes.Tip) == 0 {
+		t.Fatal("finish: tip must not be empty")
+	}
+
+	st := dA.TrustStore()
+	if st.SignerTrusted(skC.Public) {
+		t.Error("C must be revoked after ceremony")
+	}
+	if !st.SignerTrusted(skD.Public) {
+		t.Error("replacement D must be trusted after ceremony")
+	}
+	if !st.SignerTrusted(skA.Public) {
+		t.Error("A must remain trusted")
+	}
+	if !st.SignerTrusted(skB.Public) {
+		t.Error("B must remain trusted")
+	}
+	if st.DeviceAuthorized(cDevice) {
+		t.Error("C's device must be revoked after fork erased C's action")
+	}
+}
+
+func TestHandleRevokeSignerFinishRejectsIncomplete(t *testing.T) {
+	skA, skB, skC := mustGenSigner(t), mustGenSigner(t), mustGenSigner(t)
+	tlog, err := trustlog.NewGenesis([][]byte{skA.Public, skB.Public, skC.Public}, skA, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+	chain := trustlog.MarshalChain(tlog.Entries())
+	dA := newRevokeSignerNode(t, skA, genesisHash, chain)
+
+	startRes, err := callRevokeSignerStart(t, dA, api.LockRevokeSignerStartParams{
+		Revoked: [][]byte{skC.Public},
+	})
+	if err != nil {
+		t.Fatalf("revokeSignerStart: %v", err)
+	}
+
+	// Only 1 co-sign for 1 revoked signer — quorum not reached.
+	if _, err := callRevokeSignerFinish(t, dA, startRes.Blob); err == nil {
+		t.Fatal("finish with incomplete blob must return an error")
+	}
+}
+
+// The finish sub-case uses a QUORUM-COMPLETE blob to prove the SignerTrusted guard
+// (not the quorum guard) is what blocks an untrusted node from finalizing.
+func TestHandleRevokeSignerUntrustedSignerRefused(t *testing.T) {
+	skA, skB, skExtra := mustGenSigner(t), mustGenSigner(t), mustGenSigner(t)
+	skOther := mustGenSigner(t) // not in genesis
+
+	tlog, err := trustlog.NewGenesis([][]byte{skA.Public, skB.Public, skExtra.Public}, skA, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+	chain := trustlog.MarshalChain(tlog.Entries())
+
+	dBad := newRevokeSignerNode(t, skOther, genesisHash, chain)
+
+	_, err = callRevokeSignerStart(t, dBad, api.LockRevokeSignerStartParams{
+		Revoked: [][]byte{skExtra.Public},
+	})
+	if err == nil {
+		t.Fatal("start by untrusted signer must be refused")
+	}
+	var rpcErr *api.RPCError
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeInvalidRequest {
+		t.Errorf("want CodeInvalidRequest for untrusted start, got %v", err)
+	}
+
+	// Build a quorum-complete blob (2 co-signs > 1 revoked).
+	dA := newRevokeSignerNode(t, skA, genesisHash, chain)
+	dB := newRevokeSignerNode(t, skB, genesisHash, chain)
+	startRes, err := callRevokeSignerStart(t, dA, api.LockRevokeSignerStartParams{
+		Revoked: [][]byte{skExtra.Public},
+	})
+	if err != nil {
+		t.Fatalf("start by A: %v", err)
+	}
+	cosignRes, err := callRevokeSignerCosign(t, dB, startRes.Blob)
+	if err != nil {
+		t.Fatalf("cosign by B: %v", err)
+	}
+	completeBlob := cosignRes.Blob
+
+	pr, err := trustlog.UnmarshalPendingRevoke(completeBlob)
+	if err != nil {
+		t.Fatalf("UnmarshalPendingRevoke: %v", err)
+	}
+	if !trustlog.Complete(pr, tlog) {
+		t.Fatal("blob must be quorum-complete before testing untrusted finish")
+	}
+
+	// Cosign must be refused for dBad (SignerTrusted guard fires before cosign logic).
+	_, err = callRevokeSignerCosign(t, dBad, startRes.Blob)
+	if err == nil {
+		t.Fatal("cosign by untrusted signer must be refused")
+	}
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeInvalidRequest {
+		t.Errorf("want CodeInvalidRequest for untrusted cosign, got %v", err)
+	}
+
+	// Finish must be refused for dBad even with a QUORUM-COMPLETE blob —
+	// SignerTrusted fires first, before the quorum check.
+	_, err = callRevokeSignerFinish(t, dBad, completeBlob)
+	if err == nil {
+		t.Fatal("finish by untrusted signer must be refused even with a quorum-complete blob")
+	}
+	if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeInvalidRequest {
+		t.Errorf("want CodeInvalidRequest for untrusted finish, got %v", err)
+	}
+}
+
+func TestHandleRevokeSignerNoSignerKey(t *testing.T) {
+	skA := mustGenSigner(t)
+	tlog, err := trustlog.NewGenesis([][]byte{skA.Public}, skA, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := tlog.Tip()
+	chain := trustlog.MarshalChain(tlog.Entries())
+
+	// d has no signer key set (signer stays zero-value).
+	d := New()
+	d.trustPath = filepath.Join(t.TempDir(), "trustlog-chain")
+	st := trustlog.NewSyncStore(genesisHash)
+	if _, err := st.Ingest(chain); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	d.trust.Store(st)
+
+	fakeBlob := bytes.Repeat([]byte{0x01}, 32) // not a valid blob, but guard fires first
+
+	checkNoSignerKey := func(name string, fn func() error) {
+		t.Helper()
+		err := fn()
+		if err == nil {
+			t.Fatalf("%s: expected error with no signer key", name)
+		}
+		var rpcErr *api.RPCError
+		if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeInvalidRequest {
+			t.Errorf("%s: want CodeInvalidRequest, got %v", name, err)
+		}
+	}
+
+	checkNoSignerKey("start", func() error {
+		raw, _ := json.Marshal(api.LockRevokeSignerStartParams{Revoked: [][]byte{skA.Public}})
+		_, err := d.handleLockRevokeSignerStart(context.Background(), raw)
+		return err
+	})
+	checkNoSignerKey("cosign", func() error {
+		raw, _ := json.Marshal(api.LockRevokeSignerCosignParams{Blob: fakeBlob})
+		_, err := d.handleLockRevokeSignerCosign(context.Background(), raw)
+		return err
+	})
+	checkNoSignerKey("finish", func() error {
+		raw, _ := json.Marshal(api.LockRevokeSignerFinishParams{Blob: fakeBlob})
+		_, err := d.handleLockRevokeSignerFinish(context.Background(), raw)
+		return err
+	})
+}
+
+func TestHandleRevokeSignerRequiresLocked(t *testing.T) {
+	d, _ := newSignerLockNode(t) // signer set, no trust store
+	fakeBlob := bytes.Repeat([]byte{0x01}, 32)
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"start", func() error {
+			raw, _ := json.Marshal(api.LockRevokeSignerStartParams{Revoked: [][]byte{fakeBlob}})
+			_, err := d.handleLockRevokeSignerStart(context.Background(), raw)
+			return err
+		}},
+		{"cosign", func() error {
+			raw, _ := json.Marshal(api.LockRevokeSignerCosignParams{Blob: fakeBlob})
+			_, err := d.handleLockRevokeSignerCosign(context.Background(), raw)
+			return err
+		}},
+		{"finish", func() error {
+			raw, _ := json.Marshal(api.LockRevokeSignerFinishParams{Blob: fakeBlob})
+			_, err := d.handleLockRevokeSignerFinish(context.Background(), raw)
+			return err
+		}},
+	}
+	for _, c := range cases {
+		err := c.fn()
+		if err == nil {
+			t.Fatalf("%s: expected error when locked mode not enabled", c.name)
+		}
+		var rpcErr *api.RPCError
+		if !asRPCError(err, &rpcErr) || rpcErr.Code != api.CodeInvalidRequest {
+			t.Errorf("%s: want CodeInvalidRequest, got %v", c.name, err)
+		}
+	}
+}
+
+func TestFirstStillTrusted(t *testing.T) {
+	a := []byte("signer-A")
+	b := []byte("signer-B")
+	onlyATrusted := func(pub []byte) bool { return bytes.Equal(pub, a) }
+
+	// A revoked key that is gone from the signer set means the revocation took
+	// effect: no key is still trusted.
+	if got := firstStillTrusted(onlyATrusted, [][]byte{b}); got != nil {
+		t.Errorf("revoked-and-gone key reported still trusted: %x", got)
+	}
+	// A revoked key still in the signer set means the finalized chain lost
+	// fork-choice: the handler must not report success.
+	if got := firstStillTrusted(onlyATrusted, [][]byte{b, a}); !bytes.Equal(got, a) {
+		t.Errorf("still-trusted revoked key = %x, want %x", got, a)
+	}
 }

--- a/internal/trustlog/cosign.go
+++ b/internal/trustlog/cosign.go
@@ -18,6 +18,8 @@ type PendingRevoke struct {
 // ForkPoint returns the fork-point hash (the Prev that the finalized entry will carry).
 func (pr PendingRevoke) ForkPoint() []byte { return cloneBytes(pr.partial.Prev) }
 
+func (pr PendingRevoke) Revoked() [][]byte { return cloneSigners(pr.partial.Signers) }
+
 // Marshal encodes pr to a bounded wire blob using the existing entry codec. The blob
 // is bounded by the same DoS caps as the chain codec (maxCoSigns, maxReplaces, etc.).
 func (pr PendingRevoke) Marshal() []byte { return MarshalEntry(pr.partial) }


### PR DESCRIPTION
## PR 6c — revoke-signer co-signing ceremony + docs

Completes the `lock` CLI (12 commands). Adds the three-phase `revoke-signer`
co-signing ceremony so a compromised signer can be out-voted by the remaining
trusted signers (needs ≥3 signers to out-vote one). Wires the ceremony crypto
already present in `internal/trustlog/cosign.go` (PR 2) — no reimplementation.

### Changes
- **Node handlers** (`internal/node/handlers_lock.go`): `revokeSignerStart` /
  `revokeSignerCosign` / `revokeSignerFinish`. Each guards a present signer key
  and `SignerTrusted` before any `ed25519.Sign`. `finish` verifies
  `trustlog.Complete` (quorum) before `BuildRevokeChain`/ingest — quorum is
  unbypassable, and `Ingest` re-validates the co-signs.
- **api** (`internal/api/protocol.go`): additive `lock.revokeSigner{Start,Cosign,Finish}`
  methods + params/results.
- **CLI** (`cmd/argus/lock.go`): `argus lock revoke-signer` with three
  mutually-exclusive modes (start / `--cosign` / `--finish`); ≥3-signer warning.
- **Docs**: `docs/guide/locked-mode.md` (canonical locked-mode guide).
- **Integration test**: 3-signer ceremony over local sockets proving quorum
  progression (not complete at 1 co-sign, complete at 2), signer removal, and
  replacement trust.

### Compatibility
`lock.*` stays local-socket only (6a's `remoteDispatch` filter). Default
(e2ee off / no genesis) path unchanged.

Stacked on #42 (`pr/06b-signer-signing`).