### PR TITLE
PR 7 — fail-closed node lock (was: anti-equivocation beacons)

### DIFF
--- a/docs/guide/locked-mode.md
+++ b/docs/guide/locked-mode.md
@@ -195,6 +195,34 @@ argus lock unpin
 
 It clears both roles' persisted pins — the client's directly, and the node's over its socket, or from disk when the node cannot start. The device is left pinned to `lock.genesis` alone, so it never comes back open. If it was `lock.genesis` that was wrong, remove it from the config instead and re-run `argus lock pin`.
 
+## Anti-equivocation: authenticated tip cross-check
+
+A malicious or compromised gateway can try to show different nodes or clients
+different branches of the trust log. This is a "split-view" or equivocation attack.
+The client detects it by reading each node's tip over a channel the gateway cannot
+forge.
+
+1. **Authenticated tip source.** Each node reports its current trust-log tip through
+   the `node.identify` RPC. The client reads this tip over the node's authenticated
+   Noise channel, bound to the handshake identity. The gateway roster also carries
+   node data, but the roster is forgeable, so the equivocation check never uses it.
+
+2. **Tip refresh.** On each trust-sync tick, `refreshAuthTips` re-reads every
+   connected node's tip over that authenticated channel. A node that does not answer
+   keeps its previously-known tip. The gateway can drop or delay these RPCs, which
+   delays detection, but it cannot forge a tip, because it cannot complete the Noise
+   handshake as that node.
+
+3. **Consistency check.** `checkTipConsistency` compares each authenticated tip
+   against the client's resolved linear chain. A tip that is absent from the chain
+   and persists for `tipMissThreshold` consecutive ticks is flagged as equivocation.
+   Propagation lag reconciles on the next pull and resets the miss streak, so a
+   single missed tick does not flag. Tips from offline nodes are skipped.
+
+4. **Detection response.** The equivocation flag surfaces in `lock status`.
+   Fork-choice already prevents a node from adopting a bad branch. This layer exposes
+   a gateway that is hiding branches.
+
 ## The word-fingerprint backstop
 
 `argus lock status` shows two fingerprints — short sequences of English words.

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -651,8 +651,12 @@ type NodeDescriptor struct {
 	Version        string           `json:"version"`
 	Capabilities   NodeCapabilities `json:"capabilities"`
 	IdentityPubKey string           `json:"identity_pubkey,omitempty"`
-	SignerPubKey   string           `json:"signer_pubkey,omitempty"`
-	Online         bool             `json:"online"`
+	// SignerPubKey is served by the untrusted gateway roster and is therefore
+	// gateway-forgeable. Use it for discovery only (e.g. picking a signer to add).
+	// Any trust or enforcement decision must read the signer key from the
+	// authenticated node.identify reply, never from this roster copy.
+	SignerPubKey string `json:"signer_pubkey,omitempty"`
+	Online       bool   `json:"online"`
 }
 
 type NodesListResult struct {

--- a/internal/e2etest/lock_integration_test.go
+++ b/internal/e2etest/lock_integration_test.go
@@ -1,0 +1,101 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/node"
+)
+
+// macOS caps sockaddr_un.sun_path at 104 bytes; t.TempDir() embeds the full
+// test name, which exceeds that limit for names longer than ~32 characters.
+func sockDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "tq")
+	if err != nil {
+		t.Fatalf("sockDir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("sockDir cleanup: %v", err)
+		}
+	})
+	return dir
+}
+
+func startLockNode(t *testing.T, ctx context.Context, id, gwURL, socketPath, chainPath string) *node.Node {
+	t.Helper()
+	n := node.New()
+	n.SetIdentity(id, id)
+	n.SetVersion("itest")
+	kp, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("identity keypair: %v", err)
+	}
+	n.SetIdentityKey(kp)
+	n.SetE2EE(true)
+	signerDir, err := os.MkdirTemp("", "tqs")
+	if err != nil {
+		t.Fatalf("signer dir: %v", err)
+	}
+	sk, err := node.LoadOrCreateSigner(filepath.Join(signerDir, "signer-key.json"))
+	if err != nil {
+		_ = os.RemoveAll(signerDir)
+		t.Fatalf("signer keypair: %v", err)
+	}
+	n.SetSignerKey(sk)
+	n.SetTrustChainPath(chainPath)
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		_ = n.Run(ctx, socketPath)
+	}()
+	t.Cleanup(func() {
+		<-runDone
+		if err := os.RemoveAll(signerDir); err != nil {
+			t.Errorf("signer dir cleanup: %v", err)
+		}
+	})
+	go n.ConnectGateway(ctx, wsURL(gwURL, "/node"), "", nil)
+	return n
+}
+
+func resolveSignersForTest(nodes []api.NodeDescriptor, ids ...string) ([][]byte, error) {
+	want := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		want[id] = true
+	}
+	var out [][]byte
+	for _, nd := range nodes {
+		if !want[nd.ID] || nd.SignerPubKey == "" {
+			continue
+		}
+		b, err := base64.StdEncoding.DecodeString(nd.SignerPubKey)
+		if err != nil {
+			return nil, fmt.Errorf("node %s: bad signer key: %w", nd.ID, err)
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+func gatherDevicesForTest(nodes []api.NodeDescriptor) [][]byte {
+	var out [][]byte
+	for _, nd := range nodes {
+		if nd.IdentityPubKey == "" {
+			continue
+		}
+		b, err := base64.StdEncoding.DecodeString(nd.IdentityPubKey)
+		if err != nil || len(b) != 32 {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}

--- a/internal/node/handlers_session.go
+++ b/internal/node/handlers_session.go
@@ -29,7 +29,7 @@ func (d *Node) handleSessionsList(context.Context, json.RawMessage) (any, error)
 
 // handleNodeIdentify announces this node's identity over the gateway uplink.
 func (d *Node) handleNodeIdentify(context.Context, json.RawMessage) (any, error) {
-	res := api.IdentifyResult{ID: d.id, Label: d.label, Version: d.version, Capabilities: d.caps, IdentityPubKey: d.identityPubB64}
+	res := api.IdentifyResult{ID: d.id, Label: d.label, Version: d.version, Capabilities: d.caps, IdentityPubKey: d.identityPubB64, SignerPubKey: d.signerPubB64}
 	if st := d.trust.Load(); st != nil {
 		res.Tip = st.Tip()
 	}


### PR DESCRIPTION
## PR 7 — fail-closed node lock (formerly: anti-equivocation beacons)

**This PR was repurposed.** It originally added the node-side signed-beacon
anti-equivocation subsystem. That subsystem has been removed stack-wide and
replaced by an authenticated tip cross-check (the client reads each node's
trust-log tip over its already-authenticated Noise channel, via `node.identify`,
and compares tips against its resolved chain — no per-node beacon key, no
gateway-supplied verification input). See the design note in
`docs/superpowers/reviews/2026-08-31-e2e-stack-review.md` (finding I1) and the
plan `docs/superpowers/plans/2026-09-02-beacon-to-tip-crosscheck.md`.

What remains in this PR is the **fail-closed node-lock fix** that had been landed
here:

- `cmd/argus/nodelock.go` `configureNodeLock`: when `e2ee.enabled`, a node whose
  e2ee identity fails to load **refuses to start** (fatal) rather than running
  with the trust log on but encryption off — which would serve unauthenticated
  plaintext channels (a locked-mode bypass). Signer-key load stays best-effort.
- Restores the `sockDir` e2etest helper and the lock integration tests.

Tests: `TestConfigureNodeLockFailsClosedOnBadIdentity`, `...StartsWithFreshIdentity`.

Stacked on #43 (`pr/06c-revoke-signer-ceremony`).
