### PR TITLE
pr/10 live harness ci

### DIFF
--- a/.github/workflows/e2elive.yml
+++ b/.github/workflows/e2elive.yml
@@ -1,0 +1,34 @@
+name: e2elive
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  e2elive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # No `go mod download` step: `go test` fetches what the test binary needs,
+      # and the image resolves its own modules inside BuildKit cache mounts that
+      # this runner never persists.
+
+      # docker/setup-buildx-action is not used here: buildTestImage() calls
+      # plain `docker build`, not `docker buildx build`. DOCKER_BUILDKIT=1 below
+      # is enough. Reintroduce setup-buildx-action if cache-from/cache-to: type=gha
+      # is ever added for image layer caching.
+
+      - name: Test
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: go test ./internal/e2elive/ -count=1 -v

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PREFIX  ?= $(HOME)/.local
 BINDIR  ?= $(PREFIX)/bin
 APP_DIR ?= app
 
-.PHONY: build argus test vet fmt fmt-check tidy check clean install uninstall help \
+.PHONY: build argus test test-all vet fmt fmt-check tidy check clean install uninstall help \
 	app-get app-analyze app-test app-fmt app-check app-run app-build app-clean
 
 build: argus ## Build the binary into bin/
@@ -13,7 +13,10 @@ build: argus ## Build the binary into bin/
 argus: ## Build the unified argus binary (TUI, serve, hooks)
 	go build $(LDFLAGS) -o $(BIN)/argus ./cmd/argus
 
-test: ## Run all tests
+test: ## Run the tests that need no Docker daemon
+	go test ./... -short
+
+test-all: ## Run every test, including the container suite (needs Docker)
 	go test ./...
 
 vet: ## Run go vet

--- a/cmd/argus/lock.go
+++ b/cmd/argus/lock.go
@@ -75,7 +75,7 @@ func newLockStatusCmd() *cobra.Command {
 				if ierr != nil {
 					return fail(cmd, err) // surface the original node-dial error
 				}
-				shell.StdOutF("locked mode: (no local node)\nthis tui\n  identity: %s\n  → to authorize this tui, run on a signer node:\n      %s\n",
+				shell.StdOutF("locked mode: (no local node)\n\nthis tui\n  identity: %s\n  → to authorize this tui, run on a signer node:\n      %s\n",
 					keyfmt.DeviceKey.Encode(kp.Public), lockSignHint(kp.Public))
 				printClientPinStatus(ctx, cfg)
 				// Exit 0 only when the socket was not explicitly requested and simply
@@ -120,7 +120,7 @@ func printTUIRole(ctx context.Context, cfg *config.Config, st api.LockStatusResu
 	if err != nil {
 		return printClientPinStatus(ctx, cfg) // identity unreadable: still show the pin line
 	}
-	shell.StdOutF("this tui\n  identity: %s", keyfmt.DeviceKey.Encode(kp.Public))
+	shell.StdOutF("\nthis tui\n  identity: %s", keyfmt.DeviceKey.Encode(kp.Public))
 	showAuthz := st.Enabled && devicesKnown(st)
 	authorized := showAuthz && keyAuthorized(kp.Public, st.Devices)
 	if showAuthz {

--- a/cmd/fakeclaude/main.go
+++ b/cmd/fakeclaude/main.go
@@ -1,0 +1,48 @@
+// Command fakeclaude imitates the on-disk footprint of a Claude Code process.
+// The e2elive image installs it as `claude`, because discovery matches the
+// argv0 basename. It blocks until it is signalled.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/MunifTanjim/argus/internal/fakeagent"
+)
+
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func main() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "fakeclaude: getwd:", err)
+		os.Exit(1)
+	}
+	cfg := fakeagent.Config{
+		PID:       os.Getpid(),
+		SessionID: env("FAKE_CLAUDE_SESSION_ID", "fake-session"),
+		Name:      env("FAKE_CLAUDE_NAME", "fake"),
+		Status:    env("FAKE_CLAUDE_STATUS", "idle"),
+		Cwd:       cwd,
+	}
+	if err := fakeagent.Write(cfg); err != nil {
+		fmt.Fprintln(os.Stderr, "fakeclaude:", err)
+		os.Exit(1)
+	}
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
+	<-ch
+
+	if err := fakeagent.Remove(cfg.PID); err != nil {
+		fmt.Fprintln(os.Stderr, "fakeclaude:", err)
+		os.Exit(1)
+	}
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,12 @@
+# Copy to docker/.env and adjust. docker compose reads docker/.env automatically.
+
+# Shared gateway token presented by every node and client.
+ARGUS_TOKEN=devtoken
+
+# Log verbosity: trace, debug, info, warn, error, fatal.
+ARGUS_LOG_LEVEL=info
+
+# Locked mode only: paste the `lock.genesis: <B64>` value printed by
+# `argus lock init`, then uncomment ARGUS_LOCK_GENESIS in docker-compose.yml
+# (node-base and client) and run `docker compose up -d` to pin it.
+# ARGUS_LOCK_GENESIS=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+#
+# Three stages. `argus-test` carries a scripted fake claude for internal/e2elive.
+# `argus-demo` carries the real Claude Code CLI for scripts/demo.sh and compose.
+# The two agents never share an image: the real CLI installs itself at
+# /usr/local/bin/claude, which is where the fake lives.
+#
+# Build context is the REPO ROOT because assets.go //go:embed's
+# app/android/.../ic_launcher.png.
+
+# ---- builder -----------------------------------------------------------------
+FROM golang:1.26-alpine AS builder
+RUN apk add --no-cache git
+ARG VERSION=docker-dev
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+COPY . .
+# CGO off: modernc.org/sqlite is pure Go, so the binary is static and runs on
+# both Alpine (musl) and Debian.
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -ldflags "-X main.version=${VERSION}" -o /out/argus ./cmd/argus
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -o /out/claude ./cmd/fakeclaude
+
+# ---- runtime-base ------------------------------------------------------------
+FROM alpine:3 AS runtime-base
+# ca-certificates: outbound TLS (e.g. web-push). tini: clean PID 1 signal
+# handling. tmux: agent sessions live here. procps: discovery shells out to
+# BSD-style `ps -ax -o pid= -o tty= ...` (busybox ps rejects these flags).
+# git: repo-name detection.
+RUN apk add --no-cache ca-certificates tini tmux procps git \
+    && adduser -D -h /home/argus argus
+COPY --from=builder /out/argus /usr/local/bin/argus
+USER argus
+WORKDIR /home/argus
+ENV HOME=/home/argus
+EXPOSE 8443
+ENTRYPOINT ["/sbin/tini", "--", "argus"]
+
+# ---- argus-test --------------------------------------------------------------
+FROM runtime-base AS argus-test
+COPY --from=builder /out/claude /usr/local/bin/claude
+
+# ---- argus-demo --------------------------------------------------------------
+FROM runtime-base AS argus-demo
+USER root
+# nodejs/npm: install the Claude Code CLI. libc6-compat: musl shim in case the
+# claude CLI ships a glibc-linked helper (see docker/README.md fallback).
+RUN apk add --no-cache nodejs npm libc6-compat \
+    && npm install -g @anthropic-ai/claude-code
+USER argus

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,280 @@
+# Argus blind-gateway E2E — Docker Compose test harness
+
+Spins up the full topology of the `feat/e2e-encryption-blind-gateway` branch so
+you can exercise it yourself:
+
+- **gateway** — the blind relay on `:8443`. It moves opaque, per-message
+  Noise-IK-encrypted bodies between clients and nodes and publishes only a
+  cleartext node roster. It cannot read session content or forge commands.
+- **node-a / node-b / node-c** — three real nodes, each running a real Claude
+  Code agent inside tmux, connected to the gateway over `ws://`.
+- **client** — the interactive TUI. It reads the roster, opens one sealed channel
+  per node *through* the gateway, and aggregates sessions client-side.
+
+All four run the **same image** (`docker/Dockerfile`) — the role is decided
+entirely by the command in `docker-compose.yml`.
+
+Every client↔gateway connection is end-to-end encrypted **by construction**: the
+gateway is a blind relay that serves no session data in cleartext, so a client always
+opens sealed Noise channels to the nodes through it. There is no `--e2e` flag — the
+transport is decided by destination (a gateway URL is always sealed; only a direct
+local unix-socket connection to your own node is plaintext). Just bringing the stack
+up exercises the encrypted path.
+
+All commands below assume you run them from the repo root.
+
+## Prerequisites
+
+- Docker with Compose v2.
+- An Anthropic account to log Claude Code in (interactive, one-time per node —
+  argus never sees your credentials).
+
+## 1. Open mode (blind gateway) — the default
+
+```sh
+cp docker/.env.example docker/.env
+docker compose -f docker/docker-compose.yml up -d --build
+docker compose -f docker/docker-compose.yml logs -f gateway    # ^C when you see nodes connect
+```
+
+Every node auto-generates its identity/signer keys on first boot and joins the
+roster. Confirm all three are up:
+
+```sh
+docker compose -f docker/docker-compose.yml ps
+```
+
+### Log Claude in on each node (one-time)
+
+Claude Code authenticates itself; credentials persist in each node's volume.
+
+```sh
+docker compose -f docker/docker-compose.yml exec -it node-a claude
+# complete /login (it prints a URL — open it in YOUR browser, paste the code back),
+# then quit claude. Repeat for node-b and node-c.
+```
+
+### Start a real, discoverable agent session on each node
+
+Discovery scans tmux, so start `claude` inside a tmux pane (detached):
+
+```sh
+for n in node-a node-b node-c; do
+  docker compose -f docker/docker-compose.yml exec $n \
+    tmux new -d -s work -c /home/argus claude
+done
+```
+
+### Open the TUI client and watch it aggregate
+
+```sh
+docker compose -f docker/docker-compose.yml run --rm client
+```
+
+You should see **all three nodes** in the roster, each with its Claude session —
+proof of client-side aggregation over the blind relay. The TUI also joins the fleet
+as its own ephemeral node (labelled `client`, from `--id=client`); it has no tmux
+`claude` running, so it shows up empty — that is expected. Meanwhile the gateway logs
+show only opaque relay + roster events, never session content:
+
+```sh
+docker compose -f docker/docker-compose.yml logs gateway
+```
+
+Quick connectivity/auth probe (answered by the gateway itself):
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-a \
+  argus ping --gateway ws://gateway:8443 --token devtoken
+```
+
+> **Note:** discovery has no periodic ticker — a newly started agent shows up
+> after the TUI refreshes (reopen the client) or after a spawn. Expected.
+
+## 2. Locked mode (trust ledger)
+
+Locked mode makes device authorization unforgeable even against an actively
+malicious gateway, via a signer-signed, hash-chained trust log.
+
+**Init on a signer node.** `lock init` takes signer *keys*, not node names: a name
+could only be turned into a key via the roster the gateway serves, and at init time
+no trust log exists yet to constrain that mapping — so a hostile gateway could seat
+its own key in your genesis. Read each co-signer's key off the node itself first:
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-b argus lock status   #   signer:   sigpub:<hex>
+docker compose -f docker/docker-compose.yml exec node-c argus lock status   #   signer:   sigpub:<hex>
+```
+
+Read node-a's own key the same way — it must be listed explicitly, because the keys
+you pass are the complete signer set:
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-a argus lock status   #   signer:   sigpub:<hex>
+```
+
+Then init on node-a with all three keys, so any two can recover from the loss of the
+third. Run it once without `--confirm` to see the signer set and the devices it would
+authorize from the roster; nothing is created until you re-run it with the flag:
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-a \
+  argus lock init \
+    sigpub:<node-a-hex> \
+    sigpub:<node-b-hex> \
+    sigpub:<node-c-hex> \
+    --gen-disablements 1
+
+docker compose -f docker/docker-compose.yml exec node-a \
+  argus lock init --confirm \
+    sigpub:<node-a-hex> \
+    sigpub:<node-b-hex> \
+    sigpub:<node-c-hex> \
+    --gen-disablements 1
+```
+
+Save the printed **`genesis: gen:<hex>`** and the **disablement secret** (`dis:<hex>`,
+shown once — it's your break-glass recovery key).
+
+`lock init` pins both roles inside the node-a container (its node and its client).
+Every other device is unpinned and will quarantine.
+
+**Pin every other node to the genesis.** Each node that was not present at `lock init`
+must be pinned interactively. The command pulls the offered genesis, shows its word
+fingerprint, and asks for confirmation — compare those words against `argus lock status`
+on node-a before typing `y`:
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-b argus lock pin
+docker compose -f docker/docker-compose.yml exec node-c argus lock pin
+```
+
+**Pin the TUI client too.** The `client` service is a separate device with its own
+pin; unpinned, it quarantines and shows an empty dashboard. Its home volume persists,
+so pin it once:
+
+```sh
+docker compose -f docker/docker-compose.yml run --rm client \
+  lock pin --gateway ws://gateway:8443 --token "${ARGUS_TOKEN:-devtoken}"
+docker compose -f docker/docker-compose.yml run --rm client \
+  lock status --gateway ws://gateway:8443 --token "${ARGUS_TOKEN:-devtoken}"  # client pin: <words>
+```
+
+`docker compose run` replaces the service's `command:`, which is where the client's
+`--gateway`/`--token` normally live — hence the explicit flags. The `client` service
+also sets `ARGUS_GATEWAY_URL`/`ARGUS_TOKEN`, so they can be omitted on this harness;
+they are spelled out here because that is what the commands actually need. The client
+container runs no node, so `lock pin` also notes that the local node is unreachable and
+pins the client role only — expected here.
+
+**Declarative alternative:** you can instead set `ARGUS_LOCK_GENESIS=gen:<hex>` in
+`docker/.env` and uncomment the env var in `docker/docker-compose.yml` (both
+`x-node-base` and the `client` service). The env var takes precedence over the
+pinned file, which is useful for fleet-wide deployment where you want a single
+authoritative genesis wired into your compose config. After editing, restart:
+
+```sh
+docker compose -f docker/docker-compose.yml up -d
+```
+
+**Authorize the TUI client.** The client's identity is separate from the node
+identities, so `lock init` did not authorize it. Get its pubkey and sign it:
+
+```sh
+docker compose -f docker/docker-compose.yml run --rm client lock status
+# prints this device's devpub: key + the exact `argus lock sign <devpub:...>` command
+docker compose -f docker/docker-compose.yml exec node-a argus lock sign devpub:<hex>
+```
+
+**Verify:**
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-a argus lock status   # enabled, signers: 3
+docker compose -f docker/docker-compose.yml exec node-a argus lock log      # genesis + authorize-device entries
+docker compose -f docker/docker-compose.yml run --rm client                 # connects, lists sessions
+```
+
+## 3. Rejection demo (unauthorized device)
+
+This is the crown-jewel proof. Before signing the client (step 2), a client that
+has the pinned genesis but an **unsigned identity** connects to the gateway, but
+every node **drops the Noise handshake** (fail-closed —
+`internal/node/responder.go`). The client opens **zero** channels and sees no
+nodes/sessions.
+
+To reproduce cleanly, reset the client identity so it's unauthorized, then watch
+it get rejected and then accepted:
+
+```sh
+# fresh, unauthorized client identity
+docker compose -f docker/docker-compose.yml run --rm client lock status
+#   -> "locked mode enabled, this node authorized: false" + a sign hint
+docker compose -f docker/docker-compose.yml run --rm client
+#   -> roster is visible but NO node channels open (rejected)
+
+# authorize it, wait ~30s for the chain to sync, then it works
+docker compose -f docker/docker-compose.yml exec node-a argus lock sign devpub:<hex>
+docker compose -f docker/docker-compose.yml run --rm client
+#   -> now connects and lists sessions
+```
+
+Show **live revocation** kicking an authorized device off:
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-a argus lock revoke-device devpub:<hex>
+# the client's open channels are torn down within a sync tick
+```
+
+Break-glass (disable locked mode network-wide with a disablement secret):
+
+```sh
+docker compose -f docker/docker-compose.yml exec node-a argus lock disable <secret>
+```
+
+## Teardown
+
+```sh
+docker compose -f docker/docker-compose.yml down                            # keep volumes (identities persist)
+docker compose -f docker/docker-compose.yml --profile client down -v        # wipe everything
+```
+
+`--profile client` matters on the wipe: `client` is a profile service, and a
+plain `down -v` leaves `client-home` behind.
+
+## Notes & troubleshooting
+
+- **Claude Code on Alpine (musl):** the image installs `libc6-compat` as a shim.
+  If `claude` still fails to launch, replace the `argus-demo` stage in
+  `docker/Dockerfile` with one that does not inherit from `runtime-base`:
+  ```dockerfile
+  FROM node:22-slim AS argus-demo
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+          ca-certificates tini tmux procps git \
+      && adduser --disabled-password --gecos '' --home /home/argus argus \
+      && rm -rf /var/lib/apt/lists/*
+  COPY --from=builder /out/argus /usr/local/bin/argus
+  RUN npm install -g @anthropic-ai/claude-code
+  USER argus
+  WORKDIR /home/argus
+  ENV HOME=/home/argus
+  EXPOSE 8443
+  ENTRYPOINT ["/usr/bin/tini", "--", "argus"]
+  ```
+  `runtime-base` and `argus-test` are unchanged; `argus-demo` is the only stage
+  that carries the real Claude Code CLI. The argus binary is static and runs on
+  either Alpine or Debian.
+- **Port 8443 already in use?** (e.g. you already run argus on the host) — set
+  `ARGUS_GATEWAY_PORT` to a free host port in `docker/.env`; the container side
+  stays 8443, so the internal `ws://gateway:8443` used by nodes/clients is
+  unaffected.
+- **TUI needs a TTY** — always launch the client with `docker compose run` (which
+  allocates one), not `up`.
+- **The gateway serves plain `ws://`** — TLS is meant to be terminated by a
+  tunnel or reverse proxy in production; skipped here for local testing.
+- **Sessions empty?** Make sure `claude` is actually running in a tmux pane on the
+  node (`docker compose exec node-a tmux ls`) and reopen the client to trigger a
+  rescan.
+- **`permission denied` reading state** (e.g. `persisted genesis unusable`) — a
+  volume left over from an image whose container user had a different uid. The
+  home volumes hold uid-owned `0600` state, so they are not portable across a
+  user change. Wipe them: `--profile client down -v`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,119 @@
+# docker compose test harness for the feat/e2e-encryption-blind-gateway branch.
+#
+#   cp docker/.env.example docker/.env
+#   docker compose -f docker/docker-compose.yml up -d --build
+#   docker compose -f docker/docker-compose.yml run --rm client
+#
+# Every service runs the same image; only the command differs.
+# See docker/README.md for the full walkthrough (open mode + locked mode).
+
+name: argus-e2e
+
+# Only `gateway` carries the build stanza: two services exporting the same tag in
+# one (parallel) build is an error. So the first run must be `up --build`, which
+# builds the image before anything starts.
+x-argus: &argus
+  image: argus-demo:dev
+
+x-node-base: &node-base
+  <<: *argus
+  depends_on: [gateway]
+  environment:
+    ARGUS_GATEWAY_URL: ws://gateway:8443
+    ARGUS_TOKEN: ${ARGUS_TOKEN:-devtoken}
+    ARGUS_LOG_LEVEL: ${ARGUS_LOG_LEVEL:-info}
+    ARGUS_LOG_FORMAT: ${ARGUS_LOG_FORMAT:-json}
+    # Locked mode: uncomment and set to the gen:<hex> genesis printed by
+    # `argus lock init`, then `docker compose up -d` to pin it (fail-closed).
+    # ARGUS_LOCK_GENESIS: ${ARGUS_LOCK_GENESIS:-}
+  restart: unless-stopped
+
+services:
+  gateway:
+    <<: *argus
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: argus-demo
+    command:
+      - start
+      - --mode=gateway
+      - --token=${ARGUS_TOKEN:-devtoken}
+      - --listen-addr=:8443
+    environment:
+      ARGUS_LOG_LEVEL: ${ARGUS_LOG_LEVEL:-info}
+      ARGUS_LOG_FORMAT: ${ARGUS_LOG_FORMAT:-json}
+    ports:
+      - "${ARGUS_GATEWAY_PORT:-8443}:8443"
+    volumes:
+      - gw-home:/home/argus
+    restart: unless-stopped
+
+  node-a:
+    <<: *node-base
+    command:
+      [
+        "start",
+        "--gateway=ws://gateway:8443",
+        "--token=${ARGUS_TOKEN:-devtoken}",
+        "--id=node-a",
+        "--label=node-a",
+      ]
+    volumes:
+      - node-a-home:/home/argus
+
+  node-b:
+    <<: *node-base
+    command:
+      [
+        "start",
+        "--gateway=ws://gateway:8443",
+        "--token=${ARGUS_TOKEN:-devtoken}",
+        "--id=node-b",
+        "--label=node-b",
+      ]
+    volumes:
+      - node-b-home:/home/argus
+
+  node-c:
+    <<: *node-base
+    command:
+      [
+        "start",
+        "--gateway=ws://gateway:8443",
+        "--token=${ARGUS_TOKEN:-devtoken}",
+        "--id=node-c",
+        "--label=node-c",
+      ]
+    volumes:
+      - node-c-home:/home/argus
+
+  # The interactive TUI client. Not started by `up`; run on demand so it gets a
+  # TTY:  docker compose run --rm client
+  client:
+    <<: *argus
+    profiles: [client]
+    depends_on: [gateway]
+    stdin_open: true
+    tty: true
+    environment:
+      # `docker compose run` replaces the command below, so the gateway and token
+      # must also be in the environment: without them `run --rm client lock pin`
+      # falls back to a unix socket that has no node behind it.
+      ARGUS_GATEWAY_URL: ws://gateway:8443
+      ARGUS_TOKEN: ${ARGUS_TOKEN:-devtoken}
+      ARGUS_LOG_LEVEL: ${ARGUS_LOG_LEVEL:-info}
+      ARGUS_LOG_FORMAT: ${ARGUS_LOG_FORMAT:-json}
+      # Pin the same genesis here for locked mode (see README step 2).
+      # ARGUS_LOCK_GENESIS: ${ARGUS_LOCK_GENESIS:-}
+    command: ["--gateway=ws://gateway:8443", "--token=${ARGUS_TOKEN:-devtoken}"]
+    # Stable client identity across runs — required for locked-mode authorization.
+    volumes:
+      - client-home:/home/argus
+
+volumes:
+  gw-home:
+  node-a-home:
+  node-b-home:
+  node-c-home:
+  client-home:

--- a/internal/e2elive/ceremony_test.go
+++ b/internal/e2elive/ceremony_test.go
@@ -1,0 +1,99 @@
+package e2elive
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestLockRevokeSignerCeremonyCLI drives the three-phase co-signing ceremony across
+// three real processes, passing the ceremony blob between them through argv.
+func TestLockRevokeSignerCeremonyCLI(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	b := c.AddNode("node-b")
+	cc := c.AddNode("node-c")
+	c.WaitOnline("node-a", "node-b", "node-c")
+
+	statusA0 := a.LockRun("status")
+	statusB0 := b.LockRun("status")
+	statusC0 := cc.LockRun("status")
+	sigA := Scrape(t, statusA0, PatSignerKey)
+	sigB := Scrape(t, statusB0, PatSignerKey)
+	sigC := Scrape(t, statusC0, PatSignerKey)
+	devA := Scrape(t, statusA0, PatDeviceKey)
+	devB := Scrape(t, statusB0, PatDeviceKey)
+	devC := Scrape(t, statusC0, PatDeviceKey)
+	c.Redact(sigA, "<NODE-A-SIGPUB>")
+	c.Redact(sigB, "<NODE-B-SIGPUB>")
+	c.Redact(sigC, "<NODE-C-SIGPUB>")
+	c.Redact(devA, "<NODE-A-DEVPUB>")
+	c.Redact(devB, "<NODE-B-DEVPUB>")
+	c.Redact(devC, "<NODE-C-DEVPUB>")
+
+	initRes := a.LockRun("init", sigA, sigB, "--confirm")
+	genesis := Scrape(t, initRes, PatGenesis)
+	c.Redact(genesis, "<GENESIS>")
+	for i, s := range ScrapeAll(t, initRes, PatDisablement) {
+		c.Redact(s, "<SECRET-"+string(rune('1'+i))+">")
+	}
+
+	reTip := regexp.MustCompile(PatTip)
+	reEntryHash := regexp.MustCompile(PatEntryHash)
+	seenTips := map[string]bool{}
+	tipN := 0
+	redactTip := func(r Result) {
+		for _, m := range reTip.FindAllStringSubmatch(r.Stdout+r.Stderr, -1) {
+			if tip := m[1]; !seenTips[tip] {
+				seenTips[tip] = true
+				tipN++
+				c.Redact(tip, fmt.Sprintf("<TIP-%d>", tipN))
+			}
+		}
+		for _, m := range reEntryHash.FindAllStringSubmatch(r.Stdout+r.Stderr, -1) {
+			if hash := m[1]; strings.HasPrefix(hash, "tip:") && !seenTips[hash] {
+				seenTips[hash] = true
+				tipN++
+				c.Redact(hash, fmt.Sprintf("<TIP-%d>", tipN))
+			}
+		}
+	}
+	redactTip(initRes)
+
+	c.Step(t, "init-two-signers", initRes)
+	c.Step(t, "pin-node-b", b.LockRun("pin", genesis))
+	c.WaitLockEnforcing("node-b")
+
+	start := a.LockRun("revoke-signer", sigB, "--replacement", sigC)
+	redactTip(start)
+	blob1 := Scrape(t, start, PatBlob)
+	c.Redact(blob1, "<BLOB-START>")
+	c.Step(t, "revoke-signer-start", start)
+
+	cosign := b.LockRun("revoke-signer", "--cosign", blob1)
+	redactTip(cosign)
+	blob2 := Scrape(t, cosign, PatBlob)
+	c.Redact(blob2, "<BLOB-COSIGNED>")
+	c.Step(t, "revoke-signer-cosign", cosign)
+
+	finish := a.LockRun("revoke-signer", "--finish", blob2)
+	redactTip(finish)
+	c.Step(t, "revoke-signer-finish", finish)
+
+	statusA := a.LockRun("status")
+	redactTip(statusA)
+	c.Step(t, "status-a-after-ceremony", statusA)
+
+	c.Step(t, "pin-node-c", cc.LockRun("pin", genesis))
+	c.WaitLockEnforcing("node-c")
+
+	statusC := cc.LockRun("status")
+	redactTip(statusC)
+	c.Step(t, "status-c-after-ceremony", statusC)
+
+	logRes := a.LockRun("log")
+	redactTip(logRes)
+	c.Step(t, "log-after-ceremony", logRes)
+}

--- a/internal/e2elive/ceremony_test.go
+++ b/internal/e2elive/ceremony_test.go
@@ -32,6 +32,9 @@ func TestLockRevokeSignerCeremonyCLI(t *testing.T) {
 	c.Redact(devA, "<NODE-A-DEVPUB>")
 	c.Redact(devB, "<NODE-B-DEVPUB>")
 	c.Redact(devC, "<NODE-C-DEVPUB>")
+	c.Redact(Scrape(t, statusA0, PatClientDeviceKey), "<NODE-A-CLIENT-DEVPUB>")
+	c.Redact(Scrape(t, statusB0, PatClientDeviceKey), "<NODE-B-CLIENT-DEVPUB>")
+	c.Redact(Scrape(t, statusC0, PatClientDeviceKey), "<NODE-C-CLIENT-DEVPUB>")
 
 	initRes := a.LockRun("init", sigA, sigB, "--confirm")
 	genesis := Scrape(t, initRes, PatGenesis)

--- a/internal/e2elive/cluster.go
+++ b/internal/e2elive/cluster.go
@@ -16,6 +16,14 @@ import (
 	"github.com/MunifTanjim/argus/internal/client"
 )
 
+// CipherMode selects whether the fleet uses Noise E2EE or a plaintext relay channel.
+type CipherMode int
+
+const (
+	CipherE2EE      CipherMode = iota // Noise end-to-end encryption (default)
+	CipherPlaintext                   // relay channel without Noise
+)
+
 type Cluster struct {
 	t      *testing.T
 	Root   string
@@ -36,8 +44,9 @@ type Cluster struct {
 	retired    []retiredLog
 	nodes      map[string]*Node
 
-	gwEnv  []string
-	gwArgs []string
+	cipherMode CipherMode
+	gwEnv      []string
+	gwArgs     []string
 
 	redactions []redaction
 	steps      int
@@ -96,6 +105,16 @@ func New(t *testing.T) *Cluster {
 	if err := dockerRun("network", "create", "--label", runLabel+"=1", c.network); err != nil {
 		t.Fatalf("create network: %v", err)
 	}
+	return c
+}
+
+// NewPlaintext is like New but configures the fleet to use the plaintext relay
+// channel (no Noise encryption). Use it for cipher-independent scenario variants
+// and parity tests.
+func NewPlaintext(t *testing.T) *Cluster {
+	t.Helper()
+	c := New(t)
+	c.cipherMode = CipherPlaintext
 	return c
 }
 
@@ -257,7 +276,10 @@ func (c *Cluster) StartGateway() {
 		if err != nil {
 			c.t.Fatalf("gateway env: %v", err)
 		}
-		c.gwEnv = append(env, "ARGUS_E2EE_ENABLED=true")
+		if c.cipherMode == CipherE2EE {
+			env = append(env, "ARGUS_E2EE_ENABLED=true")
+		}
+		c.gwEnv = env
 		c.gwArgs = []string{
 			"start",
 			"--mode=gateway",
@@ -317,7 +339,9 @@ func (c *Cluster) AddNode(id string) *Node {
 	if err != nil {
 		c.t.Fatalf("node %s env: %v", id, err)
 	}
-	env = append(env, "ARGUS_E2EE_ENABLED=true")
+	if c.cipherMode == CipherE2EE {
+		env = append(env, "ARGUS_E2EE_ENABLED=true")
+	}
 	sock := containerHome + "/s"
 	args := []string{
 		"start",
@@ -396,7 +420,11 @@ func (c *Cluster) WaitOnline(ids ...string) {
 		}
 		online := map[string]bool{}
 		for _, nd := range r.Nodes {
-			if nd.Online && nd.IdentityPubKey != "" {
+			// In E2EE mode, IdentityPubKey being non-empty signals the node has
+			// fully announced its Noise identity. In plaintext mode the field is
+			// always empty, so Online alone is the readiness signal.
+			ready := nd.Online && (c.cipherMode == CipherPlaintext || nd.IdentityPubKey != "")
+			if ready {
 				online[nd.ID] = true
 			}
 		}
@@ -471,7 +499,13 @@ func (c *Cluster) NewClient() *client.ReconnectingE2EClient {
 	dial := func(ctx context.Context) (net.Conn, error) {
 		return api.DialWSConn(ctx, c.GWURL+"/client", c.Token, nil)
 	}
-	cl, err := client.NewReconnectingE2EClient(c.ctx, dial)
+	var cl *client.ReconnectingE2EClient
+	var err error
+	if c.cipherMode == CipherPlaintext {
+		cl, err = client.NewReconnectingPlainClient(c.ctx, dial)
+	} else {
+		cl, err = client.NewReconnectingE2EClient(c.ctx, dial)
+	}
 	if err != nil {
 		c.t.Fatalf("NewClient: %v", err)
 	}

--- a/internal/e2elive/cluster.go
+++ b/internal/e2elive/cluster.go
@@ -1,0 +1,480 @@
+package e2elive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+)
+
+type Cluster struct {
+	t      *testing.T
+	Root   string
+	Token  string
+	GWAddr string
+	// GWURL is the gateway as the test process on the host reaches it.
+	GWURL string
+	// GWURLInternal is the gateway as a container reaches it. Every command that
+	// runs through docker exec must use this one.
+	GWURLInternal string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	runID      string
+	network    string
+	containers []string
+	retired    []retiredLog
+	nodes      map[string]*Node
+
+	gwEnv  []string
+	gwArgs []string
+
+	redactions []redaction
+	steps      int
+	goldenDir  string // test override; empty means testdata/<TestName>
+}
+
+func New(t *testing.T) *Cluster {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("container e2e; skipped under -short")
+	}
+	if err := buildTestImage(); err != nil {
+		t.Fatalf("build test image: %v", err)
+	}
+	root, err := newRunRoot()
+	if err != nil {
+		t.Fatalf("scoped root: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runID := filepath.Base(root)
+	c := &Cluster{
+		t:       t,
+		Root:    root,
+		Token:   "devtoken",
+		ctx:     ctx,
+		cancel:  cancel,
+		runID:   runID,
+		network: runID + "-net",
+		nodes:   map[string]*Node{},
+	}
+	c.GWAddr = freePort(t)
+	c.GWURL = "ws://" + c.GWAddr
+	c.GWURLInternal = "ws://" + runID + "-gw:8443"
+
+	// Registered before the network exists so that a failure below still takes the
+	// run root with it.
+	t.Cleanup(func() {
+		c.cancel()
+		if t.Failed() {
+			for i, r := range c.retired {
+				t.Logf("---- %s (retired generation %d) ----\n%s", r.container, i+1, r.body)
+			}
+			for _, name := range c.containers {
+				if out, err := dockerLogs(name); err == nil {
+					t.Logf("---- %s (live) ----\n%s", name, out)
+				}
+			}
+		}
+		for i := len(c.containers) - 1; i >= 0; i-- {
+			_ = dockerRun("rm", "-f", c.containers[i])
+		}
+		_ = dockerRun("network", "rm", c.network)
+		_ = os.RemoveAll(root)
+	})
+
+	if err := dockerRun("network", "create", "--label", runLabel+"=1", c.network); err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	return c
+}
+
+// scopedRootDir names the cache directory every run's scoped root is created in.
+// normalize.go derives its volatile-path backstop from it, so the two cannot
+// drift apart.
+const scopedRootDir = "argus-e2elive"
+
+// scopedRootBase returns the parent directory a run's scoped root is created in.
+// It sits under the user's home because the VM-backed docker runtimes on macOS
+// (colima, Docker Desktop) share the home directory but not the private
+// directory TMPDIR names, and a bind mount they cannot resolve does not fail —
+// it silently becomes an empty directory inside the VM.
+func scopedRootBase() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	base := filepath.Join(home, ".cache", scopedRootDir)
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		return "", err
+	}
+	return base, nil
+}
+
+// runRootPrefix begins every run root's name. The owning test process's pid
+// follows it, so that a sweep can tell an abandoned root from one another
+// process is still writing to.
+const runRootPrefix = "axe"
+
+func newRunRoot() (string, error) {
+	base, err := scopedRootBase()
+	if err != nil {
+		return "", err
+	}
+	return os.MkdirTemp(base, fmt.Sprintf("%s%d-", runRootPrefix, os.Getpid()))
+}
+
+func runRootOwner(name string) (int, bool) {
+	rest, found := strings.CutPrefix(name, runRootPrefix)
+	if !found {
+		return 0, false
+	}
+	digits, _, found := strings.Cut(rest, "-")
+	if !found {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(digits)
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// sweepStaleRoots removes the run roots of processes that are gone. Ctrl-C skips
+// the t.Cleanup that would have removed them, and each one holds node identity
+// keys and the dev token, so leaving them to accumulate is not harmless.
+//
+// A root whose owning pid is still alive is never removed, which is what keeps a
+// concurrent run in another process safe. A name with no pid in it predates this
+// scheme and therefore cannot belong to a live run.
+func sweepStaleRoots() {
+	base, err := scopedRootBase()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if pid, ok := runRootOwner(e.Name()); ok && processAlive(pid) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(base, e.Name()))
+	}
+}
+
+// processAlive reports whether the kernel still knows pid. Signal 0 performs the
+// permission checks without delivering anything, so EPERM means alive too.
+func processAlive(pid int) bool {
+	return !errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+}
+
+// hostUser returns the --user value that makes bind-mounted files readable by
+// the test process. Without it the container writes 0600 files owned by the
+// image's uid. This is not a Linux-only concern: the VM-backed runtimes on macOS
+// carry the container uid onto the bind mount too, so dropping the flag on a Mac
+// breaks the state-file reads exactly as it does on Linux.
+func hostUser() string {
+	return fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+}
+
+// runContainer starts one detached argus container on the run network. hostDir
+// is bind-mounted at the container home, so Node.StatePath keeps working.
+func (c *Cluster) runContainer(name, hostDir string, env, argus []string, publish string) {
+	c.t.Helper()
+	args := []string{
+		"run", "-d",
+		"--name", name,
+		"--hostname", name,
+		"--network", c.network,
+		"--label", runLabel + "=1",
+		"--user", hostUser(),
+		"-v", hostDir + ":" + containerHome,
+	}
+	for _, e := range env {
+		args = append(args, "-e", e)
+	}
+	if publish != "" {
+		args = append(args, "-p", publish)
+	}
+	args = append(args, testImage)
+	args = append(args, argus...)
+
+	if err := dockerRun(args...); err != nil {
+		c.t.Fatalf("run %s: %v", name, err)
+	}
+	for _, existing := range c.containers {
+		if existing == name {
+			return
+		}
+	}
+	c.containers = append(c.containers, name)
+}
+
+// retiredLog is what one removed container generation wrote. Restarts replace the
+// container, and `docker rm` takes its log stream with it, so a failure dump would
+// otherwise only ever show the generation that happens to be alive at the end.
+type retiredLog struct {
+	container string
+	body      string
+}
+
+func (c *Cluster) removeContainer(name string) {
+	c.t.Helper()
+	_ = dockerRun("stop", "-t", "5", name)
+	if out, err := dockerLogs(name); err == nil && out != "" {
+		c.retired = append(c.retired, retiredLog{container: name, body: out})
+	}
+	_ = dockerRun("rm", "-f", name)
+}
+
+func (c *Cluster) gatewayContainer() string { return c.runID + "-gw" }
+
+func (c *Cluster) dialClient() (*api.Client, error) {
+	conn, err := api.DialWSConn(c.ctx, c.GWURL+"/client", c.Token, nil)
+	if err != nil {
+		return nil, err
+	}
+	return api.NewClient(conn), nil
+}
+
+func (c *Cluster) StartGateway() {
+	c.t.Helper()
+	dir := filepath.Join(c.Root, "gw")
+	if c.gwEnv == nil {
+		env, err := containerEnv(dir)
+		if err != nil {
+			c.t.Fatalf("gateway env: %v", err)
+		}
+		c.gwEnv = append(env, "ARGUS_E2EE_ENABLED=true")
+		c.gwArgs = []string{
+			"start",
+			"--mode=gateway",
+			"--token=" + c.Token,
+			"--listen-addr=:8443",
+		}
+	}
+	_, port, err := net.SplitHostPort(c.GWAddr)
+	if err != nil {
+		c.t.Fatalf("split gateway addr %q: %v", c.GWAddr, err)
+	}
+	c.runContainer(c.gatewayContainer(), dir, c.gwEnv, c.gwArgs, "127.0.0.1:"+port+":8443")
+
+	waitFor(c.t, "gateway /client ready", func() bool {
+		cl, derr := c.dialClient()
+		if derr != nil {
+			return false
+		}
+		defer cl.Close()
+		var r api.NodesListResult
+		return cl.Call(api.MethodNodesList, nil, &r) == nil
+	})
+}
+
+// StopGateway removes the gateway container and waits until its port stops
+// answering, so a caller observing the fleet afterwards is genuinely seeing a
+// gateway-less network.
+func (c *Cluster) StopGateway() {
+	c.t.Helper()
+	c.removeContainer(c.gatewayContainer())
+	waitFor(c.t, "gateway stops answering", func() bool {
+		cl, err := c.dialClient()
+		if err != nil {
+			return true
+		}
+		cl.Close()
+		return false
+	})
+}
+
+// RestartGateway stands in for the gateway host rebooting. The replacement starts
+// with an empty entry store — it retains trust-log entries in memory only — so the
+// fleet has to refill it from the nodes.
+func (c *Cluster) RestartGateway() {
+	c.t.Helper()
+	c.StopGateway()
+	c.StartGateway()
+}
+
+func (c *Cluster) AddNode(id string) *Node {
+	c.t.Helper()
+	if _, exists := c.nodes[id]; exists {
+		c.t.Fatalf("AddNode: node %q already exists", id)
+	}
+	dir := filepath.Join(c.Root, id)
+	env, err := containerEnv(dir)
+	if err != nil {
+		c.t.Fatalf("node %s env: %v", id, err)
+	}
+	env = append(env, "ARGUS_E2EE_ENABLED=true")
+	sock := containerHome + "/s"
+	args := []string{
+		"start",
+		"--gateway=" + c.GWURLInternal,
+		"--token=" + c.Token,
+		"--id=" + id,
+		"--label=" + id,
+		"--socket=" + sock,
+	}
+	n := &Node{
+		ID:        id,
+		Dir:       dir,
+		Socket:    sock,
+		cluster:   c,
+		container: c.runID + "-" + id,
+		env:       env,
+		args:      args,
+	}
+	c.runContainer(n.container, dir, env, args, "")
+	c.nodes[id] = n
+	return n
+}
+
+// StopNode removes the node's container, leaving its directory on disk for a
+// later StartNode to reload.
+func (c *Cluster) StopNode(id string) {
+	c.t.Helper()
+	n := c.nodes[id]
+	if n == nil {
+		c.t.Fatalf("StopNode: unknown node %q", id)
+	}
+	c.removeContainer(n.container)
+}
+
+// StartNode starts a replacement container for a stopped node on the same
+// directory and socket, and blocks until it is serving. Waiting on the node's
+// own socket rather than the gateway roster is deliberate: the roster still
+// lists the previous process as online until its offline grace expires, so it
+// cannot distinguish the two. The probe is `argus ping` with an empty --gateway,
+// which dials the unix socket and nothing else, so a node can be restarted while
+// the gateway is down.
+func (c *Cluster) StartNode(id string) {
+	c.t.Helper()
+	n := c.nodes[id]
+	if n == nil {
+		c.t.Fatalf("StartNode: unknown node %q", id)
+	}
+	c.runContainer(n.container, n.Dir, n.env, n.args, "")
+	waitFor(c.t, "node "+id+" answering on its own socket", func() bool {
+		r := dockerExec(c.ctx, n.container, n.env, []string{
+			"argus", "ping", "--count=1", "--socket=" + n.Socket, "--gateway=",
+		})
+		return r.ExitCode == 0
+	})
+}
+
+// RestartNode stands in for a machine reboot: the container goes away and a new
+// one comes up on the same directory, reloading whatever the old one persisted.
+func (c *Cluster) RestartNode(id string) {
+	c.t.Helper()
+	c.StopNode(id)
+	c.StartNode(id)
+}
+
+func (c *Cluster) WaitOnline(ids ...string) {
+	c.t.Helper()
+	waitFor(c.t, "nodes online", func() bool {
+		cl, err := c.dialClient()
+		if err != nil {
+			return false
+		}
+		defer cl.Close()
+		var r api.NodesListResult
+		if cl.Call(api.MethodNodesList, nil, &r) != nil {
+			return false
+		}
+		online := map[string]bool{}
+		for _, nd := range r.Nodes {
+			if nd.Online && nd.IdentityPubKey != "" {
+				online[nd.ID] = true
+			}
+		}
+		for _, id := range ids {
+			if !online[id] {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// WaitLockEnforcing blocks until the named node's `lock status` reports that it is
+// enforcing, so a golden taken on a second node cannot race trust-log propagation.
+func (c *Cluster) WaitLockEnforcing(id string) {
+	c.t.Helper()
+	n := c.nodes[id]
+	if n == nil {
+		c.t.Fatalf("WaitLockEnforcing: unknown node %q", id)
+	}
+	waitFor(c.t, "lock enforcing on "+id, func() bool {
+		r := n.LockRun("status")
+		return r.ExitCode == 0 && strings.Contains(r.Stdout, "locked mode: enforcing")
+	})
+}
+
+// WaitTip blocks until the named node's `lock status` reports tip as its current
+// tip. Propagation to a peer is bounded by the triggered-pull window, so a golden
+// taken on a second node right after a write on the first would otherwise capture
+// the peer's pre-change state.
+func (c *Cluster) WaitTip(id, tip string) {
+	c.t.Helper()
+	n := c.nodes[id]
+	if n == nil {
+		c.t.Fatalf("WaitTip: unknown node %q", id)
+	}
+	waitFor(c.t, "tip "+tip+" on "+id, func() bool {
+		r := n.LockRun("status")
+		return r.ExitCode == 0 && strings.Contains(r.Stdout, "  tip:     "+tip)
+	})
+}
+
+// WaitLockQuarantined blocks until the named node's `lock status` reports the
+// quarantine headline, which it can only reach after seeing a chain rooted at a
+// genesis it does not follow.
+func (c *Cluster) WaitLockQuarantined(id string) {
+	c.t.Helper()
+	n := c.nodes[id]
+	if n == nil {
+		c.t.Fatalf("WaitLockQuarantined: unknown node %q", id)
+	}
+	waitFor(c.t, "lock quarantined on "+id, func() bool {
+		r := n.LockRun("status")
+		return r.ExitCode == 0 && strings.Contains(r.Stdout, "locked mode: QUARANTINED")
+	})
+}
+
+func (c *Cluster) WaitLockDisabled(id string) {
+	c.t.Helper()
+	n := c.nodes[id]
+	if n == nil {
+		c.t.Fatalf("WaitLockDisabled: unknown node %q", id)
+	}
+	waitFor(c.t, "lock disabled on "+id, func() bool {
+		r := n.LockRun("status")
+		return r.ExitCode == 0 && strings.Contains(r.Stdout, "disabled network-wide")
+	})
+}
+
+func (c *Cluster) NewClient() *client.ReconnectingE2EClient {
+	c.t.Helper()
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, c.GWURL+"/client", c.Token, nil)
+	}
+	cl, err := client.NewReconnectingE2EClient(c.ctx, dial)
+	if err != nil {
+		c.t.Fatalf("NewClient: %v", err)
+	}
+	c.t.Cleanup(func() { cl.Close() })
+	return cl
+}

--- a/internal/e2elive/cluster.go
+++ b/internal/e2elive/cluster.go
@@ -478,7 +478,7 @@ func (c *Cluster) WaitLockQuarantined(id string) {
 	}
 	waitFor(c.t, "lock quarantined on "+id, func() bool {
 		r := n.LockRun("status")
-		return r.ExitCode == 0 && strings.Contains(r.Stdout, "locked mode: QUARANTINED")
+		return r.ExitCode == 0 && strings.Contains(r.Stdout, "locked mode: locked out")
 	})
 }
 

--- a/internal/e2elive/cluster_test.go
+++ b/internal/e2elive/cluster_test.go
@@ -1,0 +1,83 @@
+package e2elive
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+)
+
+func TestNewIsolatesRun(t *testing.T) {
+	c := New(t)
+
+	if !strings.HasPrefix(c.GWURL, "ws://127.0.0.1:") {
+		t.Fatalf("GWURL = %q", c.GWURL)
+	}
+	if want := "ws://" + c.runID + "-gw:8443"; c.GWURLInternal != want {
+		t.Fatalf("GWURLInternal = %q, want %q", c.GWURLInternal, want)
+	}
+	if _, err := os.Stat(c.Root); err != nil {
+		t.Fatalf("root missing: %v", err)
+	}
+
+	// The image's argus is the entrypoint, so bare flags reach it.
+	out, err := dockerOut("run", "--rm", "--label", runLabel+"=1", testImage, "--help")
+	if err != nil {
+		t.Fatalf("argus --help: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Usage") {
+		t.Fatalf("help output missing Usage:\n%s", out)
+	}
+}
+
+func TestGatewayServesClient(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+
+	cl, err := c.dialClient()
+	if err != nil {
+		t.Fatalf("dialClient: %v", err)
+	}
+	defer cl.Close()
+
+	var r api.NodesListResult
+	if err := cl.Call(api.MethodNodesList, nil, &r); err != nil {
+		t.Fatalf("nodes.list: %v", err)
+	}
+	if len(r.Nodes) != 0 {
+		t.Fatalf("expected empty roster, got %d nodes", len(r.Nodes))
+	}
+}
+
+func TestNodeJoinsAndLockStatus(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+	c.AddNode("node-a")
+	c.WaitOnline("node-a")
+
+	a := c.nodes["node-a"]
+
+	ok := a.LockRun("status")
+	if ok.ExitCode != 0 {
+		t.Fatalf("lock status exit = %d, stderr:\n%s", ok.ExitCode, ok.Stderr)
+	}
+	if !strings.Contains(ok.Stdout, "locked mode:") {
+		t.Fatalf("lock status stdout missing headline:\n%s", ok.Stdout)
+	}
+	if !strings.Contains(strings.Join(ok.Args, " "), "lock status") {
+		t.Fatalf("Args not recorded: %v", ok.Args)
+	}
+
+	bad := a.LockRun("init", "sigpub:zzzz")
+	if bad.ExitCode == 0 {
+		t.Fatalf("malformed key should fail, got exit 0:\n%s", bad.Stdout)
+	}
+	if bad.Stderr == "" {
+		t.Fatalf("malformed key produced no stderr")
+	}
+
+	if r := a.LockRun("status"); r.ExitCode != 0 {
+		t.Fatalf("lock status on node-a: exit %d\n%s%s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+}

--- a/internal/e2elive/container.go
+++ b/internal/e2elive/container.go
@@ -1,0 +1,141 @@
+package e2elive
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	testImage     = "argus-e2elive:test"
+	runLabel      = "argus.e2elive"
+	containerHome = "/home/argus"
+)
+
+// repoRoot walks up from the package directory until it finds go.mod. Tests run
+// with the package directory as their working directory.
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("repoRoot: no go.mod above " + dir)
+		}
+		dir = parent
+	}
+}
+
+func dockerOut(args ...string) (string, error) {
+	cmd := exec.Command("docker", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf("docker %s: %w: %s", strings.Join(args, " "), err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+func dockerRun(args ...string) error {
+	_, err := dockerOut(args...)
+	return err
+}
+
+// dockerLogs returns a container's output as one text. `docker logs` keeps the
+// container's two streams apart, and argus writes its log lines to stderr, so
+// dockerOut alone would come back empty. Uncancellable on purpose: the failure
+// dump runs from t.Cleanup after c.cancel(), so a ctx-bound command would abort.
+func dockerLogs(container string) (string, error) {
+	out, err := exec.Command("docker", "logs", container).CombinedOutput()
+	return string(out), err
+}
+
+var (
+	buildOnce sync.Once
+	buildErr  error
+)
+
+// buildTestImage builds the argus-test target once per test binary. Building it
+// here rather than by hand is what stops a stale image from testing old code.
+func buildTestImage() error {
+	buildOnce.Do(func() {
+		root, err := repoRoot()
+		if err != nil {
+			buildErr = err
+			return
+		}
+		cmd := exec.Command("docker", "build",
+			"--target", "argus-test",
+			"-t", testImage,
+			"-f", filepath.Join(root, "docker", "Dockerfile"),
+			root)
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			buildErr = fmt.Errorf("build %s: %w", testImage, err)
+		}
+	})
+	return buildErr
+}
+
+// sweepStale removes the containers, networks and run roots left behind by a run
+// that was killed before its cleanup could run.
+func sweepStale() {
+	if out, err := dockerOut("ps", "-aq", "--filter", "label="+runLabel); err == nil {
+		for _, id := range strings.Fields(out) {
+			_ = dockerRun("rm", "-f", id)
+		}
+	}
+	if out, err := dockerOut("network", "ls", "-q", "--filter", "label="+runLabel); err == nil {
+		for _, id := range strings.Fields(out) {
+			_ = dockerRun("network", "rm", id)
+		}
+	}
+	sweepStaleRoots()
+}
+
+type dockerResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// dockerExec runs argv inside a running container. A non-zero exit is data, not
+// an error: the error-path scenario tests assert on it.
+func dockerExec(ctx context.Context, container string, env, argv []string) dockerResult {
+	args := []string{"exec"}
+	for _, e := range env {
+		args = append(args, "-e", e)
+	}
+	args = append(args, container)
+	args = append(args, argv...)
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	code := 0
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+		} else {
+			code = -1
+			stderr.WriteString("\nharness: " + err.Error() + "\n")
+		}
+	}
+	return dockerResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: code}
+}

--- a/internal/e2elive/container_test.go
+++ b/internal/e2elive/container_test.go
@@ -1,0 +1,114 @@
+package e2elive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRepoRootFindsTheModuleRoot(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod at %s: %v", root, err)
+	}
+	if !strings.HasPrefix(string(b), "module github.com/MunifTanjim/argus\n") {
+		t.Fatalf("go.mod at %s is not the argus module", root)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docker", "Dockerfile")); err != nil {
+		t.Fatalf("docker/Dockerfile not under repo root %s: %v", root, err)
+	}
+}
+
+func TestRunRootOwner(t *testing.T) {
+	root, err := newRunRoot()
+	if err != nil {
+		t.Fatalf("newRunRoot: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+
+	pid, ok := runRootOwner(filepath.Base(root))
+	if !ok || pid != os.Getpid() {
+		t.Fatalf("runRootOwner(%q) = %d, %v; want %d, true", filepath.Base(root), pid, ok, os.Getpid())
+	}
+	if !processAlive(pid) {
+		t.Fatalf("processAlive(%d) = false for this very process", pid)
+	}
+
+	// A name a sweep must treat as abandoned rather than skip.
+	for _, name := range []string{"axe", "axe-123", "axeXY-1", "other-1"} {
+		if _, ok := runRootOwner(name); ok {
+			t.Fatalf("runRootOwner(%q) claimed an owner", name)
+		}
+	}
+}
+
+func TestDockerExecReportsStdoutAndExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("container test; skipped under -short")
+	}
+	if err := buildTestImage(); err != nil {
+		t.Fatalf("buildTestImage: %v", err)
+	}
+	name := "e2elive-selftest"
+	_ = dockerRun("rm", "-f", name)
+	if err := dockerRun("run", "-d", "--name", name,
+		"--label", runLabel+"=1",
+		"--entrypoint", "sh", testImage, "-c", "sleep 60"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	t.Cleanup(func() { _ = dockerRun("rm", "-f", name) })
+
+	ok := dockerExec(context.Background(), name, nil, []string{"sh", "-c", "echo out; echo err >&2"})
+	if ok.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", ok.ExitCode)
+	}
+	if strings.TrimSpace(ok.Stdout) != "out" {
+		t.Fatalf("stdout = %q, want out", ok.Stdout)
+	}
+	if strings.TrimSpace(ok.Stderr) != "err" {
+		t.Fatalf("stderr = %q, want err", ok.Stderr)
+	}
+
+	bad := dockerExec(context.Background(), name, nil, []string{"sh", "-c", "exit 3"})
+	if bad.ExitCode != 3 {
+		t.Fatalf("exit code = %d, want 3", bad.ExitCode)
+	}
+
+	withEnv := dockerExec(context.Background(), name, []string{"FOO=bar"}, []string{"sh", "-c", "echo $FOO"})
+	if strings.TrimSpace(withEnv.Stdout) != "bar" {
+		t.Fatalf("env stdout = %q, want bar", withEnv.Stdout)
+	}
+}
+
+func TestSweepStaleRemovesLabelledContainers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("container test; skipped under -short")
+	}
+	if err := buildTestImage(); err != nil {
+		t.Fatalf("buildTestImage: %v", err)
+	}
+	name := "e2elive-stale"
+	_ = dockerRun("rm", "-f", name)
+	if err := dockerRun("run", "-d", "--name", name,
+		"--label", runLabel+"=1",
+		"--entrypoint", "sh", testImage, "-c", "sleep 60"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	sweepStale()
+
+	out, err := dockerOut("ps", "-aq", "--filter", "name="+name)
+	if err != nil {
+		t.Fatalf("ps: %v", err)
+	}
+	if strings.TrimSpace(out) != "" {
+		_ = dockerRun("rm", "-f", name)
+		t.Fatalf("container %s survived the sweep", name)
+	}
+}

--- a/internal/e2elive/doc.go
+++ b/internal/e2elive/doc.go
@@ -1,0 +1,20 @@
+// Package e2elive spins up the real argus binary as isolated containers — a
+// blind gateway plus nodes, each on its own container with its own directory
+// bind-mounted under one per-run root at ~/.cache/argus-e2elive/<runID> — to
+// exercise the end-to-end encryption path against real processes. The root
+// deliberately does not live under TMPDIR: the VM-backed docker runtimes on
+// macOS share the home directory but not the private directory TMPDIR names,
+// and a bind mount they cannot resolve mounts empty instead of failing (see
+// scopedRootBase). The heavyweight tests build a docker image and bind a
+// loopback port; run go test -short to skip them.
+//
+// Scenario tests capture each `argus lock` invocation as a golden file under
+// testdata/<TestName>/, holding the normalized command line, exit code, stdout and
+// stderr. Regenerate them with:
+//
+//	go test ./internal/e2elive -run <TestName> -update
+//
+// Per-run values (keys, genesis hashes, secrets, blobs, paths, ports) must be
+// registered with Cluster.Redact; anything volatile that survives normalization
+// fails the step rather than being baked into a golden.
+package e2elive

--- a/internal/e2elive/golden.go
+++ b/internal/e2elive/golden.go
@@ -1,0 +1,65 @@
+package e2elive
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update", false, "rewrite e2elive golden files from observed CLI output")
+
+func renderResult(r Result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "$ argus %s\n", strings.Join(r.Args, " "))
+	fmt.Fprintf(&b, "exit %d\n", r.ExitCode)
+	b.WriteString("--- stdout ---\n")
+	b.WriteString(r.Stdout)
+	b.WriteString("--- stderr ---\n")
+	b.WriteString(r.Stderr)
+	return b.String()
+}
+
+func (c *Cluster) goldenPath(t *testing.T, name string) string {
+	dir := c.goldenDir
+	if dir == "" {
+		dir = filepath.Join("testdata", strings.ReplaceAll(t.Name(), "/", "_"))
+	}
+	return filepath.Join(dir, fmt.Sprintf("%02d-%s.golden", c.steps, name))
+}
+
+// Step normalizes one CLI result and compares it against its golden file. A
+// mismatch is reported with Errorf, never Fatalf, so a long journey reports every
+// drifted step in a single run. With -update the golden is rewritten instead.
+func (c *Cluster) Step(t *testing.T, name string, r Result) {
+	t.Helper()
+	path := c.goldenPath(t, name)
+	c.steps++
+
+	got, err := c.normalize(renderResult(r))
+	if err != nil {
+		t.Errorf("step %s: %v\nraw output:\n%s", name, err, renderResult(r))
+		return
+	}
+
+	if *updateGolden {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("step %s: mkdir: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatalf("step %s: write golden: %v", name, err)
+		}
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("step %s: %v — run: go test ./internal/e2elive -run %s -update", name, err, t.Name())
+		return
+	}
+	if got != string(want) {
+		t.Errorf("step %s: golden mismatch (%s)\n--- got ---\n%s\n--- want ---\n%s", name, path, got, want)
+	}
+}

--- a/internal/e2elive/golden_test.go
+++ b/internal/e2elive/golden_test.go
@@ -1,0 +1,75 @@
+package e2elive
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderResultShape(t *testing.T) {
+	got := renderResult(Result{
+		Args:     []string{"lock", "status", "--token=x"},
+		Stdout:   "locked mode: not enabled\n",
+		Stderr:   "",
+		ExitCode: 0,
+	})
+	want := "$ argus lock status --token=x\n" +
+		"exit 0\n" +
+		"--- stdout ---\n" +
+		"locked mode: not enabled\n" +
+		"--- stderr ---\n"
+	if got != want {
+		t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestRenderResultIncludesStderrAndNonZeroExit(t *testing.T) {
+	got := renderResult(Result{
+		Args:     []string{"lock", "init"},
+		Stdout:   "",
+		Stderr:   "Error: needs a signer key\n",
+		ExitCode: 1,
+	})
+	if !strings.Contains(got, "exit 1\n") {
+		t.Fatalf("exit code missing:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "--- stderr ---\nError: needs a signer key\n") {
+		t.Fatalf("stderr misplaced:\n%s", got)
+	}
+}
+
+func TestStepWritesAndComparesGolden(t *testing.T) {
+	dir := t.TempDir()
+	c := &Cluster{Root: "/var/folders/xy/abc/T/axe1", GWAddr: "127.0.0.1:1", goldenDir: dir}
+	r := Result{Args: []string{"lock", "status"}, Stdout: "locked mode: not enabled\n", ExitCode: 0}
+
+	*updateGolden = true
+	c.Step(t, "status", r)
+	*updateGolden = false
+
+	path := filepath.Join(dir, "00-status.golden")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("golden not written: %v", err)
+	}
+
+	c.steps = 0
+	c.Step(t, "status", r) // must compare clean
+	if t.Failed() {
+		t.Fatalf("re-running the same step against its own golden failed")
+	}
+}
+
+func TestStepReportsMismatchWithoutFataling(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "00-status.golden"), []byte("nope\n"), 0o644); err != nil {
+		t.Fatalf("seed golden: %v", err)
+	}
+	c := &Cluster{Root: "/var/folders/xy/abc/T/axe1", GWAddr: "127.0.0.1:1", goldenDir: dir}
+
+	fake := &testing.T{}
+	c.Step(fake, "status", Result{Args: []string{"lock", "status"}, Stdout: "different\n"})
+	if !fake.Failed() {
+		t.Fatalf("mismatch did not mark the test failed")
+	}
+}

--- a/internal/e2elive/lifecycle_test.go
+++ b/internal/e2elive/lifecycle_test.go
@@ -1,0 +1,158 @@
+package e2elive
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestLockLifecycleCLI walks a locked network's whole life through the CLI on two
+// real node processes, pinning the exit code and output of every step.
+func TestLockLifecycleCLI(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	b := c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	statusA := a.LockRun("status")
+	sigA := Scrape(t, statusA, PatSignerKey)
+	devA := Scrape(t, statusA, PatDeviceKey)
+	c.Redact(sigA, "<NODE-A-SIGPUB>")
+	c.Redact(devA, "<NODE-A-DEVPUB>")
+
+	statusB := b.LockRun("status")
+	sigB := Scrape(t, statusB, PatSignerKey)
+	devB := Scrape(t, statusB, PatDeviceKey)
+	c.Redact(sigB, "<NODE-B-SIGPUB>")
+	c.Redact(devB, "<NODE-B-DEVPUB>")
+
+	c.Step(t, "status-a-unlocked", statusA)
+	c.Step(t, "status-b-unlocked", statusB)
+
+	c.Step(t, "init-dryrun", a.LockRun("init", sigA))
+
+	initRes := a.LockRun("init", sigA, "--confirm", "--gen-disablements=2")
+	genesis := Scrape(t, initRes, PatGenesis)
+	secrets := ScrapeAll(t, initRes, PatDisablement)
+	c.Redact(genesis, "<GENESIS>")
+	for i, s := range secrets {
+		c.Redact(s, "<SECRET-"+string(rune('1'+i))+">")
+	}
+	c.Step(t, "init-confirm", initRes)
+
+	// Tip values appear in status output and in every write-operation confirmation.
+	// Each unique tip is registered in encounter order so goldens are stable.
+	reTip := regexp.MustCompile(PatTip)
+	reEntryHash := regexp.MustCompile(PatEntryHash)
+	seenTips := map[string]bool{}
+	tipN := 0
+	redactTip := func(r Result) {
+		for _, m := range reTip.FindAllStringSubmatch(r.Stdout+r.Stderr, -1) {
+			if tip := m[1]; !seenTips[tip] {
+				seenTips[tip] = true
+				tipN++
+				c.Redact(tip, fmt.Sprintf("<TIP-%d>", tipN))
+			}
+		}
+		for _, m := range reEntryHash.FindAllStringSubmatch(r.Stdout+r.Stderr, -1) {
+			if hash := m[1]; strings.HasPrefix(hash, "tip:") && !seenTips[hash] {
+				seenTips[hash] = true
+				tipN++
+				c.Redact(hash, fmt.Sprintf("<TIP-%d>", tipN))
+			}
+		}
+	}
+
+	// Node-b must be pinned before it can enforce; without this step WaitLockEnforcing
+	// would never return because an unpinned node that sees the trust log quarantines
+	// rather than enforcing.
+	c.Step(t, "pin-node-b", b.LockRun("pin", genesis))
+
+	lockedA := a.LockRun("status")
+	redactTip(lockedA)
+	c.Step(t, "status-a-locked", lockedA)
+
+	c.WaitLockEnforcing("node-b")
+
+	lockedB := b.LockRun("status")
+	redactTip(lockedB)
+	c.Step(t, "status-b-locked", lockedB)
+
+	logAfterInit := a.LockRun("log")
+	redactTip(logAfterInit)
+	c.Step(t, "log-after-init", logAfterInit)
+
+	addSignerB := a.LockRun("add-signer", sigB)
+	redactTip(addSignerB)
+	c.Step(t, "add-signer-b", addSignerB)
+
+	twoSigners := a.LockRun("status")
+	redactTip(twoSigners)
+	c.Step(t, "status-a-two-signers", twoSigners)
+
+	// Revoke before sign: node-b's device is authorized by the genesis, so signing
+	// it first would be a no-op. Revoking first makes both steps a real transition.
+	revokeDevB := a.LockRun("revoke-device", "node-b")
+	redactTip(revokeDevB)
+	c.Step(t, "revoke-device-b", revokeDevB)
+
+	c.WaitTip("node-b", Scrape(t, revokeDevB, PatTip))
+
+	revokedB := b.LockRun("status")
+	redactTip(revokedB)
+	c.Step(t, "status-b-revoked", revokedB)
+
+	signB := a.LockRun("sign", "node-b")
+	redactTip(signB)
+	c.Step(t, "sign-node-b", signB)
+
+	c.WaitTip("node-b", Scrape(t, signB, PatTip))
+
+	authorizedB := b.LockRun("status")
+	redactTip(authorizedB)
+	c.Step(t, "status-b-authorized", authorizedB)
+
+	removeSignerB := a.LockRun("remove-signer", sigB)
+	redactTip(removeSignerB)
+	c.Step(t, "remove-signer-b", removeSignerB)
+
+	oneSigner := a.LockRun("status")
+	redactTip(oneSigner)
+	c.Step(t, "status-a-one-signer", oneSigner)
+
+	logAfterChurn := a.LockRun("log")
+	redactTip(logAfterChurn)
+	c.Step(t, "log-after-signer-churn", logAfterChurn)
+
+	c.WaitTip("node-b", Scrape(t, removeSignerB, PatTip))
+
+	c.Step(t, "local-disable-b", b.LockRun("local-disable"))
+
+	localDisabledB := b.LockRun("status")
+	redactTip(localDisabledB)
+	c.Step(t, "status-b-local-disabled", localDisabledB)
+
+	stillEnforcingA := a.LockRun("status")
+	redactTip(stillEnforcingA)
+	c.Step(t, "status-a-still-enforcing", stillEnforcingA)
+
+	if len(secrets) == 0 {
+		t.Fatalf("init produced no disablement secret")
+	}
+
+	disableNet := a.LockRun("disable", secrets[0])
+	redactTip(disableNet)
+	c.Step(t, "disable-network", disableNet)
+
+	disabledA := a.LockRun("status")
+	redactTip(disabledA)
+	c.Step(t, "status-a-disabled", disabledA)
+
+	c.WaitLockDisabled("node-b")
+
+	disabledB := b.LockRun("status")
+	redactTip(disabledB)
+	c.Step(t, "status-b-disabled", disabledB)
+}

--- a/internal/e2elive/lifecycle_test.go
+++ b/internal/e2elive/lifecycle_test.go
@@ -21,12 +21,14 @@ func TestLockLifecycleCLI(t *testing.T) {
 	devA := Scrape(t, statusA, PatDeviceKey)
 	c.Redact(sigA, "<NODE-A-SIGPUB>")
 	c.Redact(devA, "<NODE-A-DEVPUB>")
+	c.Redact(Scrape(t, statusA, PatClientDeviceKey), "<NODE-A-CLIENT-DEVPUB>")
 
 	statusB := b.LockRun("status")
 	sigB := Scrape(t, statusB, PatSignerKey)
 	devB := Scrape(t, statusB, PatDeviceKey)
 	c.Redact(sigB, "<NODE-B-SIGPUB>")
 	c.Redact(devB, "<NODE-B-DEVPUB>")
+	c.Redact(Scrape(t, statusB, PatClientDeviceKey), "<NODE-B-CLIENT-DEVPUB>")
 
 	c.Step(t, "status-a-unlocked", statusA)
 	c.Step(t, "status-b-unlocked", statusB)

--- a/internal/e2elive/main_test.go
+++ b/internal/e2elive/main_test.go
@@ -1,0 +1,23 @@
+package e2elive
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		os.Exit(m.Run())
+	}
+	sweepStale()
+	if err := buildTestImage(); err != nil {
+		fmt.Fprintln(os.Stderr, "e2elive:", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sweepStale()
+	os.Exit(code)
+}

--- a/internal/e2elive/node.go
+++ b/internal/e2elive/node.go
@@ -1,0 +1,52 @@
+package e2elive
+
+import (
+	"path/filepath"
+
+	"github.com/MunifTanjim/argus/internal/config"
+)
+
+type Node struct {
+	ID     string
+	Dir    string
+	Socket string
+
+	cluster   *Cluster
+	container string
+	env       []string
+	args      []string
+}
+
+func (n *Node) Container() string { return n.container }
+
+// Log returns the node's container output. A restart replaces the container, so
+// this is always the current generation.
+func (n *Node) Log() string {
+	out, _ := dockerLogs(n.container)
+	return out
+}
+
+// StatePath resolves a file in this node's state directory on the host side of
+// the bind mount, so a test can reach the pin and chain the node persisted
+// without restating the layout.
+func (n *Node) StatePath(name string) string {
+	return filepath.Join(n.Dir, "state", config.ProjectName, name)
+}
+
+// StartAgent launches the fake claude in a detached tmux session inside the
+// node's container. Discovery correlates it through the container's own process
+// table and tmux server, so it is visible on this node only.
+func (n *Node) StartAgent(sessionName, sessionID string) {
+	n.cluster.t.Helper()
+	r := dockerExec(n.cluster.ctx, n.container, nil, []string{
+		"tmux", "new", "-d",
+		"-s", sessionName,
+		"-c", containerHome,
+		"-e", "FAKE_CLAUDE_SESSION_ID=" + sessionID,
+		"-e", "FAKE_CLAUDE_NAME=" + sessionName,
+		"claude",
+	})
+	if r.ExitCode != 0 {
+		n.cluster.t.Fatalf("StartAgent %s on %s: exit %d\n%s%s", sessionName, n.ID, r.ExitCode, r.Stdout, r.Stderr)
+	}
+}

--- a/internal/e2elive/normalize.go
+++ b/internal/e2elive/normalize.go
@@ -1,0 +1,108 @@
+package e2elive
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// isRosterLine reports whether a post-redaction line belongs to a sortable
+// roster block. The "  <NODE-…" form is the expected post-redaction placeholder
+// for both signers and devices in lock status output. The "  sigpub:…" branch
+// is unreachable in practice: redaction runs before sorting, and any raw
+// sigpub:<hex> that survives trips the volatility check before we get here.
+func isRosterLine(line string) bool {
+	return strings.HasPrefix(line, "  sigpub:") || strings.HasPrefix(line, "  <NODE-")
+}
+
+// sortSignerBlocks sorts consecutive roster lines within the string so that
+// their order is stable after redaction regardless of key-generation order.
+func sortSignerBlocks(s string) string {
+	lines := strings.Split(s, "\n")
+	i := 0
+	for i < len(lines) {
+		if !isRosterLine(lines[i]) {
+			i++
+			continue
+		}
+		j := i
+		for j < len(lines) && isRosterLine(lines[j]) {
+			j++
+		}
+		sort.Strings(lines[i:j])
+		i = j
+	}
+	return strings.Join(lines, "\n")
+}
+
+type redaction struct {
+	from string
+	to   string
+}
+
+var (
+	reTime = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})`)
+	reDur  = regexp.MustCompile(`(^|[^0-9A-Za-z_-])(\d+(?:\.\d+)?(?:ns|µs|us|ms|s|m|h))\b`)
+	reFP   = regexp.MustCompile(`\[[a-z]+(?: [a-z]+){1,23}\]`)
+
+	// A step fails if any of these survive normalization: they are per-run values
+	// that would bake randomness into a golden file.
+	volatile = []*regexp.Regexp{
+		regexp.MustCompile(`[0-9a-fA-F]{32,}`),
+		regexp.MustCompile(`127\.0\.0\.1:\d+`),
+		regexp.MustCompile(`(?:/private)?/(?:var/folders|tmp)/\S+`),
+		// Scoped roots live under the user's home, so a host path that escapes the
+		// <ROOT> and <*-DIR> redactions would carry a username into a golden.
+		regexp.MustCompile(`\S*` + regexp.QuoteMeta(scopedRootDir) + `/\S+`),
+		regexp.MustCompile(`[A-Za-z0-9+/]{40,}={0,2}`),
+		regexp.MustCompile(`\d{2}:\d{2}:\d{2}`),
+	}
+)
+
+// Redact registers a known per-run value and the placeholder that replaces it in
+// golden output. Registering the same value twice keeps the first placeholder.
+func (c *Cluster) Redact(actual, placeholder string) {
+	if actual == "" {
+		return
+	}
+	for _, r := range c.redactions {
+		if r.from == actual {
+			return
+		}
+	}
+	c.redactions = append(c.redactions, redaction{from: actual, to: placeholder})
+}
+
+func (c *Cluster) autoRedact() {
+	c.Redact(c.Root, "<ROOT>")
+	// The run id names the network and every container, so it reaches the goldens
+	// through the internal gateway URL on each command line.
+	c.Redact(c.runID, "<RUN-ID>")
+	c.Redact(c.Token, "<TOKEN>")
+	for id, n := range c.nodes {
+		c.Redact(n.Dir, "<"+id+"-DIR>")
+	}
+}
+
+func (c *Cluster) normalize(s string) (string, error) {
+	c.autoRedact()
+
+	sorted := append([]redaction{}, c.redactions...)
+	sort.SliceStable(sorted, func(i, j int) bool { return len(sorted[i].from) > len(sorted[j].from) })
+	for _, r := range sorted {
+		s = strings.ReplaceAll(s, r.from, r.to)
+	}
+
+	s = reTime.ReplaceAllString(s, "<TIME>")
+	s = reDur.ReplaceAllString(s, "${1}<DUR>")
+	s = reFP.ReplaceAllString(s, "<FP>")
+	s = sortSignerBlocks(s)
+
+	for _, re := range volatile {
+		if m := re.FindString(s); m != "" {
+			return "", fmt.Errorf("unregistered volatile value: %q — call Cluster.Redact for it", m)
+		}
+	}
+	return s, nil
+}

--- a/internal/e2elive/normalize_test.go
+++ b/internal/e2elive/normalize_test.go
@@ -1,0 +1,235 @@
+package e2elive
+
+import (
+	"strings"
+	"testing"
+)
+
+func newNormCluster() *Cluster {
+	return &Cluster{Root: "/var/folders/xy/abc123/T/axe999", GWAddr: "127.0.0.1:54321"}
+}
+
+func TestNormalizeSubstitutesRegisteredValues(t *testing.T) {
+	c := newNormCluster()
+	c.Redact("sigpub:"+strings.Repeat("a", 64), "<NODE-A-SIGPUB>")
+	c.Redact(c.Root, "<ROOT>")
+	c.Redact(c.GWAddr, "<GW-ADDR>")
+
+	in := "signer: sigpub:" + strings.Repeat("a", 64) + "\nsocket: " + c.Root + "/node-a/s\ngateway: ws://" + c.GWAddr + "\n"
+	got, err := c.normalize(in)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	want := "signer: <NODE-A-SIGPUB>\nsocket: <ROOT>/node-a/s\ngateway: ws://<GW-ADDR>\n"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestNormalizePrefersLongestMatch(t *testing.T) {
+	c := newNormCluster()
+	c.Redact("gen:abc", "<SHORT>")
+	c.Redact("gen:abcdef", "<LONG>")
+
+	got, err := c.normalize("x gen:abcdef y")
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if got != "x <LONG> y" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestNormalizeFallbacksTimeDurationFingerprint(t *testing.T) {
+	c := newNormCluster()
+	in := "at 2026-08-01T12:34:56Z took 1.25s\n  trust fingerprint: [amber koala rivet dune]\n"
+	got, err := c.normalize(in)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	want := "at <TIME> took <DUR>\n  trust fingerprint: <FP>\n"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// Fingerprints are now full-hash BIP39 mnemonics (24 words), so redaction must
+// cover a 24-word bracketed list, not just the old 8-word form.
+func TestNormalizeRedacts24WordBIP39Fingerprint(t *testing.T) {
+	c := newNormCluster()
+	in := "  pin: [omit flavor casino ticket elite odor toss gown gloom dog moment alter buddy perfect boost drip giggle talent spoil coyote refuse bird witness cover] (source: file)\n"
+	got, err := c.normalize(in)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	want := "  pin: <FP> (source: file)\n"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestNormalizeRejectsUnregisteredVolatileValues(t *testing.T) {
+	c := newNormCluster()
+	cases := map[string]string{
+		"hex":    "genesis: gen:" + strings.Repeat("f", 64),
+		"port":   "listening on 127.0.0.1:9999",
+		"tmp":    "wrote /var/folders/zz/other/T/axe000/x",
+		"base64": "blob: " + strings.Repeat("QUJD", 15) + "==",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := c.normalize(in); err == nil {
+				t.Fatalf("expected leftover-volatility failure for %q", in)
+			} else if !strings.Contains(err.Error(), "unregistered volatile value") {
+				t.Fatalf("wrong error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeAcceptsPlaceholdersAndPlainText(t *testing.T) {
+	c := newNormCluster()
+	in := "locked mode: enforcing\n  signers: 2\n  devices: 1\n  genesis: <GENESIS>\n"
+	got, err := c.normalize(in)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if got != in {
+		t.Fatalf("plain text changed:\n%s", got)
+	}
+}
+
+func TestNormalizeRejectsSpaceSeparatedTimestamp(t *testing.T) {
+	c := newNormCluster()
+	in := "event occurred at 2026-08-01 12:34:56 +0000\n"
+	if _, err := c.normalize(in); err == nil {
+		t.Fatalf("expected leftover-volatility failure for space-separated timestamp")
+	} else if !strings.Contains(err.Error(), "unregistered volatile value") {
+		t.Fatalf("wrong error: %v", err)
+	}
+}
+
+func TestNormalizeReplacesBracketedFingerprintsAnywhereInALine(t *testing.T) {
+	c := newNormCluster()
+	in := "  pin: [amber koala rivet dune] — SUPERSEDED: the network now uses [opal finch mesa gull]\n"
+	got, err := c.normalize(in)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	want := "  pin: <FP> — SUPERSEDED: the network now uses <FP>\n"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestNormalizeLeavesSingleBracketedWordsAlone(t *testing.T) {
+	c := newNormCluster()
+	in := "Usage:\n  argus lock init sigpub:<hex> [sigpub:<hex>...] [flags]\n"
+	got, err := c.normalize(in)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if got != in {
+		t.Fatalf("usage text was rewritten:\n%s", got)
+	}
+}
+
+func TestNormalizeDurationRegex(t *testing.T) {
+	c := newNormCluster()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "node-3m does not match (hyphen before duration)",
+			in:   "node: node-3m\nstatus: online\n",
+			want: "node: node-3m\nstatus: online\n",
+		},
+		{
+			name: "elapsed=1.25s matches (equals before duration)",
+			in:   "elapsed=1.25s\n",
+			want: "elapsed=<DUR>\n",
+		},
+		{
+			name: "timeout:30s matches (colon before duration)",
+			in:   "timeout:30s\n",
+			want: "timeout:<DUR>\n",
+		},
+		{
+			name: "took 1.25s matches (space before duration)",
+			in:   "took 1.25s\n",
+			want: "took <DUR>\n",
+		},
+		{
+			name: "multiple durations on one line both match",
+			in:   "1s 2s\n",
+			want: "<DUR> <DUR>\n",
+		},
+		{
+			name: "duration at start of line (^ anchor)",
+			in:   "500ms elapsed\n",
+			want: "<DUR> elapsed\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := c.normalize(tc.in)
+			if err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSortSignerBlocks(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "signers run sorted",
+			in:   "signers (2)\n  fingerprint: <FP>\n  <NODE-B-SIGPUB>\n  <NODE-A-SIGPUB>\n",
+			want: "signers (2)\n  fingerprint: <FP>\n  <NODE-A-SIGPUB>\n  <NODE-B-SIGPUB>\n",
+		},
+		{
+			name: "devices run sorted independently of signers run",
+			in: "signers (2)\n  fingerprint: <FP>\n  <NODE-B-SIGPUB>\n  <NODE-A-SIGPUB>\n" +
+				"\ndevices (2)\n  <NODE-B-DEVPUB>\n  <NODE-A-DEVPUB>\n",
+			want: "signers (2)\n  fingerprint: <FP>\n  <NODE-A-SIGPUB>\n  <NODE-B-SIGPUB>\n" +
+				"\ndevices (2)\n  <NODE-A-DEVPUB>\n  <NODE-B-DEVPUB>\n",
+		},
+		{
+			name: "run terminated by a blank line",
+			in:   "  <NODE-B-SIGPUB>\n  <NODE-A-SIGPUB>\n\nsome other section\n",
+			want: "  <NODE-A-SIGPUB>\n  <NODE-B-SIGPUB>\n\nsome other section\n",
+		},
+		{
+			name: "run terminated by fingerprint line",
+			in:   "  <NODE-B-SIGPUB>\n  <NODE-A-SIGPUB>\n  fingerprint: <FP>\n",
+			want: "  <NODE-A-SIGPUB>\n  <NODE-B-SIGPUB>\n  fingerprint: <FP>\n",
+		},
+		{
+			name: "run terminated by identity line",
+			in:   "  <NODE-B-SIGPUB>\n  <NODE-A-SIGPUB>\n  identity: <NODE-A-DEVPUB>\n",
+			want: "  <NODE-A-SIGPUB>\n  <NODE-B-SIGPUB>\n  identity: <NODE-A-DEVPUB>\n",
+		},
+		{
+			name: "no roster lines left unchanged",
+			in:   "locked mode: enforcing\n  pin: <FP> (source: file)\n",
+			want: "locked mode: enforcing\n  pin: <FP> (source: file)\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sortSignerBlocks(tc.in)
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/e2elive/parity_test.go
+++ b/internal/e2elive/parity_test.go
@@ -1,0 +1,162 @@
+package e2elive
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// TestAgentIsVisibleOnItsOwnNodeOnlyPlaintext mirrors
+// TestAgentIsVisibleOnItsOwnNodeOnly for the plaintext cipher mode.
+func TestAgentIsVisibleOnItsOwnNodeOnlyPlaintext(t *testing.T) {
+	c := NewPlaintext(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	a.StartAgent("work", "sid-node-a")
+
+	cl := c.NewClient()
+	waitChannels(t, cl, "node-a", "node-b")
+
+	found := waitSessions(t, cl, "node-a session to appear", func(ss []session.Session) bool {
+		return len(ss) > 0
+	})
+
+	if len(found) != 1 {
+		t.Fatalf("sessions = %d, want 1: %+v", len(found), found)
+	}
+	if found[0].NodeID != "node-a" {
+		t.Fatalf("session node = %q, want node-a", found[0].NodeID)
+	}
+	if found[0].AgentSessionID != "sid-node-a" {
+		t.Fatalf("agent session id = %q, want sid-node-a", found[0].AgentSessionID)
+	}
+}
+
+// TestEachNodeReportsItsOwnAgentPlaintext mirrors
+// TestEachNodeReportsItsOwnAgent for the plaintext cipher mode.
+func TestEachNodeReportsItsOwnAgentPlaintext(t *testing.T) {
+	c := NewPlaintext(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	b := c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	a.StartAgent("alpha", "sid-alpha")
+	b.StartAgent("beta", "sid-beta")
+
+	cl := c.NewClient()
+	waitChannels(t, cl, "node-a", "node-b")
+
+	found := waitSessions(t, cl, "both sessions to appear", func(ss []session.Session) bool {
+		return len(ss) == 2
+	})
+
+	byNode := map[string]string{}
+	for _, s := range found {
+		byNode[s.NodeID] = s.AgentSessionID
+	}
+	if byNode["node-a"] != "sid-alpha" {
+		t.Fatalf("node-a session = %q, want sid-alpha (all: %+v)", byNode["node-a"], found)
+	}
+	if byNode["node-b"] != "sid-beta" {
+		t.Fatalf("node-b session = %q, want sid-beta (all: %+v)", byNode["node-b"], found)
+	}
+}
+
+// TestNodeRestartsAndRejoinsPlaintext verifies that after a node restart in
+// plaintext mode the gateway re-lists it online and the client can reach its
+// sessions over a freshly established relay channel. A container restart ends
+// the live agent session (the tmux server is gone), so the test re-plants the
+// agent after restart and confirms the client sees it through the new channel.
+func TestNodeRestartsAndRejoinsPlaintext(t *testing.T) {
+	c := NewPlaintext(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	c.WaitOnline("node-a")
+
+	a.StartAgent("work", "sid-node-a")
+
+	cl := c.NewClient()
+	waitChannels(t, cl, "node-a")
+
+	waitSessions(t, cl, "initial session", func(ss []session.Session) bool {
+		return len(ss) > 0
+	})
+
+	c.RestartNode("node-a")
+	c.WaitOnline("node-a")
+
+	// After the restart a new relay channel must be established.
+	waitChannels(t, cl, "node-a")
+
+	// The old agent session died with the container; re-plant it.
+	a.StartAgent("work", "sid-node-a")
+
+	found := waitSessions(t, cl, "session after restart", func(ss []session.Session) bool {
+		return len(ss) > 0
+	})
+
+	if len(found) != 1 {
+		t.Fatalf("sessions after restart = %d, want 1: %+v", len(found), found)
+	}
+	if found[0].NodeID != "node-a" {
+		t.Fatalf("session node after restart = %q, want node-a", found[0].NodeID)
+	}
+}
+
+// sessionEntry is the subset of a session used for parity comparison.
+type sessionEntry struct {
+	NodeID         string
+	AgentSessionID string
+}
+
+// sessionEntries extracts and sorts the parity-comparable fields from a session list.
+func sessionEntries(sessions []session.Session) []sessionEntry {
+	entries := make([]sessionEntry, len(sessions))
+	for i, s := range sessions {
+		entries[i] = sessionEntry{NodeID: s.NodeID, AgentSessionID: s.AgentSessionID}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].NodeID < entries[j].NodeID
+	})
+	return entries
+}
+
+// runSessionScenario starts a two-node cluster under c, plants one agent per
+// node, and returns the merged session list seen by a client.
+func runSessionScenario(t *testing.T, c *Cluster) []sessionEntry {
+	t.Helper()
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	b := c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	a.StartAgent("alpha", "sid-alpha")
+	b.StartAgent("beta", "sid-beta")
+
+	cl := c.NewClient()
+	waitChannels(t, cl, "node-a", "node-b")
+
+	found := waitSessions(t, cl, "both sessions to appear", func(ss []session.Session) bool {
+		return len(ss) == 2
+	})
+	return sessionEntries(found)
+}
+
+// TestLiveParityPlainVsE2EE runs the same session fan-out scenario in both
+// cipher modes and asserts the client-visible merged session list is structurally
+// identical — same nodes, same agent session IDs. This guards against the
+// plaintext relay path dropping or duplicating sessions compared with E2EE.
+func TestLiveParityPlainVsE2EE(t *testing.T) {
+	plain := runSessionScenario(t, NewPlaintext(t))
+	enc := runSessionScenario(t, New(t))
+
+	if !reflect.DeepEqual(plain, enc) {
+		t.Fatalf("plaintext vs e2ee session parity mismatch:\n  plain: %+v\n  e2ee:  %+v", plain, enc)
+	}
+}

--- a/internal/e2elive/pin_errors_test.go
+++ b/internal/e2elive/pin_errors_test.go
@@ -1,0 +1,159 @@
+package e2elive
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestLockPinAndErrorsCLI pins the failure surface of `argus lock` — exit codes and
+// error text — plus the client pin lifecycle, on one cluster in state order.
+func TestLockPinAndErrorsCLI(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	b := c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	statusA := a.LockRun("status")
+	sigA := Scrape(t, statusA, PatSignerKey)
+	c.Redact(sigA, "<NODE-A-SIGPUB>")
+	c.Redact(Scrape(t, statusA, PatDeviceKey), "<NODE-A-DEVPUB>")
+	statusB := b.LockRun("status")
+	sigB := Scrape(t, statusB, PatSignerKey)
+	c.Redact(sigB, "<NODE-B-SIGPUB>")
+	c.Redact(Scrape(t, statusB, PatDeviceKey), "<NODE-B-DEVPUB>")
+
+	reTip := regexp.MustCompile(PatTip)
+	seenTips := map[string]bool{}
+	tipN := 0
+	redactTip := func(r Result) {
+		for _, m := range reTip.FindAllStringSubmatch(r.Stdout+r.Stderr, -1) {
+			if tip := m[1]; !seenTips[tip] {
+				seenTips[tip] = true
+				tipN++
+				c.Redact(tip, fmt.Sprintf("<TIP-%d>", tipN))
+			}
+		}
+	}
+
+	c.Redact("127.0.0.1:1", "<UNREACHABLE-GW-ADDR>")
+	c.Redact(strings.Repeat("0", 64), "<NULL-KEY>")
+	c.Redact(strings.Repeat("9", 64), "<FAKE-SECRET>")
+
+	// Phase 1 — unlocked network and connectivity failures.
+	c.Step(t, "p1-status-unlocked", statusA)
+	c.Step(t, "p1-log-unlocked", a.LockRun("log"))
+	c.Step(t, "p1-sign-while-unlocked", a.LockRun("sign", "node-b"))
+	c.Step(t, "p1-disable-while-unlocked", a.LockRun("disable", "somesecret"))
+	c.Step(t, "p1-bad-token", a.LockRun("status", "--token=wrong-token"))
+	c.Step(t, "p1-unreachable-gateway", a.LockRun("status", "--gateway=ws://127.0.0.1:1"))
+
+	// When the socket is unreachable the CLI falls back to client mode via the
+	// gateway, which generates an ephemeral per-run device key that must be
+	// redacted before the golden comparison.
+	unreachableSocket := a.LockRun("status", "--socket="+containerHome+"/nope.sock")
+	for _, m := range regexp.MustCompile(PatClientDeviceKey).FindAllStringSubmatch(unreachableSocket.Stdout+unreachableSocket.Stderr, -1) {
+		c.Redact(m[1], "<CLI-CLIENT-DEVPUB>")
+	}
+	c.Step(t, "p1-unreachable-socket", unreachableSocket)
+
+	// Phase 2 — argument validation; no state change, so order is free.
+	c.Step(t, "p2-init-no-args", a.LockRun("init"))
+	c.Step(t, "p2-init-malformed-key", a.LockRun("init", "sigpub:zzzz"))
+	c.Step(t, "p2-add-signer-malformed", a.LockRun("add-signer", "sigpub:nothex"))
+	c.Step(t, "p2-sign-unknown-device", a.LockRun("sign", "nosuchdevice"))
+	c.Step(t, "p2-revoke-unknown-device", a.LockRun("revoke-device", "devpub:"+strings.Repeat("0", 64)))
+	c.Step(t, "p2-pin-garbage", a.LockRun("pin", "gen:garbage"))
+	c.Step(t, "p2-unpin-not-pinned", a.LockRun("unpin"))
+	c.Step(t, "p2-cosign-garbage", a.LockRun("revoke-signer", "--cosign", "!!!notbase64!!!"))
+
+	// Phase 3 — pin lifecycle: pin, then re-init to supersede the pinned genesis.
+	first := a.LockRun("init", sigA, "--confirm")
+	redactTip(first)
+	gen1 := Scrape(t, first, PatGenesis)
+	secrets1 := ScrapeAll(t, first, PatDisablement)
+	c.Redact(gen1, "<GENESIS-1>")
+	for i, s := range secrets1 {
+		c.Redact(s, "<SECRET-1-"+string(rune('1'+i))+">")
+	}
+	c.Step(t, "p3-init-first", first)
+
+	pinRes := a.LockRun("pin", gen1)
+	redactTip(pinRes)
+	c.Step(t, "p3-pin", pinRes)
+	c.WaitLockEnforcing("node-a")
+
+	// Node-b also pins gen1 so it will show the superseded-pin quarantine state
+	// after gen2 is created. Node-a auto-repins during re-init, so it cannot be
+	// used for this check.
+	pinBRes := b.LockRun("pin", gen1)
+	redactTip(pinBRes)
+	c.Step(t, "p3-pin-b", pinBRes)
+
+	statusPinned := a.LockRun("status")
+	redactTip(statusPinned)
+	c.Step(t, "p3-status-pinned", statusPinned)
+
+	if len(secrets1) == 0 {
+		t.Fatalf("first init produced no disablement secret")
+	}
+	disableFirst := a.LockRun("disable", secrets1[0])
+	redactTip(disableFirst)
+	c.Step(t, "p3-disable-first", disableFirst)
+
+	c.WaitLockDisabled("node-a")
+	c.WaitLockDisabled("node-b")
+
+	second := a.LockRun("init", sigA, "--confirm")
+	redactTip(second)
+	gen2 := Scrape(t, second, PatGenesis)
+	for i, s := range ScrapeAll(t, second, PatDisablement) {
+		c.Redact(s, "<SECRET-2-"+string(rune('1'+i))+">")
+	}
+	c.Redact(gen2, "<GENESIS-2>")
+	c.Step(t, "p3-reinit-new-genesis", second)
+
+	// Node-b is still pinned to gen1, which is now superseded by gen2. Its status
+	// must show the quarantine/supersession headline, and the pin it advises must
+	// name the live root — not the dead one it is still following.
+	c.WaitLockQuarantined("node-b")
+
+	statusSuperseded := b.LockRun("status")
+	redactTip(statusSuperseded)
+	c.Step(t, "p3-status-superseded-pin", statusSuperseded)
+
+	unpinRes := b.LockRun("unpin")
+	redactTip(unpinRes)
+	c.Step(t, "p3-unpin", unpinRes)
+
+	statusUnpinned := b.LockRun("status")
+	redactTip(statusUnpinned)
+	c.Step(t, "p3-status-unpinned", statusUnpinned)
+
+	// Phase 4 — precondition failures against the now-locked network.
+	//
+	// p4-init-already-locked: the CLI should reject this with a non-zero exit.
+	// If it succeeds, that is a real bug; the volatile values are still redacted
+	// so the golden records the exact (buggy) output rather than aborting.
+	p4Init := a.LockRun("init", sigA, "--confirm")
+	redactTip(p4Init)
+	reGen := regexp.MustCompile(PatGenesis)
+	reDis := regexp.MustCompile(PatDisablement)
+	if m := reGen.FindStringSubmatch(p4Init.Stdout + p4Init.Stderr); m != nil {
+		c.Redact(m[1], "<GENESIS-UNEXPECTED>")
+		for i, ms := range reDis.FindAllStringSubmatch(p4Init.Stdout+p4Init.Stderr, -1) {
+			c.Redact(ms[1], fmt.Sprintf("<SECRET-UNEXPECTED-%d>", i+1))
+		}
+	}
+	c.Step(t, "p4-init-already-locked", p4Init)
+	c.Step(t, "p4-disable-wrong-secret", a.LockRun("disable", "dis:"+strings.Repeat("9", 64)))
+
+	start := a.LockRun("revoke-signer", sigA, "--replacement", sigB)
+	redactTip(start)
+	blob := Scrape(t, start, PatBlob)
+	c.Redact(blob, "<BLOB-START>")
+	c.Step(t, "p4-revoke-signer-start", start)
+	c.Step(t, "p4-finish-insufficient-cosigns", a.LockRun("revoke-signer", "--finish", blob))
+}

--- a/internal/e2elive/pin_errors_test.go
+++ b/internal/e2elive/pin_errors_test.go
@@ -20,10 +20,12 @@ func TestLockPinAndErrorsCLI(t *testing.T) {
 	sigA := Scrape(t, statusA, PatSignerKey)
 	c.Redact(sigA, "<NODE-A-SIGPUB>")
 	c.Redact(Scrape(t, statusA, PatDeviceKey), "<NODE-A-DEVPUB>")
+	c.Redact(Scrape(t, statusA, PatClientDeviceKey), "<NODE-A-CLIENT-DEVPUB>")
 	statusB := b.LockRun("status")
 	sigB := Scrape(t, statusB, PatSignerKey)
 	c.Redact(sigB, "<NODE-B-SIGPUB>")
 	c.Redact(Scrape(t, statusB, PatDeviceKey), "<NODE-B-DEVPUB>")
+	c.Redact(Scrape(t, statusB, PatClientDeviceKey), "<NODE-B-CLIENT-DEVPUB>")
 
 	reTip := regexp.MustCompile(PatTip)
 	seenTips := map[string]bool{}

--- a/internal/e2elive/procenv.go
+++ b/internal/e2elive/procenv.go
@@ -1,0 +1,55 @@
+package e2elive
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// containerEnv creates the per-process directories on the host side of the bind
+// mount and returns the environment naming them by their container paths.
+func containerEnv(hostDir string) ([]string, error) {
+	for _, sub := range []string{"config", "state", "cache", "run"} {
+		if err := os.MkdirAll(filepath.Join(hostDir, sub), 0o700); err != nil {
+			return nil, err
+		}
+	}
+	return []string{
+		"HOME=" + containerHome,
+		"XDG_CONFIG_HOME=" + containerHome + "/config",
+		"XDG_STATE_HOME=" + containerHome + "/state",
+		"XDG_CACHE_HOME=" + containerHome + "/cache",
+		"XDG_RUNTIME_DIR=" + containerHome + "/run",
+	}, nil
+}
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freePort: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().String()
+}
+
+// The budget every poll loop in this package spends. The deadline is generous
+// because a container start is far slower than a process start.
+const (
+	waitTimeout  = 60 * time.Second
+	waitInterval = 25 * time.Millisecond
+)
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(waitTimeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(waitInterval)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/internal/e2elive/procenv_test.go
+++ b/internal/e2elive/procenv_test.go
@@ -1,0 +1,56 @@
+package e2elive
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestContainerEnvCreatesHostDirsAndContainerVars(t *testing.T) {
+	dir := t.TempDir()
+	env, err := containerEnv(dir)
+	if err != nil {
+		t.Fatalf("containerEnv: %v", err)
+	}
+
+	for _, sub := range []string{"config", "state", "cache", "run"} {
+		p := filepath.Join(dir, sub)
+		info, statErr := os.Stat(p)
+		if statErr != nil || !info.IsDir() {
+			t.Fatalf("expected dir %s: err=%v", p, statErr)
+		}
+	}
+
+	want := map[string]string{
+		"HOME":            containerHome,
+		"XDG_CONFIG_HOME": containerHome + "/config",
+		"XDG_STATE_HOME":  containerHome + "/state",
+		"XDG_CACHE_HOME":  containerHome + "/cache",
+		"XDG_RUNTIME_DIR": containerHome + "/run",
+	}
+	got := map[string]string{}
+	var keys []string
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		got[k] = v
+		keys = append(keys, k)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("env %s = %q, want %q", k, got[k], v)
+		}
+	}
+	sort.Strings(keys)
+	if len(keys) != len(want) {
+		t.Errorf("env has %d vars (%v), want exactly %d", len(keys), keys, len(want))
+	}
+}
+
+func TestFreePortIsDialable(t *testing.T) {
+	addr := freePort(t)
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("addr = %q, want 127.0.0.1:<port>", addr)
+	}
+}

--- a/internal/e2elive/restart_test.go
+++ b/internal/e2elive/restart_test.go
@@ -1,0 +1,163 @@
+package e2elive
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// lockedPair brings up a gateway and two nodes, locks the network with node-a as
+// the sole signer, pins node-b to it, and returns the two nodes plus a redactor
+// that registers every tip it is shown. It exists so the restart tests start from
+// the state a reboot is interesting in — a converged, enforcing peer — without
+// each of them re-deriving it.
+func lockedPair(t *testing.T, c *Cluster) (a, b *Node, redactTip func(Result)) {
+	t.Helper()
+	c.StartGateway()
+	a = c.AddNode("node-a")
+	b = c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	statusA := a.LockRun("status")
+	sigA := Scrape(t, statusA, PatSignerKey)
+	c.Redact(sigA, "<NODE-A-SIGPUB>")
+	c.Redact(Scrape(t, statusA, PatDeviceKey), "<NODE-A-DEVPUB>")
+	statusB := b.LockRun("status")
+	c.Redact(Scrape(t, statusB, PatSignerKey), "<NODE-B-SIGPUB>")
+	c.Redact(Scrape(t, statusB, PatDeviceKey), "<NODE-B-DEVPUB>")
+
+	reTip := regexp.MustCompile(PatTip)
+	seen := map[string]bool{}
+	n := 0
+	redactTip = func(r Result) {
+		for _, m := range reTip.FindAllStringSubmatch(r.Stdout+r.Stderr, -1) {
+			if tip := m[1]; !seen[tip] {
+				seen[tip] = true
+				n++
+				c.Redact(tip, fmt.Sprintf("<TIP-%d>", n))
+			}
+		}
+	}
+
+	initRes := a.LockRun("init", sigA, "--confirm")
+	genesis := Scrape(t, initRes, PatGenesis)
+	c.Redact(genesis, "<GENESIS>")
+	for i, s := range ScrapeAll(t, initRes, PatDisablement) {
+		c.Redact(s, "<SECRET-"+string(rune('1'+i))+">")
+	}
+	redactTip(initRes)
+
+	c.Step(t, "pin-node-b", b.LockRun("pin", genesis))
+	c.WaitLockEnforcing("node-b")
+	return a, b, redactTip
+}
+
+// TestNodeRestartKeepsLockCLI answers the question an operator has after rebooting
+// a machine: is the node still locked, and do I have to pin it again? It must come
+// back enforcing at the tip it went down on, from its own disk, with no `lock pin`
+// run in between — and it must still be a live participant afterwards, not just a
+// process holding stale state.
+func TestNodeRestartKeepsLockCLI(t *testing.T) {
+	c := New(t)
+	a, b, redactTip := lockedPair(t, c)
+
+	before := b.LockRun("status")
+	redactTip(before)
+	c.Step(t, "status-b-before-restart", before)
+	tip := Scrape(t, before, PatTip)
+
+	c.RestartNode("node-b")
+
+	c.WaitTip("node-b", tip)
+	after := b.LockRun("status")
+	redactTip(after)
+	if !strings.Contains(after.Stdout, "locked mode: enforcing") {
+		t.Fatalf("node-b came back open after a restart:\n%s", after.Stdout)
+	}
+	if strings.Contains(after.Stdout, "pin: none") {
+		t.Fatalf("node-b lost its pin across a restart:\n%s", after.Stdout)
+	}
+	c.Step(t, "status-b-after-restart", after)
+
+	// Reloading the pin is not enough on its own: the restarted node has to be
+	// syncing again too, so a write on node-a must still reach it.
+	revoke := a.LockRun("revoke-device", "node-b")
+	redactTip(revoke)
+	c.Step(t, "revoke-device-b-after-restart", revoke)
+
+	c.WaitTip("node-b", Scrape(t, revoke, PatTip))
+	converged := b.LockRun("status")
+	redactTip(converged)
+	c.Step(t, "status-b-converged-after-restart", converged)
+}
+
+// TestGatewayRestartKeepsFleetLockedCLI reboots the gateway host. Two things must
+// hold: losing the relay does not unlock anything (a blind gateway is not what
+// enforces), and once it is back the fleet refills its empty entry store by itself,
+// so a write made after the restart still reaches a peer.
+func TestGatewayRestartKeepsFleetLockedCLI(t *testing.T) {
+	c := New(t)
+	a, b, redactTip := lockedPair(t, c)
+
+	c.StopGateway()
+
+	down := b.LockRun("status")
+	redactTip(down)
+	if !strings.Contains(down.Stdout, "locked mode: enforcing") {
+		t.Fatalf("node-b stopped enforcing when the gateway went away:\n%s", down.Stdout)
+	}
+	c.Step(t, "status-b-gateway-down", down)
+
+	c.StartGateway()
+	c.WaitOnline("node-a", "node-b")
+
+	// The replacement gateway holds no entries. Node-a re-offers its chain on
+	// reconnect, which is the only reason this write can reach node-b at all.
+	revoke := a.LockRun("revoke-device", "node-b")
+	redactTip(revoke)
+	c.Step(t, "revoke-device-b-after-gw-restart", revoke)
+
+	c.WaitTip("node-b", Scrape(t, revoke, PatTip))
+	converged := b.LockRun("status")
+	redactTip(converged)
+	c.Step(t, "status-b-converged-after-gw-restart", converged)
+}
+
+// TestNodeRestartWithCorruptChainCLI corrupts the persisted chain while the node is
+// down. The pin is what makes the network locked for this device, and it lives in a
+// separate file — so an unreadable chain must not come back as an open node. The
+// node is expected to start pinned with nothing loaded and refill from the gateway.
+func TestNodeRestartWithCorruptChainCLI(t *testing.T) {
+	c := New(t)
+	_, b, redactTip := lockedPair(t, c)
+
+	before := b.LockRun("status")
+	redactTip(before)
+	tip := Scrape(t, before, PatTip)
+
+	c.StopNode("node-b")
+	chain := b.StatePath("trustlog-chain")
+	if _, err := os.Stat(chain); err != nil {
+		t.Fatalf("expected a persisted chain at %s: %v", chain, err)
+	}
+	if err := os.WriteFile(chain, []byte("not a trust-log chain"), 0o600); err != nil {
+		t.Fatalf("corrupt chain: %v", err)
+	}
+	c.StartNode("node-b")
+
+	// Without this the test would still pass if the corruption never reached the
+	// boot path, and would quietly stop covering anything.
+	waitFor(t, "node-b reports the unusable chain", func() bool {
+		return strings.Contains(b.Log(), "ignoring unusable persisted trust-log chain")
+	})
+
+	c.WaitTip("node-b", tip)
+	recovered := b.LockRun("status")
+	redactTip(recovered)
+	if !strings.Contains(recovered.Stdout, "locked mode: enforcing") {
+		t.Fatalf("a corrupt chain must not leave node-b open:\n%s", recovered.Stdout)
+	}
+	c.Step(t, "status-b-after-corrupt-chain", recovered)
+}

--- a/internal/e2elive/restart_test.go
+++ b/internal/e2elive/restart_test.go
@@ -24,9 +24,11 @@ func lockedPair(t *testing.T, c *Cluster) (a, b *Node, redactTip func(Result)) {
 	sigA := Scrape(t, statusA, PatSignerKey)
 	c.Redact(sigA, "<NODE-A-SIGPUB>")
 	c.Redact(Scrape(t, statusA, PatDeviceKey), "<NODE-A-DEVPUB>")
+	c.Redact(Scrape(t, statusA, PatClientDeviceKey), "<NODE-A-CLIENT-DEVPUB>")
 	statusB := b.LockRun("status")
 	c.Redact(Scrape(t, statusB, PatSignerKey), "<NODE-B-SIGPUB>")
 	c.Redact(Scrape(t, statusB, PatDeviceKey), "<NODE-B-DEVPUB>")
+	c.Redact(Scrape(t, statusB, PatClientDeviceKey), "<NODE-B-CLIENT-DEVPUB>")
 
 	reTip := regexp.MustCompile(PatTip)
 	seen := map[string]bool{}

--- a/internal/e2elive/result.go
+++ b/internal/e2elive/result.go
@@ -1,0 +1,61 @@
+package e2elive
+
+import "strings"
+
+// Result is one CLI invocation: the arguments, the two output streams captured
+// separately, and the process exit code. A non-zero exit is data, not an error —
+// the error-path tests assert on it.
+type Result struct {
+	Args     []string
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// callerSupplied reports whether args already contains a value for the given flag
+// name (e.g. "--token"). It matches both "--token=<val>" and the two-element form
+// "--token" "<val>".
+func callerSupplied(args []string, flag string) bool {
+	prefix := flag + "="
+	for _, a := range args {
+		if a == flag || strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildLockArgs returns the full argument slice for `argus lock`, appending the
+// default socket/gateway/token values only when the caller has not already
+// supplied them. This prevents harness defaults from shadowing intentionally
+// wrong values in error-path tests.
+func buildLockArgs(callerArgs []string, socket, gwURL, token string) []string {
+	full := append([]string{"lock"}, callerArgs...)
+	if !callerSupplied(callerArgs, "--socket") {
+		full = append(full, "--socket="+socket)
+	}
+	if !callerSupplied(callerArgs, "--gateway") {
+		full = append(full, "--gateway="+gwURL)
+	}
+	if !callerSupplied(callerArgs, "--token") {
+		full = append(full, "--token="+token)
+	}
+	return full
+}
+
+func (n *Node) LockRun(args ...string) Result {
+	return n.LockRunEnv(nil, args...)
+}
+
+// LockRunEnv runs `argus lock ...` inside this node's container with extra
+// environment entries. Harness defaults for --socket, --gateway, and --token are
+// appended only when the caller has not already supplied them, so error-path
+// tests can pass intentionally wrong values. The gateway default is the internal
+// URL: the command runs inside a container, where the host address reaches
+// nothing.
+func (n *Node) LockRunEnv(extra []string, args ...string) Result {
+	full := buildLockArgs(args, n.Socket, n.cluster.GWURLInternal, n.cluster.Token)
+	env := append(append([]string{}, n.env...), extra...)
+	r := dockerExec(n.cluster.ctx, n.container, env, append([]string{"argus"}, full...))
+	return Result{Args: full, Stdout: r.Stdout, Stderr: r.Stderr, ExitCode: r.ExitCode}
+}

--- a/internal/e2elive/result_test.go
+++ b/internal/e2elive/result_test.go
@@ -1,0 +1,44 @@
+package e2elive
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBuildLockArgsDefaultsWhenCallerSuppliesNothing(t *testing.T) {
+	got := buildLockArgs([]string{"status"}, "/sock", "ws://gw", "tok")
+	want := []string{"lock", "status", "--socket=/sock", "--gateway=ws://gw", "--token=tok"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildLockArgsDoesNotAppendWhenCallerSuppliesEqualForm(t *testing.T) {
+	args := []string{"status", "--token=wrong-token"}
+	got := buildLockArgs(args, "/sock", "ws://gw", "tok")
+	for _, a := range got {
+		if a == "--token=tok" {
+			t.Fatalf("harness token was appended even though caller supplied --token: %v", got)
+		}
+	}
+}
+
+func TestBuildLockArgsDoesNotAppendWhenCallerSuppliesBareFlag(t *testing.T) {
+	args := []string{"status", "--gateway", "ws://127.0.0.1:1"}
+	got := buildLockArgs(args, "/sock", "ws://gw", "tok")
+	for _, a := range got {
+		if a == "--gateway=ws://gw" {
+			t.Fatalf("harness gateway was appended even though caller supplied --gateway: %v", got)
+		}
+	}
+}
+
+func TestBuildLockArgsDoesNotAppendWhenCallerSuppliesSocket(t *testing.T) {
+	args := []string{"status", "--socket=/nowhere.sock"}
+	got := buildLockArgs(args, "/sock", "ws://gw", "tok")
+	for _, a := range got {
+		if a == "--socket=/sock" {
+			t.Fatalf("harness socket was appended even though caller supplied --socket: %v", got)
+		}
+	}
+}

--- a/internal/e2elive/scrape.go
+++ b/internal/e2elive/scrape.go
@@ -1,0 +1,68 @@
+package e2elive
+
+import (
+	"regexp"
+	"sync"
+	"testing"
+)
+
+// Patterns for reading values back out of real CLI output. Group 1 is the value.
+const (
+	PatSignerKey = `  signer:   (sigpub:[0-9a-f]+)`
+	PatDeviceKey = `  identity: (devpub:[0-9a-f]+)`
+	// PatClientDeviceKey matches the ephemeral device identity printed in client
+	// mode (no local node socket), distinct from PatDeviceKey which matches the
+	// node-process identity.
+	PatClientDeviceKey = `this device identity: (devpub:[0-9a-f]+)`
+	PatGenesis         = `genesis: (gen:[0-9a-f]+)`
+	// PatTip matches both the operation-confirmation format ("current tip (audit):")
+	// and the lock-status section format ("  tip:").
+	PatTip = `tip(?:\s*\(audit\))?: +(tip:[0-9a-f]+)`
+	// PatEntryHash matches the per-entry hash line that lock log emits under each
+	// entry. Entry 0 uses the gen: prefix; all later entries use tip:.
+	PatEntryHash   = `  hash: ((?:gen|tip):[0-9a-f]+)`
+	PatDisablement = `disablement secret: (dis:[0-9a-f]+)`
+	// Both the `blob: <b64>` stdout line and the `--cosign <b64>` stderr hint.
+	PatBlob = `(?:blob: |--cosign )([A-Za-z0-9+/=]+)`
+)
+
+var (
+	reCacheMu sync.Mutex
+	reCache   = map[string]*regexp.Regexp{}
+)
+
+func compilePattern(pattern string) *regexp.Regexp {
+	reCacheMu.Lock()
+	defer reCacheMu.Unlock()
+	if re, ok := reCache[pattern]; ok {
+		return re
+	}
+	re := regexp.MustCompile(pattern)
+	reCache[pattern] = re
+	return re
+}
+
+// Scrape returns the first capture-group match across stdout then stderr, failing
+// the test when the value the CLI is supposed to print is absent.
+func Scrape(t *testing.T, r Result, pattern string) string {
+	t.Helper()
+	if all := ScrapeAll(t, r, pattern); len(all) > 0 {
+		return all[0]
+	}
+	return ""
+}
+
+func ScrapeAll(t *testing.T, r Result, pattern string) []string {
+	t.Helper()
+	re := compilePattern(pattern)
+	var out []string
+	for _, s := range []string{r.Stdout, r.Stderr} {
+		for _, m := range re.FindAllStringSubmatch(s, -1) {
+			out = append(out, m[1])
+		}
+	}
+	if len(out) == 0 {
+		t.Errorf("scrape %q found nothing in:\n--- stdout ---\n%s--- stderr ---\n%s", pattern, r.Stdout, r.Stderr)
+	}
+	return out
+}

--- a/internal/e2elive/scrape.go
+++ b/internal/e2elive/scrape.go
@@ -10,10 +10,9 @@ import (
 const (
 	PatSignerKey = `  signer:   (sigpub:[0-9a-f]+)`
 	PatDeviceKey = `  identity: (devpub:[0-9a-f]+)`
-	// PatClientDeviceKey matches the ephemeral device identity printed in client
-	// mode (no local node socket), distinct from PatDeviceKey which matches the
-	// node-process identity.
-	PatClientDeviceKey = `this device identity: (devpub:[0-9a-f]+)`
+	// PatClientDeviceKey matches the tui (client) identity printed in the "this tui"
+	// block, distinct from PatDeviceKey which matches the "this node" identity.
+	PatClientDeviceKey = `this tui\n  identity: (devpub:[0-9a-f]+)`
 	PatGenesis         = `genesis: (gen:[0-9a-f]+)`
 	// PatTip matches both the operation-confirmation format ("current tip (audit):")
 	// and the lock-status section format ("  tip:").

--- a/internal/e2elive/scrape_test.go
+++ b/internal/e2elive/scrape_test.go
@@ -1,0 +1,59 @@
+package e2elive
+
+import (
+	"strings"
+	"testing"
+)
+
+const sampleStatus = `locked mode: not enabled
+
+chain: none — never initialized
+
+this node
+  identity: devpub:2222222222222222222222222222222222222222222222222222222222222222
+  signer:   sigpub:1111111111111111111111111111111111111111111111111111111111111111
+`
+
+const sampleInit = `locked mode enabled
+  genesis: gen:3333333333333333333333333333333333333333333333333333333333333333
+  signers: 1
+  disablement secret: dis:4444444444444444444444444444444444444444444444444444444444444444
+  disablement secret: dis:5555555555555555555555555555555555555555555555555555555555555555
+`
+
+func TestScrapePullsKeysFromStatus(t *testing.T) {
+	r := Result{Stdout: sampleStatus}
+	if got := Scrape(t, r, PatSignerKey); !strings.HasPrefix(got, "sigpub:1111") {
+		t.Fatalf("signer key = %q", got)
+	}
+	if got := Scrape(t, r, PatDeviceKey); !strings.HasPrefix(got, "devpub:2222") {
+		t.Fatalf("device key = %q", got)
+	}
+}
+
+func TestScrapeAllPullsEveryDisablementSecret(t *testing.T) {
+	got := ScrapeAll(t, Result{Stdout: sampleInit}, PatDisablement)
+	if len(got) != 2 {
+		t.Fatalf("got %d secrets: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[1], "dis:5555") {
+		t.Fatalf("second secret = %q", got[1])
+	}
+}
+
+func TestScrapeSearchesStderrToo(t *testing.T) {
+	r := Result{Stderr: "Next: run on another signer node:\n  argus lock revoke-signer --cosign QUJDREVG\n"}
+	if got := Scrape(t, r, PatBlob); got != "QUJDREVG" {
+		t.Fatalf("blob = %q", got)
+	}
+}
+
+func TestScrapeFailsWhenValueAbsent(t *testing.T) {
+	fake := &testing.T{}
+	if got := Scrape(fake, Result{Stdout: "nothing here\n"}, PatGenesis); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+	if !fake.Failed() {
+		t.Fatalf("absent value did not fail the test")
+	}
+}

--- a/internal/e2elive/session_test.go
+++ b/internal/e2elive/session_test.go
@@ -1,0 +1,112 @@
+package e2elive
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// waitChannels blocks until the client holds an established E2E channel to every
+// named node. NewClient returns before openChannel has completed its handshake,
+// and a sessions fan-out only reaches the channels that exist when it runs, so a
+// count taken too early can omit a node without saying so — which would let a
+// fleet that duplicates one node's agents still look correct.
+func waitChannels(t *testing.T, cl *client.ReconnectingE2EClient, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		waitFor(t, "e2e channel to "+id, func() bool {
+			var r api.AgentsListResult
+			return cl.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: id}, &r) == nil
+		})
+	}
+}
+
+// waitSessions rescans every node until want accepts the result. Discovery has no
+// ticker, so a plain list can race a freshly started agent. A failing call is
+// retried rather than fatal, because one is normal while a node is still
+// settling, but the last failure is reported on timeout so that a broken
+// transport cannot present itself as a missing session.
+func waitSessions(t *testing.T, cl *client.ReconnectingE2EClient, what string, want func([]session.Session) bool) []session.Session {
+	t.Helper()
+	var last []session.Session
+	var lastErr error
+	deadline := time.Now().Add(waitTimeout)
+	for time.Now().Before(deadline) {
+		var out []session.Session
+		if err := cl.Call(api.MethodSessionsRefresh, nil, &out); err != nil {
+			lastErr = err
+		} else {
+			lastErr, last = nil, out
+			if want(out) {
+				return out
+			}
+		}
+		time.Sleep(waitInterval)
+	}
+	t.Fatalf("timed out waiting for %s (last sessions.refresh error: %v; last result: %+v)", what, lastErr, last)
+	return nil
+}
+
+// TestAgentIsVisibleOnItsOwnNodeOnly is the container isolation regression test.
+// On the process-based harness both nodes shared one tmux server and one process
+// table, so a single agent appeared twice.
+func TestAgentIsVisibleOnItsOwnNodeOnly(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	a.StartAgent("work", "sid-node-a")
+
+	cl := c.NewClient()
+	waitChannels(t, cl, "node-a", "node-b")
+
+	found := waitSessions(t, cl, "node-a session to appear", func(ss []session.Session) bool {
+		return len(ss) > 0
+	})
+
+	if len(found) != 1 {
+		t.Fatalf("sessions = %d, want 1: %+v", len(found), found)
+	}
+	if found[0].NodeID != "node-a" {
+		t.Fatalf("session node = %q, want node-a", found[0].NodeID)
+	}
+	if found[0].AgentSessionID != "sid-node-a" {
+		t.Fatalf("agent session id = %q, want sid-node-a", found[0].AgentSessionID)
+	}
+}
+
+// TestEachNodeReportsItsOwnAgent proves the fleet aggregates rather than
+// duplicating one machine.
+func TestEachNodeReportsItsOwnAgent(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+	a := c.AddNode("node-a")
+	b := c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	a.StartAgent("alpha", "sid-alpha")
+	b.StartAgent("beta", "sid-beta")
+
+	cl := c.NewClient()
+	waitChannels(t, cl, "node-a", "node-b")
+
+	found := waitSessions(t, cl, "both sessions to appear", func(ss []session.Session) bool {
+		return len(ss) == 2
+	})
+
+	byNode := map[string]string{}
+	for _, s := range found {
+		byNode[s.NodeID] = s.AgentSessionID
+	}
+	if byNode["node-a"] != "sid-alpha" {
+		t.Fatalf("node-a session = %q, want sid-alpha (all: %+v)", byNode["node-a"], found)
+	}
+	if byNode["node-b"] != "sid-beta" {
+		t.Fatalf("node-b session = %q, want sid-beta (all: %+v)", byNode["node-b"], found)
+	}
+}

--- a/internal/e2elive/smoke_test.go
+++ b/internal/e2elive/smoke_test.go
@@ -1,0 +1,40 @@
+package e2elive
+
+import (
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/api"
+)
+
+// TestSmokeUnlockedRoundTrip proves the full real-process encrypted path
+// composes: a client seals a request, the blind gateway relays it opaquely,
+// the real node process decrypts and answers, and the client opens the reply.
+func TestSmokeUnlockedRoundTrip(t *testing.T) {
+	c := New(t)
+	c.StartGateway()
+	c.AddNode("node-a")
+	c.AddNode("node-b")
+	c.WaitOnline("node-a", "node-b")
+
+	cl := c.NewClient()
+
+	// Cleartext roster served by the blind gateway.
+	var roster api.NodesListResult
+	if err := cl.Call(api.MethodNodesList, nil, &roster); err != nil {
+		t.Fatalf("nodes.list: %v", err)
+	}
+	got := map[string]bool{}
+	for _, nd := range roster.Nodes {
+		got[nd.ID] = true
+	}
+	if !got["node-a"] || !got["node-b"] {
+		t.Fatalf("roster missing nodes: %+v", roster.Nodes)
+	}
+
+	// NodeID must be explicit here: with more than one node online the gateway
+	// cannot fall back to the sole-node route, so an unaddressed call would fail.
+	var agents api.AgentsListResult
+	if err := cl.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "node-a"}, &agents); err != nil {
+		t.Fatalf("agents.list over e2e: %v", err)
+	}
+}

--- a/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/00-pin-node-b.golden
+++ b/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/00-pin-node-b.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/01-status-b-gateway-down.golden
+++ b/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/01-status-b-gateway-down.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  3 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/01-status-b-gateway-down.golden
+++ b/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/01-status-b-gateway-down.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>  ← this node
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/02-revoke-device-b-after-gw-restart.golden
+++ b/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/02-revoke-device-b-after-gw-restart.golden
@@ -1,0 +1,6 @@
+$ argus lock revoke-device node-b --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+revoke-device ok
+  current tip (audit): <TIP-2>
+--- stderr ---

--- a/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/03-status-b-converged-after-gw-restart.golden
+++ b/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/03-status-b-converged-after-gw-restart.golden
@@ -1,0 +1,29 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-2>
+           <FP>
+  length:  4 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: no
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (1)
+  <NODE-A-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+
+  to authorize this node, run on a signer node:
+    argus lock sign <NODE-B-DEVPUB>
+--- stderr ---

--- a/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/03-status-b-converged-after-gw-restart.golden
+++ b/internal/e2elive/testdata/TestGatewayRestartKeepsFleetLockedCLI/03-status-b-converged-after-gw-restart.golden
@@ -22,8 +22,13 @@ devices (1)
   <NODE-A-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
 
   to authorize this node, run on a signer node:
     argus lock sign <NODE-B-DEVPUB>
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/00-status-a-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/00-status-a-unlocked.golden
@@ -1,0 +1,18 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: not enabled
+
+chain: none — locked mode not enabled on this node
+
+this node
+  identity: <NODE-A-DEVPUB>
+  signer:   <NODE-A-SIGPUB>
+
+signers: none
+
+devices: none
+
+  pin: none
+  client pin: none
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/00-status-a-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/00-status-a-unlocked.golden
@@ -3,7 +3,7 @@ exit 0
 --- stdout ---
 locked mode: not enabled
 
-chain: none — locked mode not enabled on this node
+chain: none — this node holds no trust log
 
 this node
   identity: <NODE-A-DEVPUB>
@@ -14,5 +14,8 @@ signers: none
 devices: none
 
   pin: none
-  client pin: none
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>
+  pin: none
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/01-status-b-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/01-status-b-unlocked.golden
@@ -1,0 +1,18 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: not enabled
+
+chain: none — locked mode not enabled on this node
+
+this node
+  identity: <NODE-B-DEVPUB>
+  signer:   <NODE-B-SIGPUB>
+
+signers: none
+
+devices: none
+
+  pin: none
+  client pin: none
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/01-status-b-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/01-status-b-unlocked.golden
@@ -3,7 +3,7 @@ exit 0
 --- stdout ---
 locked mode: not enabled
 
-chain: none — locked mode not enabled on this node
+chain: none — this node holds no trust log
 
 this node
   identity: <NODE-B-DEVPUB>
@@ -14,5 +14,8 @@ signers: none
 devices: none
 
   pin: none
-  client pin: none
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>
+  pin: none
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/02-init-dryrun.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/02-init-dryrun.golden
@@ -1,0 +1,16 @@
+$ argus lock init <NODE-A-SIGPUB> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+would create a trust log with:
+  signers (1):
+    <NODE-A-SIGPUB>  (this node)
+  signer-set fingerprint: <FP>
+  disablement secrets: 1 (shown once, at creation)
+  devices authorized from the gateway roster (2):
+    <NODE-A-DEVPUB>  node-a
+    <NODE-B-DEVPUB>  node-b
+  these identity keys come from the gateway, which nothing has verified yet
+
+nothing has been created. re-run with --confirm:
+  argus lock init --confirm <NODE-A-SIGPUB>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/02-init-dryrun.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/02-init-dryrun.golden
@@ -12,5 +12,5 @@ would create a trust log with:
   these identity keys come from the gateway, which nothing has verified yet
 
 nothing has been created. re-run with --confirm:
-  argus lock init --confirm <NODE-A-SIGPUB>
+  argus lock init --confirm --gateway ws://<RUN-ID>-gw:8443 --socket /home/argus/s --token <TOKEN> <NODE-A-SIGPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/03-init-confirm.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/03-init-confirm.golden
@@ -1,0 +1,23 @@
+$ argus lock init <NODE-A-SIGPUB> --confirm --gen-disablements=2 --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode enabled
+  genesis: <GENESIS>
+  signers: 1
+  disablement secret: <SECRET-1>
+  disablement secret: <SECRET-2>
+  this machine's client (TUI) role pinned to the same genesis
+
+To pin your other devices, run on each of them:
+  argus lock pin
+(or set lock.genesis: <GENESIS> in their config)
+--- stderr ---
+
+SAVE the disablement secret(s) above NOW — shown only once. Each one disables
+locked mode network-wide (break-glass recovery if signer keys are lost).
+
+Note: only one signer. If it is lost, use a saved disablement secret to recover.
+Consider re-initialising with a second signer key listed.
+
+Note: fewer than 3 signers — 'lock revoke-signer' needs ≥3 signers to out-vote
+one compromised key; with fewer, recovery is 'lock disable' + reinit.

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/04-pin-node-b.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/04-pin-node-b.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/05-status-a-locked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/05-status-a-locked.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  3 entries
+
+this node
+  identity: <NODE-A-DEVPUB>   authorized: yes
+  signer:   <NODE-A-SIGPUB>   trusted: yes
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>  ← this node
+  <NODE-B-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/05-status-a-locked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/05-status-a-locked.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/06-status-b-locked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/06-status-b-locked.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  3 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/06-status-b-locked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/06-status-b-locked.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>  ← this node
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/07-log-after-init.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/07-log-after-init.golden
@@ -1,0 +1,16 @@
+$ argus lock log --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+[0] genesis: 1 signer(s)
+  signer: <NODE-A-SIGPUB>
+  hash: <GENESIS>
+[1] authorize-device: <NODE-A-DEVPUB>
+  hash: <TIP-2>
+[2] authorize-device: <NODE-B-DEVPUB>
+  hash: <TIP-1>
+
+genesis: <GENESIS>
+tip:     <TIP-1>
+length:  3 entries
+signers: 1  fingerprint: <FP>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/08-add-signer-b.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/08-add-signer-b.golden
@@ -1,0 +1,6 @@
+$ argus lock add-signer <NODE-B-SIGPUB> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+add-signer ok
+  current tip (audit): <TIP-3>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/09-status-a-two-signers.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/09-status-a-two-signers.golden
@@ -1,0 +1,28 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-3>
+           <FP>
+  length:  4 entries
+
+this node
+  identity: <NODE-A-DEVPUB>   authorized: yes
+  signer:   <NODE-A-SIGPUB>   trusted: yes
+
+signers (2)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+  <NODE-B-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>  ← this node
+  <NODE-B-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/09-status-a-two-signers.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/09-status-a-two-signers.golden
@@ -24,5 +24,10 @@ devices (2)
   <NODE-B-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/10-revoke-device-b.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/10-revoke-device-b.golden
@@ -1,0 +1,6 @@
+$ argus lock revoke-device node-b --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+revoke-device ok
+  current tip (audit): <TIP-4>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/11-status-b-revoked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/11-status-b-revoked.golden
@@ -1,0 +1,30 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-4>
+           <FP>
+  length:  5 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: no
+  signer:   <NODE-B-SIGPUB>   trusted: yes
+
+signers (2)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+  <NODE-B-SIGPUB>
+
+devices (1)
+  <NODE-A-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+
+  to authorize this node, run on a signer node:
+    argus lock sign <NODE-B-DEVPUB>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/11-status-b-revoked.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/11-status-b-revoked.golden
@@ -23,8 +23,13 @@ devices (1)
   <NODE-A-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
 
   to authorize this node, run on a signer node:
     argus lock sign <NODE-B-DEVPUB>
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/12-sign-node-b.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/12-sign-node-b.golden
@@ -1,0 +1,6 @@
+$ argus lock sign node-b --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+sign ok
+  current tip (audit): <TIP-5>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/13-status-b-authorized.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/13-status-b-authorized.golden
@@ -1,0 +1,28 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-5>
+           <FP>
+  length:  6 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: yes
+
+signers (2)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+  <NODE-B-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/13-status-b-authorized.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/13-status-b-authorized.golden
@@ -24,5 +24,10 @@ devices (2)
   <NODE-B-DEVPUB>  ← this node
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/14-remove-signer-b.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/14-remove-signer-b.golden
@@ -1,0 +1,6 @@
+$ argus lock remove-signer <NODE-B-SIGPUB> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+remove-signer ok
+  current tip (audit): <TIP-6>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/15-status-a-one-signer.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/15-status-a-one-signer.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-6>
+           <FP>
+  length:  7 entries
+
+this node
+  identity: <NODE-A-DEVPUB>   authorized: yes
+  signer:   <NODE-A-SIGPUB>   trusted: yes
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>  ← this node
+  <NODE-B-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/15-status-a-one-signer.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/15-status-a-one-signer.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/16-log-after-signer-churn.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/16-log-after-signer-churn.golden
@@ -1,0 +1,24 @@
+$ argus lock log --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+[0] genesis: 1 signer(s)
+  signer: <NODE-A-SIGPUB>
+  hash: <GENESIS>
+[1] authorize-device: <NODE-A-DEVPUB>
+  hash: <TIP-2>
+[2] authorize-device: <NODE-B-DEVPUB>
+  hash: <TIP-1>
+[3] add-signer: <NODE-B-SIGPUB>
+  hash: <TIP-3>
+[4] revoke-device: <NODE-B-DEVPUB>
+  hash: <TIP-4>
+[5] authorize-device: <NODE-B-DEVPUB>
+  hash: <TIP-5>
+[6] remove-signer: <NODE-B-SIGPUB>
+  hash: <TIP-6>
+
+genesis: <GENESIS>
+tip:     <TIP-6>
+length:  7 entries
+signers: 1  fingerprint: <FP>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/17-local-disable-b.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/17-local-disable-b.golden
@@ -1,0 +1,5 @@
+$ argus lock local-disable --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked-mode enforcement disabled on this node
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/18-status-b-local-disabled.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/18-status-b-local-disabled.golden
@@ -1,0 +1,28 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-6>
+           <FP>
+  length:  7 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  local-disable: active
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/18-status-b-local-disabled.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/18-status-b-local-disabled.golden
@@ -24,5 +24,10 @@ devices (2)
 
   pin: <FP> (source: file)
   local-disable: active
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/19-status-a-still-enforcing.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/19-status-a-still-enforcing.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-6>
+           <FP>
+  length:  7 entries
+
+this node
+  identity: <NODE-A-DEVPUB>   authorized: yes
+  signer:   <NODE-A-SIGPUB>   trusted: yes
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>  ← this node
+  <NODE-B-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/19-status-a-still-enforcing.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/19-status-a-still-enforcing.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/20-disable-network.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/20-disable-network.golden
@@ -1,0 +1,6 @@
+$ argus lock disable <SECRET-1> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode disabled network-wide
+  current tip (audit): <TIP-7>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/21-status-a-disabled.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/21-status-a-disabled.golden
@@ -1,0 +1,34 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: disabled network-wide — break-glass used, nothing is enforced
+  this is permanent: the log can never be re-enabled
+  to lock again: argus lock init (new genesis; every device repins)
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-7>
+           <FP>
+  length:  8 entries
+
+this node
+  identity: <NODE-A-DEVPUB>   authorized: yes
+  signer:   <NODE-A-SIGPUB>   trusted: yes
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>  ← this node
+  <NODE-B-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> — SUPERSEDED: the pinned chain was disabled network-wide; no replacement root is available yet
+       the dashboard on this machine opens no channels
+       a signer must run:
+         argus lock init
+       then on each device:
+         argus lock pin
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/21-status-a-disabled.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/21-status-a-disabled.golden
@@ -25,10 +25,15 @@ devices (2)
   <NODE-B-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> — SUPERSEDED: the pinned chain was disabled network-wide; no replacement root is available yet
-       the dashboard on this machine opens no channels
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> — the pinned root was disabled network-wide; no new root yet
+       this tui opens no channels
        a signer must run:
          argus lock init
        then on each device:
          argus lock pin
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/22-status-b-disabled.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/22-status-b-disabled.golden
@@ -1,0 +1,35 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: disabled network-wide — break-glass used, nothing is enforced
+  this is permanent: the log can never be re-enabled
+  to lock again: argus lock init (new genesis; every device repins)
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-7>
+           <FP>
+  length:  8 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  local-disable: active
+  client pin: <FP> — SUPERSEDED: the pinned chain was disabled network-wide; no replacement root is available yet
+       the dashboard on this machine opens no channels
+       a signer must run:
+         argus lock init
+       then on each device:
+         argus lock pin
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockLifecycleCLI/22-status-b-disabled.golden
+++ b/internal/e2elive/testdata/TestLockLifecycleCLI/22-status-b-disabled.golden
@@ -26,10 +26,15 @@ devices (2)
 
   pin: <FP> (source: file)
   local-disable: active
-  client pin: <FP> — SUPERSEDED: the pinned chain was disabled network-wide; no replacement root is available yet
-       the dashboard on this machine opens no channels
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> — the pinned root was disabled network-wide; no new root yet
+       this tui opens no channels
        a signer must run:
          argus lock init
        then on each device:
          argus lock pin
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/00-p1-status-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/00-p1-status-unlocked.golden
@@ -1,0 +1,18 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: not enabled
+
+chain: none — locked mode not enabled on this node
+
+this node
+  identity: <NODE-A-DEVPUB>
+  signer:   <NODE-A-SIGPUB>
+
+signers: none
+
+devices: none
+
+  pin: none
+  client pin: none
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/00-p1-status-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/00-p1-status-unlocked.golden
@@ -3,7 +3,7 @@ exit 0
 --- stdout ---
 locked mode: not enabled
 
-chain: none — locked mode not enabled on this node
+chain: none — this node holds no trust log
 
 this node
   identity: <NODE-A-DEVPUB>
@@ -14,5 +14,8 @@ signers: none
 devices: none
 
   pin: none
-  client pin: none
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>
+  pin: none
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/01-p1-log-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/01-p1-log-unlocked.golden
@@ -1,0 +1,5 @@
+$ argus lock log --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock log: locked mode not enabled

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/02-p1-sign-while-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/02-p1-sign-while-unlocked.golden
@@ -1,0 +1,5 @@
+$ argus lock sign node-b --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock sign: locked mode not enabled

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/03-p1-disable-while-unlocked.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/03-p1-disable-while-unlocked.golden
@@ -1,0 +1,5 @@
+$ argus lock disable somesecret --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock disable: expected a disablement secret of the form dis:<64 hex chars>, got "somesecret"

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/04-p1-bad-token.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/04-p1-bad-token.golden
@@ -14,6 +14,7 @@ signers: none
 devices: none
 
   pin: none
-  client pin: none (could not check this network for a trust log: failed to WebSocket dial: expected handshake response status code 101 but got 401)
+  client pin: none (could not check this network for a trust log: ws://<RUN-ID>-gw:8443/client refused the connection: HTTP 401 Unauthorized (the bearer token was rejected))
 --- stderr ---
-argus lock status: failed to WebSocket dial: expected handshake response status code 101 but got 401
+argus lock status: ws://<RUN-ID>-gw:8443/client refused the connection: HTTP 401 Unauthorized (the bearer token was rejected)
+  the gateway expects a different token: check --token, $ARGUS_TOKEN, or token: in the config file

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/04-p1-bad-token.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/04-p1-bad-token.golden
@@ -1,0 +1,19 @@
+$ argus lock status --token=wrong-token --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443
+exit 1
+--- stdout ---
+locked mode: not enabled
+
+chain: none — locked mode not enabled on this node
+
+this node
+  identity: <NODE-A-DEVPUB>
+  signer:   <NODE-A-SIGPUB>
+
+signers: none
+
+devices: none
+
+  pin: none
+  client pin: none (could not check this network for a trust log: failed to WebSocket dial: expected handshake response status code 101 but got 401)
+--- stderr ---
+argus lock status: failed to WebSocket dial: expected handshake response status code 101 but got 401

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/04-p1-bad-token.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/04-p1-bad-token.golden
@@ -3,7 +3,7 @@ exit 1
 --- stdout ---
 locked mode: not enabled
 
-chain: none — locked mode not enabled on this node
+chain: none — this node holds no trust log
 
 this node
   identity: <NODE-A-DEVPUB>
@@ -14,7 +14,10 @@ signers: none
 devices: none
 
   pin: none
-  client pin: none (could not check this network for a trust log: ws://<RUN-ID>-gw:8443/client refused the connection: HTTP 401 Unauthorized (the bearer token was rejected))
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>
+  pin: none (could not check this network for a trust log: ws://<RUN-ID>-gw:8443/client refused the connection: HTTP 401 Unauthorized (the bearer token was rejected))
 --- stderr ---
 argus lock status: ws://<RUN-ID>-gw:8443/client refused the connection: HTTP 401 Unauthorized (the bearer token was rejected)
   the gateway expects a different token: check --token, $ARGUS_TOKEN, or token: in the config file

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/05-p1-unreachable-gateway.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/05-p1-unreachable-gateway.golden
@@ -1,0 +1,19 @@
+$ argus lock status --gateway=ws://<UNREACHABLE-GW-ADDR> --socket=/home/argus/s --token=<TOKEN>
+exit 1
+--- stdout ---
+locked mode: not enabled
+
+chain: none — locked mode not enabled on this node
+
+this node
+  identity: <NODE-A-DEVPUB>
+  signer:   <NODE-A-SIGPUB>
+
+signers: none
+
+devices: none
+
+  pin: none
+  client pin: none (could not check this network for a trust log: failed to WebSocket dial: failed to send handshake request: Get "http://<UNREACHABLE-GW-ADDR>/client": dial tcp <UNREACHABLE-GW-ADDR>: connect: connection refused)
+--- stderr ---
+argus lock status: failed to WebSocket dial: failed to send handshake request: Get "http://<UNREACHABLE-GW-ADDR>/client": dial tcp <UNREACHABLE-GW-ADDR>: connect: connection refused

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/05-p1-unreachable-gateway.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/05-p1-unreachable-gateway.golden
@@ -3,7 +3,7 @@ exit 1
 --- stdout ---
 locked mode: not enabled
 
-chain: none — locked mode not enabled on this node
+chain: none — this node holds no trust log
 
 this node
   identity: <NODE-A-DEVPUB>
@@ -14,6 +14,9 @@ signers: none
 devices: none
 
   pin: none
-  client pin: none (could not check this network for a trust log: failed to WebSocket dial: failed to send handshake request: Get "http://<UNREACHABLE-GW-ADDR>/client": dial tcp <UNREACHABLE-GW-ADDR>: connect: connection refused)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>
+  pin: none (could not check this network for a trust log: failed to WebSocket dial: failed to send handshake request: Get "http://<UNREACHABLE-GW-ADDR>/client": dial tcp <UNREACHABLE-GW-ADDR>: connect: connection refused)
 --- stderr ---
 argus lock status: failed to WebSocket dial: failed to send handshake request: Get "http://<UNREACHABLE-GW-ADDR>/client": dial tcp <UNREACHABLE-GW-ADDR>: connect: connection refused

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/06-p1-unreachable-socket.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/06-p1-unreachable-socket.golden
@@ -1,0 +1,10 @@
+$ argus lock status --socket=/home/argus/nope.sock --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+locked mode: (client — no local node)
+  this device identity: <CLI-CLIENT-DEVPUB>
+  to authorize, run on a signer node:
+    argus lock sign <CLI-CLIENT-DEVPUB>
+  client pin: none
+--- stderr ---
+argus lock status: node socket: dial unix /home/argus/nope.sock: connect: no such file or directory

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/06-p1-unreachable-socket.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/06-p1-unreachable-socket.golden
@@ -1,10 +1,12 @@
 $ argus lock status --socket=/home/argus/nope.sock --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
 exit 1
 --- stdout ---
-locked mode: (client — no local node)
-  this device identity: <CLI-CLIENT-DEVPUB>
-  to authorize, run on a signer node:
-    argus lock sign <CLI-CLIENT-DEVPUB>
-  client pin: none
+locked mode: (no local node)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
+  pin: none
 --- stderr ---
 argus lock status: node socket: dial unix /home/argus/nope.sock: connect: no such file or directory

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/07-p2-init-no-args.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/07-p2-init-no-args.golden
@@ -1,0 +1,8 @@
+$ argus lock init --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock init: this node's own signer key must be listed explicitly:
+  argus lock init <NODE-A-SIGPUB>
+
+the signer keys you pass are the complete set the new trust log will trust

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/08-p2-init-malformed-key.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/08-p2-init-malformed-key.golden
@@ -1,0 +1,6 @@
+$ argus lock init sigpub:zzzz --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock init: signer "sigpub:zzzz": signer key is not valid hex: encoding/hex: invalid byte: U+007A 'z'
+  read it with `argus lock status` on that node

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/09-p2-add-signer-malformed.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/09-p2-add-signer-malformed.golden
@@ -1,0 +1,6 @@
+$ argus lock add-signer sigpub:nothex --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock add-signer: signer "sigpub:nothex": signer key is not valid hex: encoding/hex: invalid byte: U+006E 'n'
+  read it with `argus lock status` on that node

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/10-p2-sign-unknown-device.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/10-p2-sign-unknown-device.golden
@@ -1,0 +1,5 @@
+$ argus lock sign nosuchdevice --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock sign: device "nosuchdevice" is neither a known node (label/id) nor a devpub: key

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/11-p2-revoke-unknown-device.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/11-p2-revoke-unknown-device.golden
@@ -1,0 +1,5 @@
+$ argus lock revoke-device devpub:<NULL-KEY> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock revoke-device: locked mode not enabled

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/12-p2-pin-garbage.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/12-p2-pin-garbage.golden
@@ -1,0 +1,5 @@
+$ argus lock pin gen:garbage --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock pin: genesis hash is not valid hex: encoding/hex: invalid byte: U+0067 'g'

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/13-p2-unpin-not-pinned.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/13-p2-unpin-not-pinned.golden
@@ -1,0 +1,9 @@
+$ argus lock unpin --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+cleared this device's persisted pin
+  local node unpinned
+--- stderr ---
+
+This device now has no trust root. It will refuse all channels while the
+network has a trust log, until you run `argus lock pin`.

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/14-p2-cosign-garbage.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/14-p2-cosign-garbage.golden
@@ -1,0 +1,5 @@
+$ argus lock revoke-signer --cosign !!!notbase64!!! --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock revoke-signer: --cosign: invalid base64 blob: illegal base64 data at input byte 0

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/15-p3-init-first.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/15-p3-init-first.golden
@@ -1,0 +1,22 @@
+$ argus lock init <NODE-A-SIGPUB> --confirm --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode enabled
+  genesis: <GENESIS-1>
+  signers: 1
+  disablement secret: <SECRET-1-1>
+  this machine's client (TUI) role pinned to the same genesis
+
+To pin your other devices, run on each of them:
+  argus lock pin
+(or set lock.genesis: <GENESIS-1> in their config)
+--- stderr ---
+
+SAVE the disablement secret(s) above NOW — shown only once. Each one disables
+locked mode network-wide (break-glass recovery if signer keys are lost).
+
+Note: only one signer. If it is lost, use a saved disablement secret to recover.
+Consider re-initialising with a second signer key listed.
+
+Note: fewer than 3 signers — 'lock revoke-signer' needs ≥3 signers to out-vote
+one compromised key; with fewer, recovery is 'lock disable' + reinit.

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/16-p3-pin.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/16-p3-pin.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS-1> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS-1>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/17-p3-pin-b.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/17-p3-pin-b.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS-1> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS-1>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/18-p3-status-pinned.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/18-p3-status-pinned.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS-1>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  3 entries
+
+this node
+  identity: <NODE-A-DEVPUB>   authorized: yes
+  signer:   <NODE-A-SIGPUB>   trusted: yes
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>  ← this node
+  <NODE-B-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/18-p3-status-pinned.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/18-p3-status-pinned.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/19-p3-disable-first.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/19-p3-disable-first.golden
@@ -1,0 +1,6 @@
+$ argus lock disable <SECRET-1-1> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode disabled network-wide
+  current tip (audit): <TIP-2>
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/20-p3-reinit-new-genesis.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/20-p3-reinit-new-genesis.golden
@@ -1,0 +1,24 @@
+$ argus lock init <NODE-A-SIGPUB> --confirm --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode enabled
+  genesis: <GENESIS-2>
+  signers: 1
+  disablement secret: <SECRET-2-1>
+  this machine's client (TUI) role repinned from the disabled genesis <GENESIS-1>
+
+This replaced a disabled trust log, so every device still pinned to the old
+genesis must be repinned, run on each of them:
+  argus lock unpin
+  argus lock pin
+(or set lock.genesis: <GENESIS-2> in their config)
+--- stderr ---
+
+SAVE the disablement secret(s) above NOW — shown only once. Each one disables
+locked mode network-wide (break-glass recovery if signer keys are lost).
+
+Note: only one signer. If it is lost, use a saved disablement secret to recover.
+Consider re-initialising with a second signer key listed.
+
+Note: fewer than 3 signers — 'lock revoke-signer' needs ≥3 signers to out-vote
+one compromised key; with fewer, recovery is 'lock disable' + reinit.

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/21-p3-status-superseded-pin.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/21-p3-status-superseded-pin.golden
@@ -1,0 +1,34 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: QUARANTINED — this device refuses all channels
+  it follows a trust root the network has left: its own log was disabled by
+  break-glass (permanently), and the network has since locked again under a new one
+
+chain
+  genesis: <GENESIS-1>
+           <FP>
+  tip:     <TIP-2>
+           <FP>
+  length:  4 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> — SUPERSEDED: the network now uses <FP>
+       run:
+         argus lock pin <GENESIS-2>
+  client pin: <FP> — SUPERSEDED: the network now uses <FP>
+       the dashboard on this machine opens no channels; run:
+         argus lock pin <GENESIS-2>
+       then restart argus
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/21-p3-status-superseded-pin.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/21-p3-status-superseded-pin.golden
@@ -1,9 +1,9 @@
 $ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
 exit 0
 --- stdout ---
-locked mode: QUARANTINED — this device refuses all channels
-  it follows a trust root the network has left: its own log was disabled by
-  break-glass (permanently), and the network has since locked again under a new one
+locked mode: locked out — this node opens no channels
+  the trust root it is pinned to was disabled by break-glass (permanently), and
+  the network has since locked again under a new root
 
 chain
   genesis: <GENESIS-1>
@@ -24,11 +24,16 @@ devices (2)
   <NODE-A-DEVPUB>
   <NODE-B-DEVPUB>  ← this node
 
-  pin: <FP> — SUPERSEDED: the network now uses <FP>
+  pin: <FP> — the network now uses a new root (<FP>)
        run:
          argus lock pin <GENESIS-2>
-  client pin: <FP> — SUPERSEDED: the network now uses <FP>
-       the dashboard on this machine opens no channels; run:
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> — the network now uses a new root (<FP>)
+       this tui opens no channels; run:
          argus lock pin <GENESIS-2>
        then restart argus
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/22-p3-unpin.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/22-p3-unpin.golden
@@ -1,0 +1,9 @@
+$ argus lock unpin --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+cleared this device's persisted pin
+  local node unpinned
+--- stderr ---
+
+This device now has no trust root. It will refuse all channels while the
+network has a trust log, until you run `argus lock pin`.

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/23-p3-status-unpinned.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/23-p3-status-unpinned.golden
@@ -1,0 +1,21 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: not enabled
+
+chain: none — locked mode not enabled on this node
+
+this node
+  identity: <NODE-B-DEVPUB>
+  signer:   <NODE-B-SIGPUB>
+
+signers: none
+
+devices: none
+
+  pin: none — QUARANTINED (chain seen: <FP>)
+       run:
+         argus lock pin <GENESIS-2>
+  client pin: none — QUARANTINED (chain seen: <FP>)
+       the dashboard on this machine opens no channels; run: argus lock pin
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/23-p3-status-unpinned.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/23-p3-status-unpinned.golden
@@ -1,9 +1,10 @@
 $ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
 exit 0
 --- stdout ---
-locked mode: not enabled
+locked mode: locked out — the network is locked, but this node is not pinned to it
+  this node opens no channels until you pin it (see pin: below)
 
-chain: none — locked mode not enabled on this node
+chain: none — this node holds no trust log
 
 this node
   identity: <NODE-B-DEVPUB>
@@ -13,9 +14,12 @@ signers: none
 
 devices: none
 
-  pin: none — QUARANTINED (chain seen: <FP>)
+  pin: none — not pinned to the network's root (<FP>)
        run:
          argus lock pin <GENESIS-2>
-  client pin: none — QUARANTINED (chain seen: <FP>)
-       the dashboard on this machine opens no channels; run: argus lock pin
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>
+  pin: none — locked out: not pinned to the network's root (<FP>)
+       this tui opens no channels; run: argus lock pin
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/24-p4-init-already-locked.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/24-p4-init-already-locked.golden
@@ -1,0 +1,5 @@
+$ argus lock init <NODE-A-SIGPUB> --confirm --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock init: locked mode already enabled

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/25-p4-disable-wrong-secret.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/25-p4-disable-wrong-secret.golden
@@ -1,0 +1,5 @@
+$ argus lock disable dis:<FAKE-SECRET> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock disable: disable: trustlog: disable secret does not match any genesis commitment

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/26-p4-revoke-signer-start.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/26-p4-revoke-signer-start.golden
@@ -1,0 +1,13 @@
+$ argus lock revoke-signer <NODE-A-SIGPUB> --replacement <NODE-B-SIGPUB> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+revoke-signer started
+  blob: <BLOB-START>
+--- stderr ---
+
+Next: run on another signer node:
+  argus lock revoke-signer --cosign <BLOB-START>
+After collecting enough co-signs, run on any signer node:
+  argus lock revoke-signer --finish <blob>
+
+Note: entries appended after the fork point by revoked signers will be erased.

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/26-p4-revoke-signer-start.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/26-p4-revoke-signer-start.golden
@@ -10,4 +10,4 @@ Next: run on another signer node:
 After collecting enough co-signs, run on any signer node:
   argus lock revoke-signer --finish <blob>
 
-Note: entries appended after the fork point by revoked signers will be erased.
+Note: all entries after the fork point are erased, not only the revoked signer's; honest entries after it must be re-created.

--- a/internal/e2elive/testdata/TestLockPinAndErrorsCLI/27-p4-finish-insufficient-cosigns.golden
+++ b/internal/e2elive/testdata/TestLockPinAndErrorsCLI/27-p4-finish-insufficient-cosigns.golden
@@ -1,0 +1,5 @@
+$ argus lock revoke-signer --finish <BLOB-START> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 1
+--- stdout ---
+--- stderr ---
+argus lock revoke-signer: co-sign quorum not yet reached; collect more co-signs

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/00-init-two-signers.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/00-init-two-signers.golden
@@ -1,0 +1,19 @@
+$ argus lock init <NODE-A-SIGPUB> <NODE-B-SIGPUB> --confirm --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode enabled
+  genesis: <GENESIS>
+  signers: 2
+  disablement secret: <SECRET-1>
+  this machine's client (TUI) role pinned to the same genesis
+
+To pin your other devices, run on each of them:
+  argus lock pin
+(or set lock.genesis: <GENESIS> in their config)
+--- stderr ---
+
+SAVE the disablement secret(s) above NOW — shown only once. Each one disables
+locked mode network-wide (break-glass recovery if signer keys are lost).
+
+Note: fewer than 3 signers — 'lock revoke-signer' needs ≥3 signers to out-vote
+one compromised key; with fewer, recovery is 'lock disable' + reinit.

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/01-pin-node-b.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/01-pin-node-b.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/02-revoke-signer-start.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/02-revoke-signer-start.golden
@@ -1,0 +1,13 @@
+$ argus lock revoke-signer <NODE-B-SIGPUB> --replacement <NODE-C-SIGPUB> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+revoke-signer started
+  blob: <BLOB-START>
+--- stderr ---
+
+Next: run on another signer node:
+  argus lock revoke-signer --cosign <BLOB-START>
+After collecting enough co-signs, run on any signer node:
+  argus lock revoke-signer --finish <blob>
+
+Note: entries appended after the fork point by revoked signers will be erased.

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/02-revoke-signer-start.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/02-revoke-signer-start.golden
@@ -10,4 +10,4 @@ Next: run on another signer node:
 After collecting enough co-signs, run on any signer node:
   argus lock revoke-signer --finish <blob>
 
-Note: entries appended after the fork point by revoked signers will be erased.
+Note: all entries after the fork point are erased, not only the revoked signer's; honest entries after it must be re-created.

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/03-revoke-signer-cosign.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/03-revoke-signer-cosign.golden
@@ -1,0 +1,11 @@
+$ argus lock revoke-signer --cosign <BLOB-START> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+co-signed
+  blob: <BLOB-COSIGNED>
+--- stderr ---
+
+If more co-signs are needed, run on another signer node:
+  argus lock revoke-signer --cosign <BLOB-COSIGNED>
+When you have enough co-signs, run on any signer node:
+  argus lock revoke-signer --finish <BLOB-COSIGNED>

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/04-revoke-signer-finish.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/04-revoke-signer-finish.golden
@@ -1,0 +1,8 @@
+$ argus lock revoke-signer --finish <BLOB-COSIGNED> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+revocation applied
+  new tip (audit): <TIP-1>
+--- stderr ---
+
+Revocation propagates to the network within ~<DUR>.

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/05-status-a-after-ceremony.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/05-status-a-after-ceremony.golden
@@ -1,0 +1,29 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  5 entries
+
+this node
+  identity: <NODE-A-DEVPUB>   authorized: yes
+  signer:   <NODE-A-SIGPUB>   trusted: yes
+
+signers (2)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+  <NODE-C-SIGPUB>
+
+devices (3)
+  <NODE-A-DEVPUB>  ← this node
+  <NODE-B-DEVPUB>
+  <NODE-C-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/05-status-a-after-ceremony.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/05-status-a-after-ceremony.golden
@@ -25,5 +25,10 @@ devices (3)
   <NODE-C-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-A-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-A-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/06-pin-node-c.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/06-pin-node-c.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/07-status-c-after-ceremony.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/07-status-c-after-ceremony.golden
@@ -1,0 +1,29 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  5 entries
+
+this node
+  identity: <NODE-C-DEVPUB>   authorized: yes
+  signer:   <NODE-C-SIGPUB>   trusted: yes
+
+signers (2)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+  <NODE-C-SIGPUB>
+
+devices (3)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>
+  <NODE-C-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/07-status-c-after-ceremony.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/07-status-c-after-ceremony.golden
@@ -25,5 +25,10 @@ devices (3)
   <NODE-C-DEVPUB>  ← this node
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-C-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-C-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/08-log-after-ceremony.golden
+++ b/internal/e2elive/testdata/TestLockRevokeSignerCeremonyCLI/08-log-after-ceremony.golden
@@ -1,0 +1,23 @@
+$ argus lock log --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+[0] genesis: 2 signer(s)
+  signer: <NODE-A-SIGPUB>
+  signer: <NODE-B-SIGPUB>
+  hash: <GENESIS>
+[1] authorize-device: <NODE-A-DEVPUB>
+  hash: <TIP-2>
+[2] authorize-device: <NODE-B-DEVPUB>
+  hash: <TIP-3>
+[3] authorize-device: <NODE-C-DEVPUB>
+  hash: <TIP-4>
+[4] revoke-signer: 1 revoked, 2 co-sign(s)
+  revoked: <NODE-B-SIGPUB>
+  replaces: <NODE-C-SIGPUB>
+  hash: <TIP-1>
+
+genesis: <GENESIS>
+tip:     <TIP-1>
+length:  5 entries
+signers: 2  fingerprint: <FP>
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/00-pin-node-b.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/00-pin-node-b.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/01-status-b-before-restart.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/01-status-b-before-restart.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  3 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/01-status-b-before-restart.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/01-status-b-before-restart.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>  ← this node
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/02-status-b-after-restart.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/02-status-b-after-restart.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  3 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/02-status-b-after-restart.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/02-status-b-after-restart.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>  ← this node
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/03-revoke-device-b-after-restart.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/03-revoke-device-b-after-restart.golden
@@ -1,0 +1,6 @@
+$ argus lock revoke-device node-b --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+revoke-device ok
+  current tip (audit): <TIP-2>
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/04-status-b-converged-after-restart.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/04-status-b-converged-after-restart.golden
@@ -1,0 +1,29 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-2>
+           <FP>
+  length:  4 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: no
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (1)
+  <NODE-A-DEVPUB>
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+
+  to authorize this node, run on a signer node:
+    argus lock sign <NODE-B-DEVPUB>
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/04-status-b-converged-after-restart.golden
+++ b/internal/e2elive/testdata/TestNodeRestartKeepsLockCLI/04-status-b-converged-after-restart.golden
@@ -22,8 +22,13 @@ devices (1)
   <NODE-A-DEVPUB>
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
 
   to authorize this node, run on a signer node:
     argus lock sign <NODE-B-DEVPUB>
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartWithCorruptChainCLI/00-pin-node-b.golden
+++ b/internal/e2elive/testdata/TestNodeRestartWithCorruptChainCLI/00-pin-node-b.golden
@@ -1,0 +1,8 @@
+$ argus lock pin <GENESIS> --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+pinned this device
+  genesis: <GENESIS>
+  <FP>
+  local node pinned and enforcing
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartWithCorruptChainCLI/01-status-b-after-corrupt-chain.golden
+++ b/internal/e2elive/testdata/TestNodeRestartWithCorruptChainCLI/01-status-b-after-corrupt-chain.golden
@@ -1,0 +1,27 @@
+$ argus lock status --socket=/home/argus/s --gateway=ws://<RUN-ID>-gw:8443 --token=<TOKEN>
+exit 0
+--- stdout ---
+locked mode: enforcing
+
+chain
+  genesis: <GENESIS>
+           <FP>
+  tip:     <TIP-1>
+           <FP>
+  length:  3 entries
+
+this node
+  identity: <NODE-B-DEVPUB>   authorized: yes
+  signer:   <NODE-B-SIGPUB>   trusted: no
+
+signers (1)
+  fingerprint: <FP>
+  <NODE-A-SIGPUB>
+
+devices (2)
+  <NODE-A-DEVPUB>
+  <NODE-B-DEVPUB>  ← this node
+
+  pin: <FP> (source: file)
+  client pin: <FP> (source: file)
+--- stderr ---

--- a/internal/e2elive/testdata/TestNodeRestartWithCorruptChainCLI/01-status-b-after-corrupt-chain.golden
+++ b/internal/e2elive/testdata/TestNodeRestartWithCorruptChainCLI/01-status-b-after-corrupt-chain.golden
@@ -23,5 +23,10 @@ devices (2)
   <NODE-B-DEVPUB>  ← this node
 
   pin: <FP> (source: file)
-  client pin: <FP> (source: file)
+
+this tui
+  identity: <NODE-B-CLIENT-DEVPUB>   authorized: no
+  pin: <FP> (source: file)
+  → to authorize this tui, run on a signer node:
+      argus lock sign <NODE-B-CLIENT-DEVPUB>
 --- stderr ---

--- a/internal/e2etest/lock_client_enforcement_integration_test.go
+++ b/internal/e2etest/lock_client_enforcement_integration_test.go
@@ -1,0 +1,193 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/base64"
+	"net"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+// TestClientExcludesUnauthorizedNode proves symmetric client-side enforcement:
+// a locked client syncs the trust log at Connect time, opens a channel only to
+// node A (whose identity is authorized), and silently excludes node B (whose
+// identity is not in the authorized-devices set).
+//
+// Assertion strategy: after Connect, a node-addressed call to node-a succeeds
+// (channel exists); a node-addressed call to node-b fails with "no channel to
+// node" (callNode returns that error when byNode[nodeID] is nil, which it is
+// because Connect skipped node-b during silent exclusion).
+func TestClientExcludesUnauthorizedNode(t *testing.T) {
+	node.SetTrustSyncIntervalForTest(50 * time.Millisecond)
+	client.SetTrustSyncIntervalForTest(50 * time.Millisecond)
+	t.Cleanup(func() {
+		node.SetTrustSyncIntervalForTest(5 * time.Minute)
+		client.SetTrustSyncIntervalForTest(5 * time.Minute)
+	})
+
+	agg := gateway.New(time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dir := t.TempDir()
+	sd := sockDir(t)
+	sockA := filepath.Join(sd, "a.sock")
+	nodeA := startLockNode(t, ctx, "node-a", ts.URL, sockA, filepath.Join(dir, "a-chain"))
+	_ = startLockNode(t, ctx, "node-b", ts.URL, filepath.Join(sd, "b.sock"), filepath.Join(dir, "b-chain"))
+
+	// Wait until both nodes are rostered with signer and identity keys.
+	waitFor(t, "both nodes rostered with keys", func() bool {
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			return false
+		}
+		defer pc.Close()
+		var r api.NodesListResult
+		if api.NewClient(pc).Call(api.MethodNodesList, nil, &r) != nil || len(r.Nodes) != 2 {
+			return false
+		}
+		for _, nd := range r.Nodes {
+			if nd.SignerPubKey == "" || nd.IdentityPubKey == "" {
+				return false
+			}
+		}
+		return true
+	})
+
+	// Capture the roster while both nodes are present.
+	var roster api.NodesListResult
+	{
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			t.Fatalf("roster dial: %v", err)
+		}
+		if err := api.NewClient(pc).Call(api.MethodNodesList, nil, &roster); err != nil {
+			t.Fatalf("nodes.list: %v", err)
+		}
+		pc.Close()
+	}
+
+	// Resolve node A's identity key and node B's signer key from the roster.
+	var sigB, idA []byte
+	for _, nd := range roster.Nodes {
+		switch nd.ID {
+		case "node-a":
+			b, err := base64.StdEncoding.DecodeString(nd.IdentityPubKey)
+			if err != nil {
+				t.Fatalf("decode node-a identity: %v", err)
+			}
+			idA = b
+		case "node-b":
+			b, err := base64.StdEncoding.DecodeString(nd.SignerPubKey)
+			if err != nil {
+				t.Fatalf("decode node-b signer: %v", err)
+			}
+			sigB = b
+		}
+	}
+	if len(idA) == 0 || len(sigB) == 0 {
+		t.Fatal("could not resolve node keys from roster")
+	}
+
+	// Dial node A's unix socket (it becomes ready shortly after the node starts).
+	var aConn net.Conn
+	waitFor(t, "node A socket ready", func() bool {
+		c, err := net.Dial("unix", sockA)
+		if err != nil {
+			return false
+		}
+		aConn = c
+		return true
+	})
+	ac := api.NewClient(aConn)
+	defer ac.Close()
+
+	// lock.init: node B's signer key is included (for co-signing), but ONLY node
+	// A's identity key is in Devices — node B is NOT an authorized device.
+	var initRes api.LockInitResult
+	if err := ac.Call(api.MethodLockInit, api.LockInitParams{
+		Signers: [][]byte{nodeA.SignerPublic(), sigB},
+		Devices: [][]byte{idA},
+	}, &initRes); err != nil {
+		t.Fatalf("lock.init: %v", err)
+	}
+
+	// Generate a stable client identity and authorize it on node A so the node
+	// accepts the client's Noise handshake (5a node-side enforcement).
+	clientKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate client keypair: %v", err)
+	}
+	if _, err := lockSign(ac, clientKP.Public); err != nil {
+		t.Fatalf("lock.sign client: %v", err)
+	}
+
+	// Wait until node A's trust store reflects the client's authorization.
+	waitFor(t, "node A authorizes client", func() bool {
+		st := nodeA.TrustStore()
+		return st != nil && st.DeviceAuthorized(clientKP.Public)
+	})
+
+	// Wait until node A has pushed the full chain (including the lock.sign entry) to
+	// the gateway. Connect() only syncs once at startup; if the gateway chain is empty
+	// or stale, the client's trust store stays at genesis with no authorized devices
+	// and silently excludes ALL nodes, including node A. Poll until the chain is live.
+	waitFor(t, "chain propagated to gateway", func() bool {
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			return false
+		}
+		defer pc.Close()
+		var got api.TrustLogSyncResult
+		if err := api.NewClient(pc).Call(api.MethodTrustLogSync, api.TrustLogSyncParams{}, &got); err != nil || len(got.Entries) == 0 {
+			return false
+		}
+		st := trustlog.NewSyncStore(initRes.Tip)
+		for _, chain := range trustlog.AssembleChains(got.Entries) {
+			st.Ingest(chain) //nolint:errcheck
+		}
+		return st.DeviceAuthorized(clientKP.Public)
+	})
+
+	// Build the locked client: it syncs the trust log at Connect time, then for
+	// each rostered node checks DeviceAuthorized(nd.IdentityPubKey). Node A is
+	// authorized; node B is not — node B is silently excluded (no channel opened).
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	}
+	c, err := client.NewReconnectingE2EClientLocked(ctx, dial, initRes.Tip, clientKP, filepath.Join(dir, "client-chain"))
+	if err != nil {
+		t.Fatalf("locked client: %v", err)
+	}
+	defer c.Close()
+
+	// AUTHORIZED: node-a-addressed call succeeds (channel was opened during Connect).
+	var agentsA api.AgentsListResult
+	if err := c.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "node-a"}, &agentsA); err != nil {
+		t.Fatalf("call to authorized node-a failed: %v", err)
+	}
+
+	// EXCLUDED: node-b-addressed call fails with "no channel to node" because the
+	// client silently skipped node B during Connect (its identity is not authorized).
+	var agentsB api.AgentsListResult
+	err = c.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "node-b"}, &agentsB)
+	if err == nil {
+		t.Fatal("call to unauthorized node-b should fail (no channel opened)")
+	}
+	if !strings.Contains(err.Error(), "no channel to node") {
+		t.Fatalf("unexpected error for node-b (want \"no channel to node\"): %v", err)
+	}
+}

--- a/internal/e2etest/lock_disable_integration_test.go
+++ b/internal/e2etest/lock_disable_integration_test.go
@@ -1,0 +1,272 @@
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+// TestLockDisablePropagatesAndStopsEnforcement proves the disable flow end-to-end:
+// a locked node REFUSES an unauthorized client, then lock.disable turns enforcement
+// OFF so the same unsigned client key is served.
+func TestLockDisablePropagatesAndStopsEnforcement(t *testing.T) {
+	node.SetTrustSyncIntervalForTest(50 * time.Millisecond)
+	client.SetTrustSyncIntervalForTest(50 * time.Millisecond)
+	client.SetHandshakeTimeoutForTest(300 * time.Millisecond)
+	t.Cleanup(func() {
+		node.SetTrustSyncIntervalForTest(5 * time.Minute)
+		client.SetTrustSyncIntervalForTest(5 * time.Minute)
+		client.SetHandshakeTimeoutForTest(10 * time.Second)
+	})
+
+	agg := gateway.New(time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dir := t.TempDir()
+	sd := sockDir(t)
+	sockA := filepath.Join(sd, "a.sock")
+	nodeA := startLockNode(t, ctx, "node-a", ts.URL, sockA, filepath.Join(dir, "a-chain"))
+
+	// Wait until node A appears on the roster with its identity key populated.
+	waitFor(t, "node rostered with identity key", func() bool {
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			return false
+		}
+		defer pc.Close()
+		var r api.NodesListResult
+		return api.NewClient(pc).Call(api.MethodNodesList, nil, &r) == nil &&
+			len(r.Nodes) == 1 && r.Nodes[0].IdentityPubKey != ""
+	})
+
+	// Capture node A's identity pubkey from the roster so it can be placed in
+	// Devices. Including idA means the client-side (5b) will open a channel to
+	// node A, which then lets the node-side (5a) reject the unauthorized client.
+	var idA []byte
+	{
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			t.Fatalf("roster dial: %v", err)
+		}
+		var roster api.NodesListResult
+		if err := api.NewClient(pc).Call(api.MethodNodesList, nil, &roster); err != nil {
+			t.Fatalf("nodes.list: %v", err)
+		}
+		pc.Close()
+		for _, nd := range roster.Nodes {
+			if nd.ID == "node-a" {
+				b, err := base64.StdEncoding.DecodeString(nd.IdentityPubKey)
+				if err != nil {
+					t.Fatalf("decode node-a identity: %v", err)
+				}
+				idA = b
+			}
+		}
+		if len(idA) == 0 {
+			t.Fatal("could not resolve node-a identity from roster")
+		}
+	}
+
+	// Dial node A's unix socket (it becomes ready shortly after the node starts).
+	var aConn net.Conn
+	waitFor(t, "node A socket ready", func() bool {
+		c, err := net.Dial("unix", sockA)
+		if err != nil {
+			return false
+		}
+		aConn = c
+		return true
+	})
+	ac := api.NewClient(aConn)
+	defer ac.Close()
+
+	// lock.init: authorize node A's identity so the client's 5b filter passes
+	// it through (the node-side 5a check then rejects the unsigned client key).
+	// GenDisablements:1 causes the node to generate one disablement secret.
+	var initRes api.LockInitResult
+	if err := ac.Call(api.MethodLockInit, api.LockInitParams{
+		Signers:         [][]byte{nodeA.SignerPublic()},
+		GenDisablements: 1,
+		Devices:         [][]byte{idA},
+	}, &initRes); err != nil {
+		t.Fatalf("lock.init: %v", err)
+	}
+	if len(initRes.DisablementSecrets) == 0 {
+		t.Fatal("lock.init returned no disablement secrets")
+	}
+	secret := initRes.DisablementSecrets[0]
+
+	// Wait until the genesis (with idA authorized) has propagated to the gateway.
+	// The client syncs at Connect time; if the chain is empty the client-side
+	// filter excludes node A so no channel is attempted and node-side enforcement
+	// is never exercised.
+	waitFor(t, "genesis propagated to gateway", func() bool {
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			return false
+		}
+		defer pc.Close()
+		var got api.TrustLogSyncResult
+		if err := api.NewClient(pc).Call(api.MethodTrustLogSync, api.TrustLogSyncParams{}, &got); err != nil || len(got.Entries) == 0 {
+			return false
+		}
+		st := trustlog.NewSyncStore(initRes.Tip)
+		for _, chain := range trustlog.AssembleChains(got.Entries) {
+			st.Ingest(chain) //nolint:errcheck
+		}
+		return st.DeviceAuthorized(idA)
+	})
+
+	// Generate a stable client identity that is NOT lock-signed.
+	clientKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	}
+
+	// REFUSED: clientKP is not authorized. The node drops the Noise handshake (no
+	// msg2); Connect() returns nil, but byNode is empty so any node-addressed call
+	// fails with "no channel to node".
+	cUnauth, err := client.NewReconnectingE2EClientLocked(ctx, dial, initRes.Tip, clientKP, "")
+	if err != nil {
+		t.Fatalf("Connect should succeed even for unauthorized client: %v", err)
+	}
+	defer cUnauth.Close()
+	var agentsUnauth api.AgentsListResult
+	unauthCallErr := cUnauth.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "node-a"}, &agentsUnauth)
+	if unauthCallErr == nil {
+		t.Fatal("unauthorized client should have no channel to node-a")
+	}
+	if !strings.Contains(unauthCallErr.Error(), "no channel to node") {
+		t.Fatalf("unexpected error (want \"no channel to node\"): %v", unauthCallErr)
+	}
+
+	// Disable enforcement: consume the disablement secret on node A.
+	var disableRes api.LockDisableResult
+	if err := ac.Call(api.MethodLockDisable, api.LockDisableParams{Secret: secret}, &disableRes); err != nil {
+		t.Fatalf("lock.disable: %v", err)
+	}
+	if !disableRes.Disabled {
+		t.Fatal("lock.disable returned Disabled=false")
+	}
+
+	// Wait until node A's own trust store reflects the KindDisable entry.
+	waitFor(t, "node A trust store disabled", func() bool {
+		st := nodeA.TrustStore()
+		return st != nil && st.Disabled()
+	})
+
+	// Wait until the disable entry has propagated to the gateway so the fresh
+	// client can sync the chain and see enforcement is off before it connects.
+	waitFor(t, "disable propagated to gateway", func() bool {
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			return false
+		}
+		defer pc.Close()
+		var got api.TrustLogSyncResult
+		if err := api.NewClient(pc).Call(api.MethodTrustLogSync, api.TrustLogSyncParams{}, &got); err != nil || len(got.Entries) == 0 {
+			return false
+		}
+		st := trustlog.NewSyncStore(initRes.Tip)
+		for _, chain := range trustlog.AssembleChains(got.Entries) {
+			st.Ingest(chain) //nolint:errcheck
+		}
+		return st.Disabled()
+	})
+
+	// SERVED: a fresh locked client using the same unsigned clientKP now connects
+	// because enforcement is off: the node skips the authorization check and the
+	// client-side opens channels to all nodes (Disabled() is true on both sides).
+	cPost, err := client.NewReconnectingE2EClientLocked(ctx, dial, initRes.Tip, clientKP, "")
+	if err != nil {
+		t.Fatalf("post-disable client should connect: %v", err)
+	}
+	defer cPost.Close()
+
+	// A node-addressed call proves the full encrypted channel is functional.
+	waitFor(t, "post-disable agents.list succeeds", func() bool {
+		var agents api.AgentsListResult
+		return cPost.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "node-a"}, &agents) == nil
+	})
+
+	// RE-INIT: disable + reinit is the documented recovery path, so a disabled log
+	// must not block lock.init. The new genesis is a new network — enforcement is
+	// back on and the still-unsigned clientKP is refused again.
+	var reinitRes api.LockInitResult
+	if err := ac.Call(api.MethodLockInit, api.LockInitParams{
+		Signers:         [][]byte{nodeA.SignerPublic()},
+		GenDisablements: 1,
+		Devices:         [][]byte{idA},
+	}, &reinitRes); err != nil {
+		t.Fatalf("lock.init after disable: %v", err)
+	}
+	if bytes.Equal(reinitRes.Tip, initRes.Tip) {
+		t.Fatal("re-init must create a new genesis")
+	}
+	if st := nodeA.TrustStore(); st == nil || st.Disabled() {
+		t.Fatal("node A must be enabled again after re-init")
+	}
+	waitFor(t, "re-init genesis propagated to gateway", func() bool {
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			return false
+		}
+		defer pc.Close()
+		var got api.TrustLogSyncResult
+		if err := api.NewClient(pc).Call(api.MethodTrustLogSync, api.TrustLogSyncParams{}, &got); err != nil {
+			return false
+		}
+		st := trustlog.NewSyncStore(reinitRes.Tip)
+		for _, chain := range trustlog.AssembleChains(got.Entries) {
+			st.Ingest(chain) //nolint:errcheck
+		}
+		return st.DeviceAuthorized(idA) && !st.Disabled()
+	})
+
+	cReinit, err := client.NewReconnectingE2EClientLocked(ctx, dial, reinitRes.Tip, clientKP, "")
+	if err != nil {
+		t.Fatalf("Connect should succeed even for unauthorized client: %v", err)
+	}
+	defer cReinit.Close()
+	waitFor(t, "re-init client refused again", func() bool {
+		var agents api.AgentsListResult
+		err := cReinit.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "node-a"}, &agents)
+		return err != nil && strings.Contains(err.Error(), "no channel to node")
+	})
+
+	// Signing the same key into the NEW chain serves it: the refusal above is the
+	// new genesis enforcing, not a client that never synced a chain.
+	var signRes api.LockDeviceResult
+	if err := ac.Call(api.MethodLockSign, api.LockDeviceParams{Device: clientKP.Public}, &signRes); err != nil {
+		t.Fatalf("lock.sign after re-init: %v", err)
+	}
+	cSigned, err := client.NewReconnectingE2EClientLocked(ctx, dial, reinitRes.Tip, clientKP, "")
+	if err != nil {
+		t.Fatalf("signed client connect: %v", err)
+	}
+	defer cSigned.Close()
+	waitFor(t, "signed client served on the new chain", func() bool {
+		var agents api.AgentsListResult
+		return cSigned.Call(api.MethodAgentsList, api.AgentsListParams{NodeID: "node-a"}, &agents) == nil
+	})
+}

--- a/internal/e2etest/lock_integration_test.go
+++ b/internal/e2etest/lock_integration_test.go
@@ -99,3 +99,10 @@ func gatherDevicesForTest(nodes []api.NodeDescriptor) [][]byte {
 	}
 	return out
 }
+
+// lockSign authorizes a device key on a signer node via the unix socket client.
+func lockSign(c *api.Client, dev []byte) (api.LockDeviceResult, error) {
+	var res api.LockDeviceResult
+	err := c.Call(api.MethodLockSign, api.LockDeviceParams{Device: dev}, &res)
+	return res, err
+}

--- a/internal/e2etest/node_lifecycle_integration_test.go
+++ b/internal/e2etest/node_lifecycle_integration_test.go
@@ -1,0 +1,161 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/adapter/claudecode"
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/registry"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// startNodeWithSession brings up a real node uplinked to the gateway, holding one
+// discovered session.
+func startNodeWithSession(t *testing.T, ctx context.Context, tsURL, id, pane string) *node.Node {
+	t.Helper()
+	n := node.New()
+	n.SetIdentity(id, id)
+	n.SetVersion("itest")
+	kp, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	n.SetIdentityKey(kp)
+	n.SetE2EE(true)
+	go n.ConnectGateway(ctx, wsURL(tsURL, "/node"), "", nil)
+	n.Registry().ReconcileSessions(claudecode.Agent, []registry.DiscoveredSession{{
+		HasPane: true, Server: session.TmuxServerArgus, PaneID: pane, AgentSessionID: id + "-sess",
+	}})
+	return n
+}
+
+// waitRostered blocks until the gateway roster lists id as online with its
+// identity key — the point from which a client could open a channel to it.
+func waitRostered(t *testing.T, ctx context.Context, tsURL, id string) {
+	t.Helper()
+	pollConn, err := api.DialWSConn(ctx, wsURL(tsURL, "/client"), "", nil)
+	if err != nil {
+		t.Fatalf("poll dial: %v", err)
+	}
+	poll := api.NewClient(pollConn)
+	defer poll.Close()
+	waitFor(t, "roster has "+id, func() bool {
+		var r api.NodesListResult
+		if poll.Call(api.MethodNodesList, nil, &r) != nil {
+			return false
+		}
+		for _, nd := range r.Nodes {
+			if nd.ID == id && nd.IdentityPubKey != "" && nd.Online {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// awaitSessionEventFrom reads the client stream until a session.event for nodeID
+// arrives.
+func awaitSessionEventFrom(t *testing.T, events <-chan api.Notification, nodeID string) registry.Event {
+	t.Helper()
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case n := <-events:
+			if n.Method != api.MethodSessionEvent {
+				continue
+			}
+			var ev registry.Event
+			if json.Unmarshal(n.Params, &ev) != nil || ev.Session.NodeID != nodeID {
+				continue
+			}
+			return ev
+		case <-deadline:
+			t.Fatalf("no session.event from node %q reached the client", nodeID)
+		}
+	}
+}
+
+// startGateway runs a real gateway with a short offline grace so a dead node is
+// reported as offline quickly.
+func startGateway(t *testing.T) *httptest.Server {
+	t.Helper()
+	agg := gateway.New(time.Second)
+	ts := httptest.NewServer(gateway.NewServer(agg, nil, nil).Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// connectClient dials a real E2E client at the gateway.
+func connectClient(t *testing.T, ctx context.Context, tsURL string) *client.ReconnectingE2EClient {
+	t.Helper()
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(tsURL, "/client"), "", nil)
+	}
+	c, err := client.NewReconnectingE2EClient(ctx, dial)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// A node joining after the client connected must become visible without a client
+// restart: the client owns one channel per node, so it has to adopt the newcomer
+// off the gateway's roster notification.
+func TestLateJoiningNodeReachesConnectedClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts := startGateway(t)
+
+	startNodeWithSession(t, ctx, ts.URL, "node-early", "%1")
+	waitRostered(t, ctx, ts.URL, "node-early")
+
+	c := connectClient(t, ctx, ts.URL)
+	awaitSessionEventFrom(t, c.Events(), "node-early")
+
+	startNodeWithSession(t, ctx, ts.URL, "node-late", "%2")
+	if ev := awaitSessionEventFrom(t, c.Events(), "node-late"); ev.Type != registry.EventAdded {
+		t.Fatalf("late node event = %q, want added", ev.Type)
+	}
+
+	var list []session.Session
+	if err := c.Call(api.MethodSessionsList, nil, &list); err != nil {
+		t.Fatalf("sessions.list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("sessions.list returned %d sessions, want 2 (both nodes)", len(list))
+	}
+}
+
+// A node that drops must grey its sessions on the client at once. Nothing else
+// can report them: the node that owned them is what went away.
+func TestOfflineNodeGreysItsSessionsOnClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts := startGateway(t)
+
+	nodeCtx, killNode := context.WithCancel(ctx)
+	startNodeWithSession(t, nodeCtx, ts.URL, "node-dies", "%1")
+	waitRostered(t, ctx, ts.URL, "node-dies")
+
+	c := connectClient(t, ctx, ts.URL)
+	if ev := awaitSessionEventFrom(t, c.Events(), "node-dies"); ev.Session.Offline {
+		t.Fatalf("live session already offline: %+v", ev.Session)
+	}
+
+	killNode()
+	ev := awaitSessionEventFrom(t, c.Events(), "node-dies")
+	if ev.Type != registry.EventUpdated || !ev.Session.Offline {
+		t.Fatalf("event after the node died = %q offline=%v, want updated and offline",
+			ev.Type, ev.Session.Offline)
+	}
+}

--- a/internal/e2etest/session_events_integration_test.go
+++ b/internal/e2etest/session_events_integration_test.go
@@ -1,0 +1,147 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/adapter"
+	"github.com/MunifTanjim/argus/internal/adapter/claudecode"
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/registry"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// awaitClientSessionEvent reads the client's event stream until a session.event
+// arrives, skipping unrelated notifications (node.event, ...).
+func awaitClientSessionEvent(t *testing.T, events <-chan api.Notification) registry.Event {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case n := <-events:
+			if n.Method != api.MethodSessionEvent {
+				continue
+			}
+			var ev registry.Event
+			if err := json.Unmarshal(n.Params, &ev); err != nil {
+				t.Fatalf("decode session.event: %v", err)
+			}
+			return ev
+		case <-deadline:
+			t.Fatal("no session.event reached the client")
+		}
+	}
+}
+
+// A session's whole lifecycle must reach a gateway-relayed client: the snapshot
+// on channel open, the SessionEnd hook marking it dead, and the removal a later
+// scan publishes. The relay carries these sealed with nothing to trigger them
+// client-side, so a break anywhere leaves the client's list silently frozen.
+func TestSessionLifecycleEventsReachE2EClient(t *testing.T) {
+	agg := gateway.New(time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	n := node.New()
+	n.SetIdentity("itest-node", "itest-node")
+	n.SetVersion("itest")
+	kp, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	n.SetIdentityKey(kp)
+	n.SetE2EE(true)
+	go n.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	// Seed before the client connects so the snapshot itself is under test.
+	reg := n.Registry()
+	reg.ReconcileSessions(claudecode.Agent, []registry.DiscoveredSession{{
+		HasPane:        true,
+		Server:         session.TmuxServerArgus,
+		PaneID:         "%1",
+		AgentSessionID: "agent-session-1",
+	}})
+
+	pollConn, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	if err != nil {
+		t.Fatalf("poll dial: %v", err)
+	}
+	poll := api.NewClient(pollConn)
+	waitFor(t, "node adoption", func() bool {
+		var r api.NodesListResult
+		if poll.Call(api.MethodNodesList, nil, &r) != nil {
+			return false
+		}
+		for _, nd := range r.Nodes {
+			if nd.ID == "itest-node" && nd.IdentityPubKey != "" && nd.Online {
+				return true
+			}
+		}
+		return false
+	})
+	poll.Close()
+
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	}
+	c, err := client.NewReconnectingE2EClient(ctx, dial)
+	if err != nil {
+		t.Fatalf("NewReconnectingE2EClient: %v", err)
+	}
+	defer c.Close()
+
+	added := awaitClientSessionEvent(t, c.Events())
+	if added.Type != registry.EventAdded {
+		t.Fatalf("snapshot event type = %q, want added", added.Type)
+	}
+	// The client stamps origin onto every relayed session; without it the TUI
+	// can't route a later call back to the node that owns the session.
+	if added.Session.NodeID != "itest-node" {
+		t.Fatalf("snapshot session node = %q, want itest-node", added.Session.NodeID)
+	}
+	if !strings.Contains(added.Session.ID, "%1") {
+		t.Fatalf("snapshot session id = %q, want the pane's session", added.Session.ID)
+	}
+
+	claudecode.ProcessHook(reg, adapter.HookEvent{
+		Agent:      claudecode.Agent,
+		Event:      "SessionEnd",
+		TmuxPane:   "%1",
+		TmuxSocket: "argus",
+		Payload:    json.RawMessage(`{"session_id":"agent-session-1","reason":"other"}`),
+	})
+	// SessionEnd drops the session outright (ApplyHook removes on a dead status),
+	// so the client sees a removal carrying the dead status — not an update.
+	dead := awaitClientSessionEvent(t, c.Events())
+	if dead.Type != registry.EventRemoved || dead.Session.Status != session.StatusDead {
+		t.Fatalf("SessionEnd event = %q/%q, want removed/dead", dead.Type, dead.Session.Status)
+	}
+	if dead.Session.NodeID != "itest-node" {
+		t.Fatalf("SessionEnd session node = %q, want itest-node", dead.Session.NodeID)
+	}
+
+	// The stream survives the removal: a later scan re-adds and re-removes.
+	reg.ReconcileSessions(claudecode.Agent, []registry.DiscoveredSession{{
+		HasPane: true, Server: session.TmuxServerArgus, PaneID: "%2",
+	}})
+	if ev := awaitClientSessionEvent(t, c.Events()); ev.Type != registry.EventAdded {
+		t.Fatalf("rescan event type = %q, want added", ev.Type)
+	}
+	reg.ReconcileSessions(claudecode.Agent, nil)
+	if ev := awaitClientSessionEvent(t, c.Events()); ev.Type != registry.EventRemoved {
+		t.Fatalf("post-scan event type = %q, want removed", ev.Type)
+	}
+}

--- a/internal/e2etest/trustlog_integration_test.go
+++ b/internal/e2etest/trustlog_integration_test.go
@@ -1,0 +1,111 @@
+package e2etest
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/trustlog"
+)
+
+func TestTrustLogDistributionThroughRealGateway(t *testing.T) {
+	node.SetTrustSyncIntervalForTest(50 * time.Millisecond)
+	client.SetTrustSyncIntervalForTest(50 * time.Millisecond)
+	t.Cleanup(func() {
+		node.SetTrustSyncIntervalForTest(5 * time.Minute)
+		client.SetTrustSyncIntervalForTest(5 * time.Minute)
+	})
+
+	// Seed a chain: genesis + authorize one device and the test client.
+	signer, err := trustlog.GenerateSigner()
+	if err != nil {
+		t.Fatalf("GenerateSigner: %v", err)
+	}
+	log, err := trustlog.NewGenesis([][]byte{signer.Public}, signer, nil)
+	if err != nil {
+		t.Fatalf("NewGenesis: %v", err)
+	}
+	genesisHash := log.Tip()
+	device := []byte("device-key-0000000000000000000000")[:32]
+	if err := log.AuthorizeDevice(device, signer); err != nil {
+		t.Fatalf("AuthorizeDevice: %v", err)
+	}
+	// The client needs a stable authorized key; node enforcement rejects ephemeral
+	// keys once a trust store is active.
+	clientKP, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("client keypair: %v", err)
+	}
+	if err := log.AuthorizeDevice(clientKP.Public, signer); err != nil {
+		t.Fatalf("AuthorizeDevice client: %v", err)
+	}
+
+	// Real gateway.
+	agg := gateway.New(time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Real node with the seeded chain persisted, uplinked to the gateway.
+	dir := t.TempDir()
+	chainPath := filepath.Join(dir, "trustlog-chain")
+	// Write after all AuthorizeDevice calls so the persisted chain is complete.
+	if err := os.WriteFile(chainPath, trustlog.MarshalChain(log.Entries()), 0o600); err != nil {
+		t.Fatalf("seed chain: %v", err)
+	}
+	n := node.New()
+	n.SetIdentity("tl-node", "tl-node")
+	n.SetVersion("itest")
+	kp, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	n.SetIdentityKey(kp)
+	n.SetE2EE(true)
+	if err := n.EnableTrustLog(genesisHash, chainPath); err != nil {
+		t.Fatalf("EnableTrustLog: %v", err)
+	}
+	gwDone := make(chan struct{})
+	go func() {
+		defer close(gwDone)
+		n.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+	}()
+	t.Cleanup(func() { <-gwDone })
+
+	// Real client pinned to the same genesis. clientKP is authorized in the
+	// genesis chain so the locked node accepts its handshake.
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	}
+	c, err := client.NewReconnectingE2EClientLocked(ctx, dial, genesisHash, clientKP, "")
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+
+	// The node offered its chain; the gateway holds it; the client pulled it.
+	waitFor(t, "device authorized at client", func() bool { return c.DeviceAuthorized(device) })
+
+	// Revoke the device on the node's store and watch it propagate.
+	if err := log.RevokeDevice(device, signer); err != nil {
+		t.Fatalf("RevokeDevice: %v", err)
+	}
+	revoked := trustlog.MarshalChain(log.Entries())
+	if _, err := n.TrustStore().Ingest(revoked); err != nil {
+		t.Fatalf("node ingest revoke: %v", err)
+	}
+
+	waitFor(t, "device revoked at client", func() bool { return !c.DeviceAuthorized(device) })
+}

--- a/internal/e2etest/uplink_keepalive_integration_test.go
+++ b/internal/e2etest/uplink_keepalive_integration_test.go
@@ -1,0 +1,121 @@
+package e2etest
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/client"
+	"github.com/MunifTanjim/argus/internal/e2e"
+	"github.com/MunifTanjim/argus/internal/gateway"
+	"github.com/MunifTanjim/argus/internal/node"
+	"github.com/MunifTanjim/argus/internal/session"
+)
+
+// gatewayWithNode stands up a real gateway plus one real uplinked node and waits
+// for adoption. It compresses the gateway's node heartbeat so a test covers many
+// keepalive cycles in about a second. The reply timeout stays generous relative to
+// the interval: the bug under test refuses pings outright, so it reproduces no
+// matter how long the timeout is, and a tight one would just make the test flaky
+// on a loaded machine.
+func gatewayWithNode(t *testing.T, ctx context.Context) (*gateway.Aggregator, *httptest.Server) {
+	t.Helper()
+	agg := gateway.New(30 * time.Second)
+	srv := gateway.NewServer(agg, nil, nil)
+	srv.SetNodeKeepalive(50*time.Millisecond, 2*time.Second, 2)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	n := node.New()
+	n.SetIdentity("ka-node", "ka-node")
+	n.SetVersion("itest")
+	kp, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	n.SetIdentityKey(kp)
+	n.SetE2EE(true)
+	go n.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	waitFor(t, "node adoption", func() bool {
+		for _, nd := range agg.Roster() {
+			if nd.ID == "ka-node" && nd.IdentityPubKey != "" && nd.Online {
+				return true
+			}
+		}
+		return false
+	})
+	return agg, ts
+}
+
+// Regression: the gateway heartbeats node uplinks, and the node's blind uplink
+// dispatch serves only node.identify and ping. When ping was refused by that dispatch, the
+// gateway scored every heartbeat as a miss and tore the uplink down on a fixed
+// ~30s cycle. An idle uplink must survive indefinitely.
+func TestNodeUplinkSurvivesGatewayKeepalive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	agg, _ := gatewayWithNode(t, ctx)
+
+	var drops atomic.Int64
+	events, cancelSub := agg.SubscribeRoster()
+	defer cancelSub()
+	go func() {
+		for ev := range events {
+			if ev.Type == api.NodeEventOffline {
+				drops.Add(1)
+			}
+		}
+	}()
+
+	// 1s at a 50ms heartbeat is ~20 cycles; the bug tore the link down every 2.
+	time.Sleep(time.Second)
+
+	if d := drops.Load(); d != 0 {
+		t.Fatalf("idle uplink torn down %d time(s) by the gateway's own keepalive", d)
+	}
+}
+
+// Regression: the uplink churn above silently killed the client's E2E channel. The
+// client kept its stale channel (it only re-handshakes on a fresh gateway
+// connection, and its gateway link stayed healthy), so every node-addressed call
+// blocked for the full 30s call timeout and then returned an empty result with no
+// error — permanently, while the roster still reported the node online.
+func TestE2EChannelSurvivesKeepaliveWindow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, ts := gatewayWithNode(t, ctx)
+
+	dial := func(ctx context.Context) (net.Conn, error) {
+		return api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+	}
+	c, err := client.NewReconnectingE2EClient(ctx, dial)
+	if err != nil {
+		t.Fatalf("e2e client: %v", err)
+	}
+	defer c.Close()
+
+	callSessions := func(when string) {
+		t.Helper()
+		start := time.Now()
+		var ss []session.Session
+		if err := c.Call(api.MethodSessionsList, nil, &ss); err != nil {
+			t.Fatalf("%s: sessions.list: %v", when, err)
+		}
+		// A dead channel manifests as a full-timeout stall, not an error, so assert
+		// on latency: the call must be answered by the node, not by the timeout.
+		if d := time.Since(start); d > 5*time.Second {
+			t.Fatalf("%s: sessions.list took %s — the E2E channel is dead and the call stalled to its timeout", when, d)
+		}
+	}
+
+	callSessions("before the keepalive window")
+	time.Sleep(time.Second) // ~20 heartbeat cycles
+	callSessions("after the keepalive window")
+}

--- a/internal/fakeagent/fakeagent.go
+++ b/internal/fakeagent/fakeagent.go
@@ -1,0 +1,132 @@
+// Package fakeagent writes the on-disk artifacts a Claude Code process leaves
+// behind, so a container can host a discoverable session without the real CLI.
+// The field names match what internal/adapter/claudecode reads.
+package fakeagent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/MunifTanjim/argus/internal/adapter/claudecode/parser"
+)
+
+type Config struct {
+	PID        int
+	SessionID  string
+	Name       string
+	Cwd        string
+	Status     string
+	Version    string
+	Entrypoint string
+}
+
+func (c Config) withDefaults() Config {
+	if c.Status == "" {
+		c.Status = "idle"
+	}
+	if c.Version == "" {
+		c.Version = "0.0.0-fake"
+	}
+	if c.Entrypoint == "" {
+		c.Entrypoint = "cli"
+	}
+	return c
+}
+
+// SessionFilePath returns ~/.claude/sessions/<pid>.json.
+func SessionFilePath(pid int) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "sessions", strconv.Itoa(pid)+".json"), nil
+}
+
+func Write(c Config) error {
+	c = c.withDefaults()
+	if err := writeSessionFile(c); err != nil {
+		return err
+	}
+	return writeTranscript(c)
+}
+
+// Remove ignores a missing session file.
+func Remove(pid int) error {
+	path, err := SessionFilePath(pid)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func writeSessionFile(c Config) error {
+	path, err := SessionFilePath(c.PID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	b, err := json.Marshal(map[string]any{
+		"pid":        c.PID,
+		"sessionId":  c.SessionID,
+		"cwd":        c.Cwd,
+		"name":       c.Name,
+		"status":     c.Status,
+		"version":    c.Version,
+		"entrypoint": c.Entrypoint,
+	})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// Timestamps are fixed so that a golden never captures a clock.
+const fakeTimestamp = "2026-01-01T00:00:00.000Z"
+
+func writeTranscript(c Config) error {
+	dir, err := parser.ProjectDirForPath(c.Cwd)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	entries := []map[string]any{
+		{
+			"type":      "user",
+			"uuid":      c.SessionID + "-1",
+			"timestamp": fakeTimestamp,
+			"cwd":       c.Cwd,
+			"message":   map[string]any{"role": "user", "content": "hello from " + c.Name},
+		},
+		{
+			"type":      "assistant",
+			"uuid":      c.SessionID + "-2",
+			"timestamp": fakeTimestamp,
+			"cwd":       c.Cwd,
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": []map[string]any{{"type": "text", "text": "hello back from " + c.Name}},
+				"model":   "fake-model",
+			},
+		},
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		line, err := json.Marshal(e)
+		if err != nil {
+			return err
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	return os.WriteFile(filepath.Join(dir, c.SessionID+".jsonl"), []byte(b.String()), 0o600)
+}

--- a/internal/fakeagent/fakeagent_test.go
+++ b/internal/fakeagent/fakeagent_test.go
@@ -1,0 +1,89 @@
+package fakeagent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteCreatesSessionFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := Config{PID: 4242, SessionID: "sid-1", Name: "alpha", Cwd: home}
+	if err := Write(cfg); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(home, ".claude", "sessions", "4242.json"))
+	if err != nil {
+		t.Fatalf("read session file: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["sessionId"] != "sid-1" || got["name"] != "alpha" {
+		t.Fatalf("session file = %v, want sessionId sid-1 and name alpha", got)
+	}
+	if got["entrypoint"] != "cli" {
+		t.Fatalf("entrypoint = %v, want cli", got["entrypoint"])
+	}
+}
+
+func TestWriteCreatesTranscript(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := Config{PID: 7, SessionID: "sid-2", Name: "beta", Cwd: home}
+	if err := Write(cfg); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(home, ".claude", "projects", "*", "sid-2.jsonl"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("transcript matches = %v, want exactly one", matches)
+	}
+	b, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	var line map[string]any
+	if err := json.Unmarshal([]byte(firstLine(string(b))), &line); err != nil {
+		t.Fatalf("first line is not JSON: %v", err)
+	}
+	if line["type"] != "user" {
+		t.Fatalf("first entry type = %v, want user", line["type"])
+	}
+}
+
+func TestRemoveDeletesSessionFileAndIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Write(Config{PID: 9, SessionID: "sid-3", Cwd: home}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Remove(9); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "sessions", "9.json")); !os.IsNotExist(err) {
+		t.Fatalf("session file still present, stat err = %v", err)
+	}
+	if err := Remove(9); err != nil {
+		t.Fatalf("second Remove: %v", err)
+	}
+}
+
+func firstLine(s string) string {
+	for i := range s {
+		if s[i] == '\n' {
+			return s[:i]
+		}
+	}
+	return s
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -28,16 +28,20 @@ type Server struct {
 	clientSrv  *api.Server
 
 	clientTokens  *clienttoken.Store
-	pushStore     *push.Store            // nil = push disabled
-	pushSender    *push.Dispatcher       // for push.test
-	pushDeliverer push.Deliverer         // blind-path egress for push.deliver; nil disables
-	vapidPubKey   string                 // served via push.vapidKey
-	master        string                 // a /client conn presenting it is admin
-	version       string                 // served via server.info
-	publicURL     atomic.Pointer[string] // base URL for pairing QRs
+	pushStore     *push.Store
+	pushSender    *push.Dispatcher
+	pushDeliverer push.Deliverer
+	vapidPubKey   string
+	master        string
+	version       string
+	publicURL     atomic.Pointer[string]
+
+	nodeKeepaliveInterval time.Duration
+	nodeKeepaliveTimeout  time.Duration
+	nodeKeepaliveFailures int
 
 	pairMu      sync.Mutex
-	pairWaiters map[string]<-chan struct{} // minted token -> "device connected" signal
+	pairWaiters map[string]<-chan struct{}
 
 	relayMu   sync.Mutex
 	channels  map[string]*relayChannel // chan_id -> paired client/node + pumps
@@ -55,6 +59,10 @@ func NewServer(agg *Aggregator, nodeAuth, clientAuth func(token string) bool) *S
 		channels:    map[string]*relayChannel{},
 		nodePeers:   map[string]*api.Peer{},
 		entries:     trustlog.NewEntryStore(),
+
+		nodeKeepaliveInterval: api.DefaultKeepaliveInterval,
+		nodeKeepaliveTimeout:  api.DefaultKeepaliveTimeout,
+		nodeKeepaliveFailures: api.DefaultKeepaliveFailures,
 	}
 	s.clientSrv = s.buildClientServer()
 	s.clientSrv.SetRelayFrameHandler(s.forwardFromClient)
@@ -74,7 +82,7 @@ func (s *Server) SetPush(store *push.Store, dispatcher *push.Dispatcher) {
 	s.pushSender = dispatcher
 }
 
-// SetPushDeliverer wires the blind-path egress for the push.deliver node→gateway RPC.
+// SetPushDeliverer wires the egress for the push.deliver node→gateway RPC.
 func (s *Server) SetPushDeliverer(d push.Deliverer) { s.pushDeliverer = d }
 
 // SetVAPIDPublicKey publishes the VAPID public key devices fetch via push.vapidKey.
@@ -126,7 +134,7 @@ func (s *Server) clientHandler() http.Handler {
 		}
 		admin := s.master != "" && tok == s.master
 		ctx := api.WithPrincipal(context.Background(), api.Principal{Admin: admin})
-		s.clientSrv.ServeConnContext(ctx, conn) // blocks until the conn closes
+		s.clientSrv.ServeConnContext(ctx, conn)
 	})
 }
 
@@ -174,7 +182,6 @@ func (s *Server) registerPush(srv *api.Server) {
 		return nil, nil
 	})
 
-	// test sends a notification through the real backend to confirm end-to-end delivery.
 	srv.Handle(api.MethodPushTest, func(ctx context.Context, params json.RawMessage) (any, error) {
 		if s.pushStore == nil || s.pushSender == nil {
 			return nil, unavailable
@@ -196,7 +203,6 @@ func (s *Server) registerPush(srv *api.Server) {
 		if err := s.pushSender.SendTo(sctx, p.DeviceID, n); err != nil {
 			code := api.CodeInternalError
 			if errors.Is(err, push.ErrGone) {
-				// Target dead and already pruned; client should mint a fresh endpoint.
 				code = api.CodePushGone
 			}
 			return nil, &api.RPCError{Code: code, Message: err.Error()}
@@ -204,7 +210,6 @@ func (s *Server) registerPush(srv *api.Server) {
 		return nil, nil
 	})
 
-	// vapidKey serves the gateway's VAPID public key for Web Push subscription.
 	srv.Handle(api.MethodPushVAPIDKey, func(_ context.Context, _ json.RawMessage) (any, error) {
 		return api.PushVAPIDKey{Key: s.vapidPubKey}, nil
 	})
@@ -224,7 +229,6 @@ func requireAdmin(h api.HandlerFunc) api.HandlerFunc {
 func (s *Server) registerClientAdmin(srv *api.Server) {
 	unavailable := &api.RPCError{Code: api.CodeInvalidRequest, Message: "client token management not enabled on this gateway"}
 
-	// pairStart mints a pending token and returns it with the public URL for a QR.
 	srv.Handle(api.MethodClientsPairStart, requireAdmin(func(context.Context, json.RawMessage) (any, error) {
 		if s.clientTokens == nil {
 			return nil, unavailable
@@ -240,8 +244,6 @@ func (s *Server) registerClientAdmin(srv *api.Server) {
 		return api.PairStartResult{Token: tok, URL: s.getPublicURL()}, nil
 	}))
 
-	// pairAwait blocks until the token's device connects (waiter closed on promotion)
-	// or the pairing window elapses.
 	srv.Handle(api.MethodClientsPairAwait, requireAdmin(func(ctx context.Context, params json.RawMessage) (any, error) {
 		if s.clientTokens == nil {
 			return nil, unavailable
@@ -269,7 +271,6 @@ func (s *Server) registerClientAdmin(srv *api.Server) {
 		}
 	}))
 
-	// list returns the persisted client tokens.
 	srv.Handle(api.MethodClientsList, requireAdmin(func(context.Context, json.RawMessage) (any, error) {
 		if s.clientTokens == nil {
 			return nil, unavailable
@@ -285,7 +286,6 @@ func (s *Server) registerClientAdmin(srv *api.Server) {
 		return out, nil
 	}))
 
-	// remove revokes a client token by deleting its record.
 	srv.Handle(api.MethodClientsRemove, requireAdmin(func(_ context.Context, params json.RawMessage) (any, error) {
 		if s.clientTokens == nil {
 			return nil, unavailable
@@ -315,27 +315,20 @@ func (s *Server) nodeHandler() http.Handler {
 	})
 }
 
-// Node uplink keepalive: pings detect a half-open link (host vanished without a
-// TCP FIN) promptly. Closing after nodeKeepaliveFailures unanswered pings fires
-// Done into the aggregator's offline → grace → removal path; two failures ride out
-// a transient blip so a briefly busy node isn't dropped.
-const (
-	nodeKeepaliveInterval = 15 * time.Second
-	nodeKeepaliveTimeout  = 5 * time.Second
-	nodeKeepaliveFailures = 2
-)
+// SetNodeKeepalive tunes this server's node-uplink heartbeat. Call before serving.
+// Pings detect a half-open link (host vanished without a TCP FIN) promptly; closing
+// after failures unanswered pings fires Done into the aggregator's offline → grace →
+// removal path. Defaults (api.DefaultKeepalive*) ride out a transient blip so a
+// briefly busy node is not dropped.
+func (s *Server) SetNodeKeepalive(interval, timeout time.Duration, failures int) {
+	s.nodeKeepaliveInterval, s.nodeKeepaliveTimeout, s.nodeKeepaliveFailures = interval, timeout, failures
+}
 
 // nodeIdentifyTimeout bounds the post-auth identify handshake on a node uplink.
 const nodeIdentifyTimeout = 30 * time.Second
 
-// maxClosedOrphans caps the per-uplink debounce set for orphaned terminal output
-// so a long-lived node connection with heavy attach churn can't grow it without
-// bound. Far above any plausible count of concurrently-dying orphans.
-const maxClosedOrphans = 4096
-
 var discardLog = slog.New(slog.DiscardHandler)
 
-// logger returns the configured logger, or a discarding one so call sites can log unconditionally.
 func (s *Server) logger() *slog.Logger {
 	if s.log != nil {
 		return s.log
@@ -354,8 +347,7 @@ const relayQueueDepth = 64
 const maxChannelsPerClient = 64
 
 // relayChannel is one client<->node E2E channel. The gateway forwards opaque
-// frames between the two peers by chan_id, never reading the sealed Body. Two pump
-// goroutines (one per direction) decouple the peers' read loops.
+// frames between the two peers by chan_id, never reading the sealed Body.
 type relayChannel struct {
 	chanID   string
 	client   *api.Peer
@@ -380,8 +372,7 @@ func (s *Server) addChannel(chanID string, client, node *api.Peer) {
 	s.logger().Info("relay channel opened", "chan", chanID)
 }
 
-// dropChannel removes a channel and stops its pumps. It does not close the peers
-// (they may host other channels). Idempotent.
+// dropChannel is idempotent.
 func (s *Server) dropChannel(chanID, reason string) {
 	s.relayMu.Lock()
 	ch, ok := s.channels[chanID]
@@ -409,8 +400,6 @@ func (s *Server) dropChannelsWhere(reason string, pred func(*relayChannel) bool)
 	}
 }
 
-// relayPump drains q and forwards each frame to dst verbatim. A write error tears
-// the channel down.
 func (s *Server) relayPump(ch *relayChannel, q chan []byte, dst *api.Peer) {
 	for {
 		select {
@@ -436,8 +425,6 @@ func (s *Server) enqueue(ch *relayChannel, q chan []byte, raw []byte) {
 	}
 }
 
-// forwardFromClient relays a client's frame to the channel's node — but only if
-// src actually owns the channel.
 func (s *Server) forwardFromClient(src *api.Peer, f api.RelayFrame) {
 	s.relayMu.Lock()
 	ch := s.channels[f.Route.ChanID]
@@ -447,8 +434,6 @@ func (s *Server) forwardFromClient(src *api.Peer, f api.RelayFrame) {
 	}
 }
 
-// forwardFromNode relays a node's frame to the channel's client — but only if src
-// owns the channel.
 func (s *Server) forwardFromNode(src *api.Peer, f api.RelayFrame) {
 	s.relayMu.Lock()
 	ch := s.channels[f.Route.ChanID]
@@ -492,8 +477,8 @@ func (s *Server) notifyNodePeers(except *api.Peer, method string, params any) {
 	}
 }
 
-// buildClientServer wires the client-facing JSON-RPC: ping, server.info,
-// nodes.list, relay.open/close, node.event roster stream, and clients.*.
+// buildClientServer wires the client-facing JSON-RPC: ping, server.info, nodes.list,
+// trustlog.sync, relay.open/close, node.event roster stream, and clients.*.
 func (s *Server) buildClientServer() *api.Server {
 	srv := api.NewServer()
 
@@ -597,8 +582,8 @@ func (s *Server) buildClientServer() *api.Server {
 	return srv
 }
 
-// serveNode adopts an accepted node uplink: identify,
-// register as a source, record as a relay target, and block until it disconnects.
+// serveNode adopts an accepted node uplink: identify, register as a source, record
+// as a relay target, and block until it disconnects.
 func (s *Server) serveNode(conn net.Conn) {
 	var self atomic.Pointer[api.Peer]
 
@@ -652,9 +637,9 @@ func (s *Server) serveNode(conn net.Conn) {
 	}
 
 	peer := api.NewPeer(conn, api.PeerOptions{
-		KeepaliveInterval:         nodeKeepaliveInterval,
-		KeepaliveTimeout:          nodeKeepaliveTimeout,
-		KeepaliveFailureThreshold: nodeKeepaliveFailures,
+		KeepaliveInterval:         s.nodeKeepaliveInterval,
+		KeepaliveTimeout:          s.nodeKeepaliveTimeout,
+		KeepaliveFailureThreshold: s.nodeKeepaliveFailures,
 		Dispatch:                  nodeDispatch,
 		OnRelayFrame:              s.forwardFromNode,
 	})


### PR DESCRIPTION
## PR 10 — live harness and CI

The final PR: a Docker-based live end-to-end harness that runs real argus
daemons (a blind gateway + nodes) over a network with e2e on, plus the
`fakeclaude` test agent, the deferred `internal/e2etest` integration tests, the
`e2elive.yml` CI workflow, and the `make test`/`test-all` split. Almost entirely
test infrastructure; the one production file it touches
(`internal/gateway/server.go`) is behavior-neutral (see the Changes list).

### Changes
- **`cmd/fakeclaude` + `internal/fakeagent`**: a stub `claude` binary (session
  file + transcript) baked into the Docker `argus-test` image so daemons
  discover a running agent without the real Claude Code. Test-only.
- **`docker/`**: multi-stage `Dockerfile` (builder → runtime-base → argus-test →
  argus-demo), `docker-compose.yml`, `.env.example`, `README.md`.
- **`internal/e2elive`**: the container `Cluster` harness (23 files) + 6 scenario
  suites (smoke, lock lifecycle, pin/errors, revoke-signer ceremony, gateway/node
  restart, session isolation) + 71 golden files. Gated by `testing.Short()`.
  **Adaptation:** `cluster.go` sets `ARGUS_E2EE_ENABLED=true` on the gateway and
  every node (our opt-in model vs the monolith's always-on) so the live fleet is
  genuinely e2e.
- **`internal/e2etest`**: 6 deferred integration tests (client enforcement,
  disable, node lifecycle, session events, trust-log distribution, uplink
  keepalive). The 4 superseded `_integration_` files are excluded — their
  coverage lives in the `_e2e_` versions already on the stack.
- **`internal/gateway/server.go`** (production, behavior-neutral): the
  node-keepalive `const`s become `var`s at the same values (15s / 5s / 2),
  plus `SetNodeKeepaliveForTest`/`ResetNodeKeepaliveForTest`, so a test can
  shrink the keepalive window (`uplink_keepalive_integration_test.go`). No
  runtime behavior change.
- **`.github/workflows/e2elive.yml`**: runs `go test ./internal/e2elive/` (no
  `-short`) with `DOCKER_BUILDKIT=1` on push to main/dev + PRs to main. `ci.yml`
  unchanged.
- **Makefile**: `test` → `go test ./... -short` (no Docker); new `test-all` →
  `go test ./...`. Keeps the regular CI job Docker-free.

### A real bug the harness caught
The live suite surfaced a defect the incremental port introduced: the blind
uplink's `uplinkDispatch` allowed only `node.identify`, so the gateway's
keepalive `ping` was refused and the uplink was torn down after ~30s (blind/e2e
path only; plaintext uses `remoteDispatch`, unaffected). The 1-line fix landed in
**#36 (PR 3)** where `uplinkDispatch` was introduced (the stack was rebased onto
it); this PR carries the regression tests (`TestNodeUplinkSurvivesGatewayKeepalive`,
`TestE2EChannelSurvivesKeepaliveWindow`).

### Acceptance
`go test ./internal/e2elive/` runs green (all scenarios, zero golden mismatches)
— the opt-in stack reproduces the monolith's e2e behavior end-to-end.

Stacked on #46 (`pr/09-app-transport`).
