### PR TITLE
fix: accept pasted text in the new session and gateway forms

### DIFF
--- a/cmd/argus/launcher.go
+++ b/cmd/argus/launcher.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
@@ -80,6 +82,11 @@ func (m launcherModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	key, ok := msg.(tea.KeyPressMsg)
 	if !ok {
+		// A paste is its own message, not a keypress. Hand it to the focused
+		// field: textinput handles tea.PasteMsg and sanitizes the content.
+		if m.state == stateGateway {
+			return m.forwardToField(msg)
+		}
 		return m, nil
 	}
 	if m.state == stateMenu {
@@ -142,12 +149,16 @@ func (m launcherModel) updateGateway(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.submitGateway()
 	}
 
-	// Forward typing to the focused field.
+	return m.forwardToField(key) // typing
+}
+
+// forwardToField hands a message to the focused gateway input.
+func (m launcherModel) forwardToField(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	if m.field == 0 {
-		m.urlIn, cmd = m.urlIn.Update(key)
+		m.urlIn, cmd = m.urlIn.Update(msg)
 	} else {
-		m.tokenIn, cmd = m.tokenIn.Update(key)
+		m.tokenIn, cmd = m.tokenIn.Update(msg)
 	}
 	return m, cmd
 }
@@ -164,7 +175,9 @@ func (m launcherModel) toggleField() (tea.Model, tea.Cmd) {
 }
 
 func (m launcherModel) submitGateway() (tea.Model, tea.Cmd) {
-	url := m.urlIn.Value()
+	// Trim: a pasted value carries a trailing newline, which textinput turns
+	// into a space, and a space in a token fails auth with no visible cause.
+	url := strings.TrimSpace(m.urlIn.Value())
 	if _, _, err := resolveGatewayURL(url, routeClient, nil); err != nil {
 		m.errMsg = err.Error()
 		return m, nil
@@ -173,7 +186,7 @@ func (m launcherModel) submitGateway() (tea.Model, tea.Cmd) {
 	if m.spawnConnected {
 		kind = launchSpawnConnected
 	}
-	m.choice = launchChoice{kind: kind, gatewayURL: url, token: m.tokenIn.Value()}
+	m.choice = launchChoice{kind: kind, gatewayURL: url, token: strings.TrimSpace(m.tokenIn.Value())}
 	return m, tea.Quit
 }
 

--- a/cmd/argus/launcher_test.go
+++ b/cmd/argus/launcher_test.go
@@ -174,3 +174,31 @@ func TestLauncherMenuLabelReflectsToken(t *testing.T) {
 		t.Fatalf("no token should offer an isolated spawn, got:\n%s", noToken)
 	}
 }
+
+// A pasted URL and token must reach the focused field, newline and all.
+func TestGatewayPasteReachesFocusedField(t *testing.T) {
+	m := enterGateway(newLauncherModel(""))
+	m = drive(m, tea.PasteMsg{Content: "ws://gw.example.com:8443"})
+	if got := m.urlIn.Value(); got != "ws://gw.example.com:8443" {
+		t.Fatalf("url after paste = %q", got)
+	}
+	m = drive(m, tea.KeyPressMsg{Code: tea.KeyEnter}) // url -> token
+	m = drive(m, tea.PasteMsg{Content: "secret\n"})
+	// textinput turns the pasted newline into a space; submit must trim it, or
+	// the gateway rejects the token for no visible reason.
+	m = drive(m, tea.KeyPressMsg{Code: tea.KeyEnter}) // submit
+	if m.choice.token != "secret" {
+		t.Fatalf("submitted token = %q, want %q", m.choice.token, "secret")
+	}
+	if m.choice.gatewayURL != "ws://gw.example.com:8443" {
+		t.Fatalf("submitted url = %q", m.choice.gatewayURL)
+	}
+}
+
+// A paste on the menu must not leak into the hidden gateway fields.
+func TestMenuPasteIgnored(t *testing.T) {
+	m := drive(newLauncherModel(""), tea.PasteMsg{Content: "junk"})
+	if m.urlIn.Value() != "" || m.tokenIn.Value() != "" {
+		t.Fatalf("paste leaked: url=%q token=%q", m.urlIn.Value(), m.tokenIn.Value())
+	}
+}

--- a/internal/tui/spawn.go
+++ b/internal/tui/spawn.go
@@ -82,6 +82,19 @@ func editText(cur string, msg tea.KeyPressMsg) (string, bool) {
 	return cur, false
 }
 
+// pasteSpawn routes a bracketed paste into whichever spawn field accepts text.
+// Keypress handling lives in handleSpawnKey; a paste arrives as its own message,
+// so it needs its own route or it is dropped.
+func (m *model) pasteSpawn(content string) {
+	switch {
+	case m.spawn.step == spawnStepPrompt:
+		m.spawn.prompt += content
+	case m.spawn.step == spawnStepDir && m.spawn.custom:
+		// A path is one line: a pasted newline would submit or corrupt it.
+		m.spawn.cwd += strings.ReplaceAll(content, "\n", "")
+	}
+}
+
 // beginSpawn initializes the staged flow. A lone node without tmux stays on the
 // node step so its disabled state is visible rather than auto-selected.
 func (m *model) beginSpawn(nodes []api.NodeInfo, projects []session.HistoryProject, fallbackCwd string) tea.Cmd {

--- a/internal/tui/spawn_test.go
+++ b/internal/tui/spawn_test.go
@@ -488,3 +488,27 @@ func TestProjectsForNodeDedupesCwd(t *testing.T) {
 		t.Fatalf("dedupe within node = %+v", projectsForNode(all, "home"))
 	}
 }
+
+// A pasted PR link must land in the prompt buffer; the custom path drops newlines.
+func TestSpawnPaste(t *testing.T) {
+	c := &spawnPickClient{projects: []session.HistoryProject{{Label: "p", Cwd: "/p"}}}
+	m := openSpawn(t, c)
+
+	// Dir step, custom path row: paste is stripped of newlines.
+	m.spawn.custom, m.spawn.cwd = true, ""
+	mm, _ := m.Update(tea.PasteMsg{Content: "/tmp/x\n"})
+	m = mm.(model)
+	if m.spawn.cwd != "/tmp/x" {
+		t.Fatalf("custom path after paste = %q, want %q", m.spawn.cwd, "/tmp/x")
+	}
+
+	// Prompt step: paste lands verbatim.
+	m.spawn.custom = false
+	m.spawn.step = spawnStepPrompt
+	url := "review https://github.com/o/r/pull/1"
+	mm, _ = m.Update(tea.PasteMsg{Content: url})
+	m = mm.(model)
+	if m.spawn.prompt != url {
+		t.Fatalf("prompt after paste = %q, want %q", m.spawn.prompt, url)
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -82,6 +82,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case m.mode == modeScreen:
 			m.sendTermKey(m.termID, []byte(msg.Content))
 			return m, nil
+		case m.spawn.active():
+			m.pasteSpawn(msg.Content)
+			return m, nil
 		case m.idleComposerActive():
 			// Idle reply composer: append the paste verbatim (newlines and all).
 			m.prompt.reasonText += msg.Content


### PR DESCRIPTION
Paste did not work in the "new session" flow or the gateway login form. Pasted text vanished with no error.

A terminal paste arrives as `tea.PasteMsg`, not as a `tea.KeyPressMsg`. Both screens built their text only from keypresses, so the paste fell through and was discarded.

## Changes

- `internal/tui/spawn.go` — new `pasteSpawn`. The prompt step appends the paste as is. The custom path step strips newlines, because a newline would corrupt the path.
- `internal/tui/update.go` — the `PasteMsg` switch routes to `pasteSpawn` while the spawn flow is active.
- `cmd/argus/launcher.go` — `Update` no longer drops non-key messages on the gateway form. It forwards them to the focused field. `bubbles/textinput` handles `tea.PasteMsg` itself.
- `cmd/argus/launcher.go` — `submitGateway` trims the URL and the token.

The trim is not cosmetic. `textinput` converts a pasted newline into a space, so a copied token arrived as `"secret "`. That fails auth and shows no reason why. The trim on submit also catches a typed trailing space.

## Out of scope

Paste is still not wired into the deny reason field or the question "other" answer field. Both are the same one-line shape. I left them out to keep this diff to the two screens that block a real task.

## QA

Build: `make build`

**New session prompt**

1. Run `./bin/argus`.
2. Press `n`. Step through node and agent if asked.
3. Press Enter on a project in the directory list.
4. Paste a URL at the prompt step.

Expect the full URL. Paste a multi-line block too. Expect the newlines to survive.

**Custom path**

1. Same flow. At the directory list, select the last row, `Custom path…`.
2. Paste a path that you copied with a trailing newline.

Expect one line. Expect no early submit.

**Gateway login**

1. Run `./bin/argus --no-config --socket /tmp/argus-nope.sock` to force the launcher.
2. Choose `Connect to gateway`.
3. Paste `ws://gw.example.com:8443`. Press Enter.
4. Paste a token that you copied with a trailing newline. Press Enter.

Expect both fields to take the paste. The connection fails, since that host does not exist. Expect the error to name the URL with no stray space.

Repeat step 4 against a real gateway. Expect it to connect.

**Regression**

Paste on the launcher menu screen. Expect nothing to enter the hidden gateway fields.

## Tests

- `TestSpawnPaste` — prompt field and custom path field.
- `TestGatewayPasteReachesFocusedField` — both fields, plus the trim on submit.
- `TestMenuPasteIgnored` — a menu paste does not leak into hidden fields.

`make check` passes.
