### PR TITLE
fix(app): keep respond sheet input across dismissals

### DIFF
--- a/app/lib/state/respond_draft.dart
+++ b/app/lib/state/respond_draft.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/enums.dart';
+import '../models/session.dart';
+import 'respond_params.dart';
+
+/// Unsent respond-sheet input for one session. The sheet is a modal the user
+/// must dismiss to read the transcript behind it, so the draft cannot live in
+/// the sheet's State — it would die on every dismissal.
+class RespondDraft {
+  String text = ''; // idle reply, or the reject reason
+  bool denying = false; // the reject free-text field is open
+  List<QuestionDraft> questions = const [];
+  String _fingerprint = '';
+
+  /// Drops the draft when the pending prompt is no longer the one it was typed
+  /// for, so a reason meant for one permission request never lands on the next.
+  void syncTo(Interaction ix) {
+    final fp = _fingerprintOf(ix);
+    if (fp == _fingerprint) return;
+    _fingerprint = fp;
+    text = '';
+    denying = false;
+    questions = List.generate(ix.questions.length, (_) => QuestionDraft());
+  }
+
+  /// Called after a successful send. Blanking the fingerprint forces the next
+  /// open to re-run [syncTo], which rebuilds [questions] at the right length.
+  void clear() {
+    _fingerprint = '';
+    text = '';
+    denying = false;
+    questions = const [];
+  }
+}
+
+/// Idle carries no prompt identity, only the session's readiness to take input.
+/// Its message also varies between notifications, so keying on the message would
+/// drop a reply draft for a cosmetic change.
+String _fingerprintOf(Interaction ix) {
+  if (ix.kind == InteractionKind.idle) return 'idle';
+  return [
+    ix.kind.name,
+    ix.toolName ?? '',
+    ix.toolInput ?? '',
+    ix.plan ?? '',
+    ix.message ?? '',
+    for (final q in ix.questions)
+      '${q.header}|${q.question}|${q.multiSelect}|${q.options.join(',')}',
+    for (final o in ix.options) o.value,
+  ].join('\u0000');
+}
+
+// ponytail: not auto-disposed, so one small draft object survives per session id
+// seen this run. Add isAutoDispose plus a keepAlive link to the session list if
+// that ever grows.
+final respondDraftProvider = Provider.family<RespondDraft, String>(
+  (ref, sessionId) => RespondDraft(),
+);

--- a/app/lib/ui/respond_sheet.dart
+++ b/app/lib/ui/respond_sheet.dart
@@ -7,6 +7,7 @@ import '../data/session_repository.dart';
 import '../models/chunk.dart';
 import '../models/enums.dart';
 import '../models/session.dart';
+import '../state/respond_draft.dart';
 import '../state/respond_params.dart';
 import '../state/respond_view_model.dart';
 import 'code_block.dart';
@@ -37,9 +38,10 @@ class RespondSheet extends ConsumerStatefulWidget {
 
 class _RespondSheetState extends ConsumerState<RespondSheet> {
   late final RespondViewModel _vm;
-  bool _denying = false;
-  final _text = TextEditingController();
-  List<QuestionDraft>? _drafts;
+  // The draft outlives this sheet: the user must dismiss the modal to read the
+  // transcript behind it, and the reply typed so far has to survive that.
+  late final RespondDraft _draft;
+  late final TextEditingController _text;
 
   @override
   void initState() {
@@ -47,16 +49,17 @@ class _RespondSheetState extends ConsumerState<RespondSheet> {
     _vm = RespondViewModel(ref.read(sessionRepositoryProvider));
     _vm.respond.addListener(_onCommand);
     _vm.sendInput.addListener(_onCommand);
+    _draft = ref.read(respondDraftProvider(widget.session.id));
+    // build tolerates a null interaction, so this must too.
+    final ix = widget.session.interaction;
+    if (ix != null) _draft.syncTo(ix);
+    _text = TextEditingController(text: _draft.text)..addListener(_saveText);
   }
+
+  void _saveText() => _draft.text = _text.text;
 
   void _onCommand() {
     if (mounted) setState(() {}); // reflect running state on the buttons
-  }
-
-  List<QuestionDraft> _ensureDrafts(int n) {
-    final d = _drafts;
-    if (d != null && d.length == n) return d;
-    return _drafts = List.generate(n, (_) => QuestionDraft());
   }
 
   @override
@@ -85,6 +88,10 @@ class _RespondSheetState extends ConsumerState<RespondSheet> {
     if (!mounted) return;
     switch (cmd.result) {
       case Ok():
+        // Detach first: unfocusing on pop mutates the controller's selection,
+        // which would fire _saveText and write the text back after the clear.
+        _text.removeListener(_saveText);
+        _draft.clear(); // sent: the next open starts empty
         Navigator.of(context).pop();
       case Error(:final error):
         ScaffoldMessenger.of(
@@ -188,7 +195,7 @@ class _RespondSheetState extends ConsumerState<RespondSheet> {
     Widget optionButton(DecisionOption o, bool primary) {
       void onTap() {
         if (o.reject) {
-          setState(() => _denying = true);
+          setState(() => _draft.denying = true);
         } else {
           _respond(optionRespond(sessionId: _sid, kind: kind, value: o.value));
         }
@@ -213,7 +220,7 @@ class _RespondSheetState extends ConsumerState<RespondSheet> {
         ),
       ),
       const SizedBox(height: 16),
-      if (!_denying)
+      if (!_draft.denying)
         for (var i = 0; i < options.length; i++)
           optionButton(options[i], i == 0)
       else ...[
@@ -283,7 +290,7 @@ class _RespondSheetState extends ConsumerState<RespondSheet> {
 
   List<Widget> _questions(Interaction ix) {
     final qs = ix.questions;
-    final drafts = _ensureDrafts(qs.length);
+    final drafts = _draft.questions; // sized by syncTo from this same snapshot
     final canSubmit =
         questionRespond(sessionId: _sid, questions: qs, drafts: drafts) != null;
     return [
@@ -406,8 +413,11 @@ class _RespondSheetState extends ConsumerState<RespondSheet> {
     final showCustom = q.multiSelect ? d.toggles.contains(oi) : d.chosen == oi;
     if (showCustom) {
       rows.add(
-        TextField(
+        // TextFormField seeds its own controller from initialValue, so the
+        // saved answer reappears when the sheet re-opens.
+        TextFormField(
           autofocus: true,
+          initialValue: d.custom,
           decoration: const InputDecoration(
             labelText: 'Your answer',
             border: OutlineInputBorder(),

--- a/app/test/ui/respond_sheet_test.dart
+++ b/app/test/ui/respond_sheet_test.dart
@@ -232,4 +232,121 @@ void main() {
       expect(find.textContaining('preview-bravo'), findsOneWidget);
     });
   });
+
+  // The sheet is a modal the user must dismiss to read the transcript behind
+  // it. These pump the real route inside one ProviderScope, so the draft
+  // container survives a dismissal the way it does on device.
+  group('draft persistence', () {
+    Future<void> pumpHost(WidgetTester tester, SessionRepository c,
+        Session Function() session) async {
+      await tester.pumpWidget(ProviderScope(
+        overrides: [sessionRepositoryProvider.overrideWithValue(c)],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (ctx) => ElevatedButton(
+                onPressed: () => showRespondSheet(ctx, session()),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> open(WidgetTester tester) async {
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> dismiss(WidgetTester tester) async {
+      Navigator.of(tester.element(find.byType(RespondSheet))).pop();
+      await tester.pumpAndSettle();
+      expect(find.byType(RespondSheet), findsNothing);
+    }
+
+    testWidgets('an unsent reply survives a dismissal', (tester) async {
+      final c = _RecordingControl();
+      final s = _session({'kind': 'idle'});
+      await pumpHost(tester, c, () => s);
+      await open(tester);
+      await tester.enterText(find.byType(TextField), 'half typed');
+      await tester.pump();
+      await dismiss(tester);
+      await open(tester);
+      expect(find.text('half typed'), findsOneWidget);
+    });
+
+    testWidgets('a sent reply does not come back on the next open',
+        (tester) async {
+      final c = _RecordingControl();
+      final s = _session({'kind': 'idle'});
+      await pumpHost(tester, c, () => s);
+      await open(tester);
+      await tester.enterText(find.byType(TextField), 'next task');
+      await tester.tap(find.text('Send'));
+      await tester.pumpAndSettle();
+      expect(c.inputCalls.single, ['mac:%1', 'next task']);
+      await open(tester);
+      expect(find.text('next task'), findsNothing);
+    });
+
+    testWidgets('question answers survive a dismissal', (tester) async {
+      final c = _RecordingControl();
+      final s = _session({
+        'kind': 'question',
+        'questions': [
+          {
+            'question': 'Pick one',
+            'options': ['A', 'B'],
+          }
+        ],
+      });
+      await pumpHost(tester, c, () => s);
+      await open(tester);
+      await tester.tap(find.text('B'));
+      await tester.pump();
+      await dismiss(tester);
+      await open(tester);
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+      expect(c.respondCalls.single['answers'], {'Pick one': 'B'});
+    });
+
+    testWidgets('the same permission prompt keeps the deny reason',
+        (tester) async {
+      final c = _RecordingControl();
+      final s = _session({'kind': 'permission', 'tool_name': 'Bash'});
+      await pumpHost(tester, c, () => s);
+      await open(tester);
+      await tester.tap(find.text('Deny'));
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'too risky');
+      await tester.pump();
+      await dismiss(tester);
+      await open(tester);
+      // still in reject mode, with the reason intact
+      expect(find.text('too risky'), findsOneWidget);
+    });
+
+    testWidgets('a different permission prompt drops the deny reason',
+        (tester) async {
+      final c = _RecordingControl();
+      var s = _session({'kind': 'permission', 'tool_name': 'Bash'});
+      await pumpHost(tester, c, () => s);
+      await open(tester);
+      await tester.tap(find.text('Deny'));
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'too risky');
+      await tester.pump();
+      await dismiss(tester);
+      // same session id, but the agent now waits on a different tool call
+      s = _session({'kind': 'permission', 'tool_name': 'Edit'});
+      await open(tester);
+      expect(find.text('too risky'), findsNothing);
+      expect(find.byType(TextField), findsNothing);
+      expect(find.text('Deny'), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
## Problem

The respond sheet is a modal. The user must dismiss it to read the transcript
behind it. Everything typed so far lived in the sheet's `State`, so every
dismissal threw it away.

Three symptoms, one cause:

| Field | Symptom |
|---|---|
| `_text` | The idle reply text disappears. |
| `_drafts` | Question radio buttons, checkboxes and custom answers reset. |
| `_denying` | The deny reason disappears and the sheet returns to the option buttons. |

```
BEFORE
  RespondSheet -- open --X dismiss          draft dies here
    _text  _denying  _drafts

AFTER
  respondDraftProvider(sessionId) --> RespondDraft    draft lives here
    RespondSheet -- open --X dismiss -- open -->      reads the same object
```

## Change

- New `app/lib/state/respond_draft.dart`. A `RespondDraft` per session id, held
  by a `Provider.family`. The object is mutable, so the sheet writes fields in
  place. No per-keystroke provider write.
- `respond_sheet.dart` reads the draft in `initState` instead of owning the
  state.
- The custom-answer field becomes a `TextFormField` with `initialValue`, so a
  saved answer reappears. Before, it wrote to `d.custom` but never read it back.
- The draft clears after a successful send.

### Stale-prompt guard

A draft must never reach a different prompt. `Interaction` carries no id, so
`syncTo` fingerprints the prompt and resets the draft when it changes. Without
this, a reason typed for `Bash rm -rf` could land on the next permission prompt
with one tap.

Idle is fingerprinted as the constant `'idle'`. Idle carries no prompt identity,
and its `message` varies between notifications
(`internal/adapter/claudecode/hook.go:193` sets it, `registry.go:283` does not),
so keying on the message would drop a reply draft for a cosmetic change.

## QA

Setup: pair with a node and open a live session that waits for input.

1. Tap `Reply`, type text, dismiss the sheet, scroll the transcript, re-open.
   The text is still there.
2. Type a reply and send it. Re-open. The field is empty.
3. On a question prompt, pick an option, dismiss, re-open. The pick is still
   selected. Submit sends it.
4. On a permission prompt, tap `Deny`, type a reason, dismiss, re-open. The
   reason field is still open with the text.
5. Repeat step 4, but answer the prompt in the terminal so a different prompt
   arrives. Re-open. The sheet shows the option buttons and no reason.

Five widget tests cover the same five cases.

## Not verified

**Nobody has compiled or run this.** This machine has no Flutter toolchain, and
CI does not run `flutter test`. Please run `make app-check` before review.

## Out of scope

- Drafts do not survive an app restart. They are in memory only.
- `showRespondSheet` passes a session snapshot and the sheet watches no
  provider, so a prompt that changes while the sheet is open is not reflected.
  That bug predates this change.
