### PR TITLE
test(e2ee): de-flake TestNodeIdentifyOverSealedChannel by polling for authTip

### DIFF
--- a/internal/e2etest/e2e_integration_test.go
+++ b/internal/e2etest/e2e_integration_test.go
@@ -142,8 +142,10 @@ func TestNodeIdentifyOverSealedChannel(t *testing.T) {
 	}
 	defer c.Close()
 
-	_, known := c.AuthTipKnownForTest(kp.Public)
-	if !known {
-		t.Fatal("node.identify over the sealed channel did not populate authTip: responder may not route node.identify")
-	}
+	// node.identify runs over the sealed channel asynchronously (and survives a
+	// reconnect), so poll rather than reading authTip the instant the client returns.
+	waitFor(t, "authTip populated by node.identify over the sealed channel", func() bool {
+		_, known := c.AuthTipKnownForTest(kp.Public)
+		return known
+	})
 }


### PR DESCRIPTION
TestNodeIdentifyOverSealedChannel read authTip the instant NewReconnectingE2EClient returned, but node.identify runs over the sealed channel asynchronously (and re-runs after a reconnect). Under CI load the handshake had not completed, so authTip was empty and the test failed with 'responder may not route node.identify'.

Fix: poll with the existing waitFor helper (10s) until authTip is populated, matching how the same test already waits for node adoption. No production behavior change.

Verified: passes 5x locally. Flaky test lives in dev; targets dev so the open stack picks it up on rebase.