### PR TITLE
test: harden timing-flaky node/client tests against CI load

### DIFF
--- a/internal/client/node_lifecycle_test.go
+++ b/internal/client/node_lifecycle_test.go
@@ -37,7 +37,7 @@ func newLifecycleNode(t *testing.T, id, sessionID string) *fakeNode {
 
 func awaitSessionEventFor(t *testing.T, c *E2EClient, nodeID string) registry.Event {
 	t.Helper()
-	deadline := time.After(3 * time.Second)
+	deadline := time.After(10 * time.Second)
 	for {
 		select {
 		case n := <-c.Events():

--- a/internal/node/handlers_terminal_test.go
+++ b/internal/node/handlers_terminal_test.go
@@ -93,7 +93,7 @@ func TestTerminalOpenStreamsAndCloses(t *testing.T) {
 		if m.TermID != "t1" || m.Data == "" {
 			t.Fatalf("bad output: %+v", m)
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("no terminal.output received")
 	}
 
@@ -144,7 +144,7 @@ func TestTerminalOpenSharedWindowGuard(t *testing.T) {
 	}
 	select {
 	case <-notif.outputs:
-	case <-time.After(3 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("no terminal.output after allowed open")
 	}
 	if _, err := d.handleTerminalClose(octx, mustJSON(api.TerminalCloseParams{TermID: "t2"})); err != nil {
@@ -187,7 +187,7 @@ func TestTerminalOpenEvictsExistingViewer(t *testing.T) {
 
 	// A second open evicts A before the new viewer registers (as handleTerminalOpen does).
 	d.evictSessionTerm("s")
-	if !waitEvicted(nA, "tA", 3*time.Second) {
+	if !waitEvicted(nA, "tA", 10*time.Second) {
 		t.Fatal("viewer A was not evicted")
 	}
 
@@ -222,7 +222,7 @@ func TestTerminalOpenEvictsExistingViewer(t *testing.T) {
 		if m.TermID != "tB" {
 			t.Fatalf("bad output for B: %+v", m)
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("viewer B: no output")
 	}
 }
@@ -254,7 +254,7 @@ func TestSessionEndBootsViewer(t *testing.T) {
 	}
 	select {
 	case <-n.outputs:
-	case <-time.After(3 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("no output before session end")
 	}
 
@@ -268,7 +268,7 @@ func TestSessionEndBootsViewer(t *testing.T) {
 		Server: session.TmuxServerDefault, PaneID: pane, Status: session.StatusDead,
 	})
 
-	if !waitExited(n, "t1", 3*time.Second) {
+	if !waitExited(n, "t1", 10*time.Second) {
 		t.Fatal("viewer was not booted on session end")
 	}
 	d.sessionTermsMu.Lock()

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -95,7 +95,7 @@ func TestCaptureAndInputEndToEnd(t *testing.T) {
 		t.Fatalf("input: %v", err)
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		var c api.CaptureResult
 		if err := client.Call(api.MethodSessionCapture, api.SessionRef{SessionID: sessionID}, &c); err == nil {
@@ -206,7 +206,7 @@ func TestSpawnAndKillEndToEnd(t *testing.T) {
 		t.Fatalf("kill: %v", err)
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if !paneExists(t, tmuxClient, res.PaneID) {
 			return // killed

--- a/internal/node/push_test.go
+++ b/internal/node/push_test.go
@@ -71,6 +71,17 @@ type chanSink struct{ ch chan push.Notification }
 
 func (c chanSink) Notify(_ context.Context, n push.Notification) { c.ch <- n }
 
+func waitSubscribed(t *testing.T, d *Node) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for d.reg.SubscriberCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("StartPush did not subscribe within 10s")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestNodeStartPushRendersDesktopWhenEnabled(t *testing.T) {
 	d := New()
 	d.SetDesktopNotify(true, nil)
@@ -80,7 +91,7 @@ func TestNodeStartPushRendersDesktopWhenEnabled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go d.StartPush(ctx, 0)
-	time.Sleep(20 * time.Millisecond) // let Watch subscribe before publishing
+	waitSubscribed(t, d)
 
 	d.reg.ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s1", Status: session.StatusWorking})
 	d.reg.ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s1", Status: session.StatusAwaitingInput})
@@ -101,7 +112,7 @@ func TestNodeStartPushSkipsDesktopWhenDisabled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go d.StartPush(ctx, 0)
-	time.Sleep(20 * time.Millisecond)
+	waitSubscribed(t, d)
 
 	d.reg.ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s1", Status: session.StatusWorking})
 	d.reg.ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s1", Status: session.StatusAwaitingInput})
@@ -145,8 +156,7 @@ func TestNodeStartPushDeliversMobileOnAwaitingInput(t *testing.T) {
 	defer cancel()
 	go d.StartPush(ctx, 0) // delay 0 => mobile fires immediately
 
-	// Allow the goroutine to subscribe to the registry before publishing events.
-	time.Sleep(20 * time.Millisecond)
+	waitSubscribed(t, d)
 
 	d.reg.ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s1", Status: session.StatusWorking})
 	d.reg.ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s1", Status: session.StatusAwaitingInput})
@@ -218,8 +228,7 @@ func TestNodeStartPushDelivererRefreshedAfterStart(t *testing.T) {
 	defer cancel()
 	go d.StartPush(ctx, 0)
 
-	// Allow Watch to subscribe before we set the deliverer and publish events.
-	time.Sleep(20 * time.Millisecond)
+	waitSubscribed(t, d)
 
 	got := make(chan []byte, 1)
 	d.SetPushDeliverer(delivererFunc(func(_ context.Context, _ string, body []byte, _, _ string) error {

--- a/internal/node/subscriptions_test.go
+++ b/internal/node/subscriptions_test.go
@@ -61,19 +61,24 @@ func TestSubscribeWorksWithoutRegisterConn(t *testing.T) {
 		if n.Method != api.MethodTranscriptDelta {
 			t.Fatalf("method = %q, want %q", n.Method, api.MethodTranscriptDelta)
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("no delta notification after append (waited 3s)")
+	case <-time.After(10 * time.Second):
+		t.Fatal("no delta notification after append (waited 10s)")
 	}
 
 	// Cancel the ctx; the lazy goroutine should call dropConn and stop the poller.
 	cancel()
-	time.Sleep(150 * time.Millisecond) // let the goroutine run
-
-	d.subsMu.Lock()
-	_, stillRegistered := d.conns[fn]
-	d.subsMu.Unlock()
-	if stillRegistered {
-		t.Fatal("ctx cancel should have removed the lazily-registered conn via dropConn")
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		d.subsMu.Lock()
+		_, stillRegistered := d.conns[fn]
+		d.subsMu.Unlock()
+		if !stillRegistered {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("ctx cancel should have removed the lazily-registered conn via dropConn")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	// Drain any in-flight notification.
@@ -223,8 +228,8 @@ func TestSubscribePushesDeltaOnAppend(t *testing.T) {
 		if got.SubID != "x" {
 			t.Errorf("sub_id = %q, want x", got.SubID)
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("no delta notification received after append (waited 3s)")
+	case <-time.After(10 * time.Second):
+		t.Fatal("no delta notification received after append (waited 10s)")
 	}
 
 	// dropConn must stop the poller; drain the channel and confirm no more arrive.

--- a/internal/node/uplink_test.go
+++ b/internal/node/uplink_test.go
@@ -10,7 +10,7 @@ func wsURL(u string) string { return "ws" + strings.TrimPrefix(u, "http") }
 
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if cond() {
 			return

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -77,6 +77,14 @@ func (r *Registry) Snapshot() []session.Session {
 	return out
 }
 
+// SubscriberCount reports active subscribers so a caller can wait for a watcher to
+// subscribe before publishing.
+func (r *Registry) SubscriberCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.subs)
+}
+
 // Subscribe returns an event channel plus a cancel func. The channel is buffered;
 // events are dropped for a slow subscriber rather than blocking the registry.
 func (r *Registry) Subscribe() (<-chan Event, func()) {


### PR DESCRIPTION
The integration/tmux/e2e tests run in parallel under `go test ./... -short` and intermittently miss tight 2-3s deadlines on loaded CI runners, so a different test fails on each run.

Hardening (no production behavior change; one test-support accessor added):
- **Races → polls:** push_test.go replaced four `sleep 20ms; then publish` with a poll on the new `registry.SubscriberCount()` so events are never published before StartPush subscribes; subscriptions_test.go post-cancel sleep replaced with a poll for dropConn.
- **Deadlines bumped 3s → 10s** for positive waits in the tmux/terminal/subscription/node-lifecycle tests (handlers_terminal_test.go, subscriptions_test.go, node_test.go tmux poll loops, uplink_test.go waitFor, client/node_lifecycle_test.go). Negative-assertion windows left unchanged.
- Added `registry.SubscriberCount()` — the only production change, used by the poll above.

Verified: affected packages pass; race-fixed tests pass 20x under -race; TestSessionEndBootsViewer passes. Targets dev (these tests live there); the open stack picks it up on rebase.