### PR TITLE
test(node): accept empty exit reason as process-exit in waitExited

### DIFF
--- a/internal/node/handlers_terminal_test.go
+++ b/internal/node/handlers_terminal_test.go
@@ -401,7 +401,9 @@ func waitExited(n *recordingNotifier, termID string, d time.Duration) bool {
 			if json.Unmarshal(msg.Params, &ex) != nil {
 				continue
 			}
-			if ex.TermID == termID && ex.Reason == api.TermExitedProcess {
+			// Empty reason means process-exit too (see api.TerminalExited.Reason), and
+			// the pump-EOF path can win the race and report it that way.
+			if ex.TermID == termID && (ex.Reason == api.TermExitedProcess || ex.Reason == "") {
 				return true
 			}
 		case <-deadline:


### PR DESCRIPTION
TestSessionEndBootsViewer flakes on CI even after the deadline bump. Root cause: two teardown paths race on session end — the watch loop's bootSessionTerm (reason 'exited') and pumpTerm's PTY-EOF path (empty reason). api.TerminalExited documents empty reason as process-exit, but waitExited compared the reason literally and rejected empty, so when the pump path won the test failed.

Fix (test-only): waitExited accepts empty reason as TermExitedProcess, per the protocol. No production change. Passes 10x locally.