### PR TITLE
feat: add PushPort push-notification support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,9 +42,10 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           TAG_NAME: ${{ inputs.tag }}
+          PUSHPORT_APP_ID: ${{ secrets.PUSHPORT_APP_ID }}
         run: |
           mkdir -p build
-          go build -trimpath -ldflags "-s -w -X main.version=${TAG_NAME}" -o build/argus-${TAG_NAME}-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/argus
+          go build -trimpath -ldflags "-s -w -X main.version=${TAG_NAME} -X main.pushPortAppID=${PUSHPORT_APP_ID}" -o build/argus-${TAG_NAME}-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/argus
       - name: Upload Release Asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ docs/superpowers
 
 # local files
 *.local.*
+
+# Firebase — real config is not committed; copy .example and fill in real values
+app/android/app/google-services.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS := -ldflags "-X main.version=$(VERSION)"
+VERSION           := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+PUSHPORT_APP_ID   ?=
+PUSHPORT_BASE_URL ?= https://pushport.muniftanjim.dev
+LDFLAGS           := -ldflags "-X main.version=$(VERSION) -X main.pushPortAppID=$(PUSHPORT_APP_ID) -X main.pushPortBaseURL=$(PUSHPORT_BASE_URL)"
 BIN     := bin
 PREFIX  ?= $(HOME)/.local
 BINDIR  ?= $(PREFIX)/bin
@@ -62,16 +64,19 @@ app-fmt: ## Format the Flutter app's Dart sources
 
 app-check: app-analyze app-test ## Run the app analyzer and tests
 
-app-run: ## Run the Flutter app; fzf-select the device when several are connected (ARGS=... forwarded)
+app-run: ## Run the Flutter app; loads app/.env if present; fzf-select the device when several are connected (ARGS=... forwarded)
 	@cd $(APP_DIR) && \
 	lines=$$(flutter devices 2>/dev/null | grep ' • '); \
 	line=$$(echo "$$lines" | fzf --prompt='device> ' --select-1 --reverse) || exit 1; \
 	device=$$(echo "$$line" | awk -F' • ' '{print $$2}' | xargs); \
 	echo "Running on $$device"; \
-	flutter run -d "$$device" $(ARGS); \
+	envflag=""; [ -f .env ] && envflag="--dart-define-from-file=.env"; \
+	flutter run -d "$$device" $$envflag $(ARGS); \
 
-app-build: ## Build the Flutter app release APK
-	cd $(APP_DIR) && flutter build apk
+app-build: ## Build the Flutter app release APK; loads app/.env if present (ARGS=... forwarded)
+	@cd $(APP_DIR) && \
+	envflag=""; [ -f .env ] && envflag="--dart-define-from-file=.env"; \
+	flutter build apk $$envflag $(ARGS)
 
 app-clean: ## Remove the Flutter app's build artifacts
 	cd $(APP_DIR) && flutter clean

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,2 @@
+ARGUS_PUSHPORT_APP_ID=
+ARGUS_PUSHPORT_BASE_URL=https://pushport.muniftanjim.dev

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -46,3 +46,6 @@ app.*.map.json
 
 # FVM Version Cache
 .fvm/
+
+# PushPort build-time defines (--dart-define-from-file=.env); .env.example is committed
+/.env

--- a/app/README.md
+++ b/app/README.md
@@ -15,3 +15,52 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## PushPort build configuration
+
+PushPort support is off unless the build embeds a PushPort app id. Configure it
+with a `.env` file consumed via `--dart-define-from-file`. Copy the template and
+fill it in (all values are public — no secrets):
+
+```sh
+cp .env.example .env
+```
+
+| Key | Purpose |
+|---|---|
+| `ARGUS_PUSHPORT_APP_ID` | Your registered PushPort app id. Empty by default; set it to enable PushPort. |
+| `ARGUS_PUSHPORT_BASE_URL` | Overrides the default `https://pushport.muniftanjim.dev`. |
+
+`.env` is gitignored; `.env.example` is committed.
+
+The **gateway's** instance token is not a build-time value — it is set by running
+`argus pushport register --gateway wss://your-gateway --token <master-token>` on
+the gateway machine.
+
+Both `make app-build` and `make app-run` load `app/.env` automatically when it
+is present:
+
+```sh
+make app-build   # release APK, PushPort config from .env
+make app-run     # dev run, PushPort config from .env
+```
+
+To point at a different file, pass it via `ARGS`, e.g.
+`make app-build ARGS="--dart-define-from-file=prod.env"`.
+
+### FCM (PushPort/FCM provider)
+
+FCM needs a real Firebase config, which is not committed:
+
+1. `cp android/app/google-services.example.json android/app/google-services.json`
+2. Replace the placeholder values with the real Firebase credentials for
+   `dev.muniftanjim.argus`.
+3. Rebuild.
+
+Without `google-services.json`, the `com.google.gms.google-services` Gradle
+plugin is skipped and `Firebase.initializeApp()` fails gracefully — FCM is
+inactive, every other feature works.
+
+The gateway must send the encrypted body under the FCM data key `body`
+(`lib/push/fcm_source.dart`, `_kBodyKey`). Confirm the PushPort server uses the
+same key before deploying a new server version.

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -6,6 +6,11 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+// Optional FCM support: only applied when google-services.json is present.
+if (file("google-services.json").exists()) {
+    apply(plugin = "com.google.gms.google-services")
+}
+
 // Release signing config, read from android/key.properties (gitignored). Absent
 // on machines that only do debug builds, in which case the release build falls
 // back to debug keys below.

--- a/app/android/app/google-services.example.json
+++ b/app/android/app/google-services.example.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "000000000000",
+    "project_id": "argus-example",
+    "storage_bucket": "argus-example.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "dev.muniftanjim.argus"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "REPLACE_WITH_REAL_API_KEY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/android/settings.gradle.kts
+++ b/app/android/settings.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.0.1" apply false
     id("org.jetbrains.kotlin.android") version "2.3.20" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }
 
 include(":app")

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -5,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'pairing/gateway_store.dart';
 import 'pairing/legacy_migration.dart';
+import 'push/fcm_source.dart';
 import 'push/unifiedpush_background.dart';
 import 'state/gateway.dart';
 import 'state/profiles.dart';
@@ -17,6 +20,15 @@ import 'ui/theme.dart';
 
 Future<void> main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
+  // Firebase.initializeApp needs google-services.json; a missing/invalid config
+  // is swallowed so FCM stays inactive while everything else works.
+  try {
+    await Firebase.initializeApp();
+    FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+    initFcmListeners();
+  } catch (e) {
+    debugPrint('Firebase init failed: $e');
+  }
   // Register UnifiedPush callbacks here so they also run in the headless
   // background isolate (started with --unifiedpush-bg) when the app is killed,
   // letting an incoming push raise a notification.

--- a/app/lib/push/fcm_source.dart
+++ b/app/lib/push/fcm_source.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/widgets.dart';
+
+import 'notifications.dart';
+import 'pushport_fcm_provider.dart' show SecureWebPushKeyStore;
+import 'unifiedpush_background.dart' show decodeUnifiedPush;
+import 'webpush_crypto.dart';
+
+// PushPort packs the aes128gcm ciphertext under the FCM data key `e`, base64url
+// unpadded (Go's base64.RawURLEncoding). See pushport internal/transport/fcm.go.
+const _kCiphertextKey = 'e';
+
+/// Decodes the PushPort ciphertext from an FCM data map; null when absent or malformed.
+List<int>? decodeFcmBody(Map<String, dynamic> data) {
+  final encoded = data[_kCiphertextKey];
+  if (encoded is! String || encoded.isEmpty) return null;
+  try {
+    return base64Url.decode(encoded + '=' * ((4 - encoded.length % 4) % 4));
+  } catch (_) {
+    return null;
+  }
+}
+
+final _controller = StreamController<List<int>>.broadcast();
+final _openController = StreamController<List<int>>.broadcast();
+
+/// Stream of raw aes128gcm-encrypted Web Push bodies from FCM foreground messages.
+/// Feed this as [PushPortFcmProvider.incomingEncrypted].
+Stream<List<int>> get fcmEncryptedMessages => _controller.stream;
+
+/// Stream of encrypted bodies from FCM notification taps (onMessageOpenedApp).
+/// Feed this as [PushPortFcmProvider.incomingEncryptedOpens] so the controller
+/// routes the decrypted message to the deep-link/open path, not the display path.
+Stream<List<int>> get fcmEncryptedOpens => _openController.stream;
+
+/// Returns the FCM registration token for this device.
+/// Pass as [PushPortFcmProvider.getFcmToken].
+Future<String> fcmToken() async {
+  final token = await FirebaseMessaging.instance.getToken();
+  if (token == null) throw StateError('FCM token unavailable');
+  return token;
+}
+
+List<int>? _extractBody(RemoteMessage message) => decodeFcmBody(message.data);
+
+/// Call once after [Firebase.initializeApp] succeeds.
+void initFcmListeners() {
+  FirebaseMessaging.onMessage.listen((msg) {
+    final body = _extractBody(msg);
+    if (body != null) _controller.add(body);
+  });
+  // Tap on an already-shown notification: route to the open/deep-link path,
+  // not the display path — the message was already shown by the background handler.
+  FirebaseMessaging.onMessageOpenedApp.listen((msg) {
+    final body = _extractBody(msg);
+    if (body != null) _openController.add(body);
+  });
+}
+
+/// Called by the Firebase plugin in a headless isolate when the app is killed;
+/// shows the notification without launching the full UI.
+///
+/// Must be a top-level function; the @pragma keeps it from being tree-shaken so
+/// the VM can locate it from native code.
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+
+  final body = _extractBody(message);
+  if (body == null) return;
+
+  final keys = await SecureWebPushKeyStore().loadOrCreate();
+  final List<int> plaintext;
+  try {
+    plaintext = await decryptWebPush(
+      privateKey: keys.privateKey,
+      auth: keys.auth,
+      body: body,
+    );
+  } catch (_) {
+    return;
+  }
+
+  // Dedup lives in PushNotifications.show (shared across the fg/bg isolates).
+  await PushNotifications.instance.show(decodeUnifiedPush(Uint8List.fromList(plaintext)));
+}

--- a/app/lib/push/push_controller.dart
+++ b/app/lib/push/push_controller.dart
@@ -1,12 +1,17 @@
 import 'dart:async';
 
-import '../e2e/aggregate.dart' show pushGoneCode;
+import 'package:meta/meta.dart';
+
 import '../pairing/gateway_store.dart';
 import '../transport/gateway_client.dart';
 import 'device_id.dart';
+import 'fcm_source.dart';
 import 'notifications.dart';
 import 'push_provider.dart';
 import 'push_target_store.dart';
+import 'pushport_client.dart';
+import 'pushport_config.dart';
+import 'pushport_fcm_provider.dart';
 import 'register.dart';
 import 'unifiedpush_background.dart';
 import 'unifiedpush_provider.dart';
@@ -15,28 +20,39 @@ import 'unifiedpush_provider.dart';
 /// distributor, preferred by default when no distributor has been chosen.
 const appPackageName = 'dev.muniftanjim.argus';
 
-/// PushController coordinates push end to end over UnifiedPush / Web Push. It
-/// activates a distributor (the embedded FCM one by default, or an external/chosen
-/// one), shows incoming messages, tracks the device [target] and (re)registers it
-/// on each connect — keyed by a stable device id so re-registration replaces the
-/// prior endpoint — and surfaces tapped notifications as session ids.
+/// Coordinates push end to end across backends: UnifiedPush (always) and the
+/// PushPort/FCM provider (when [PushPortConfig.isConfigured]). Keeps [_active] as
+/// the single running provider, (re)registers the device [target] on each
+/// connect, and surfaces tapped notifications as session ids.
 class PushController {
   PushController({
     UnifiedPushProvider? unifiedPush,
+    @visibleForTesting
+    List<PushProvider>? extraProviders,
     DeviceIdStore? deviceIdStore,
     PushTargetStore? targetStore,
+    SecureKv? providerKv,
     void Function(String sessionId)? onSessionTap,
+    @visibleForTesting
+    String? testDeviceId,
   })  : _unifiedPush = unifiedPush ?? UnifiedPushProvider(),
         _deviceIdStore = deviceIdStore ?? DeviceIdStore(const FlutterSecureKv()),
         _targetStore = targetStore ?? PushTargetStore(const FlutterSecureKv()),
+        _providerKv = providerKv ?? const FlutterSecureKv(),
         // ignore: prefer_initializing_formals — private field, public named param.
-        _onSessionTap = onSessionTap;
+        _onSessionTap = onSessionTap {
+    _deviceId = testDeviceId;
+    _buildProviders(extraProviders);
+  }
 
   final UnifiedPushProvider _unifiedPush;
   final DeviceIdStore _deviceIdStore;
   final PushTargetStore _targetStore;
+  final SecureKv _providerKv;
+  static const _kProviderKey = 'push_provider';
   final void Function(String sessionId)? _onSessionTap;
   final _registrations = StreamController<bool>.broadcast();
+  late final Map<String, PushProvider> _providers;
   bool? _lastRegistration;
   PushTarget? _registeredTarget; // target already registered on this connection
   Future<bool>? _registerInFlight; // the running registration for _registeredTarget
@@ -47,6 +63,26 @@ class PushController {
   String? _deviceId;
   String? _selectedDistributor;
   StreamSubscription<String>? _tapSub;
+  bool _pushPortAvailable = false;
+
+  void _buildProviders(List<PushProvider>? extra) {
+    final all = <PushProvider>[_unifiedPush];
+    if (extra != null) {
+      all.addAll(extra);
+    } else if (PushPortConfig.isConfigured) {
+      final ppClient = PushPortClient(
+        baseUrl: PushPortConfig.baseUrl,
+        appId: PushPortConfig.appId,
+      );
+      all.add(PushPortFcmProvider(
+        client: ppClient,
+        getFcmToken: fcmToken,
+        incomingEncrypted: fcmEncryptedMessages,
+        incomingEncryptedOpens: fcmEncryptedOpens,
+      ));
+    }
+    _providers = {for (final p in all) p.name: p};
+  }
 
   PushTarget? get target => _target;
 
@@ -57,21 +93,19 @@ class PushController {
   /// why no endpoint was produced.
   Stream<String> get pushFailures => unifiedPushFailures;
 
-  /// Whether each gateway (re)registration attempt succeeded. Lets the UI surface
-  /// a failed registration instead of silently leaving the device unreachable.
+  /// Whether each gateway (re)registration attempt succeeded.
   Stream<bool> get registrations => _registrations.stream;
 
   /// The most recent registration result, or null if none has been attempted yet.
-  /// The stream is broadcast (no replay), so a screen that opens after the attempt
-  /// reads this to seed its state instead of waiting for the next event.
   bool? get lastRegistration => _lastRegistration;
+
+  /// Whether the connected gateway has a PushPort token configured.
+  bool get pushPortAvailable => _pushPortAvailable;
 
   /// Sets up local notifications, permission, tap routing, and starts UnifiedPush
   /// (defaulting to the embedded distributor when present).
   Future<void> init() async {
-    _deviceId = await _deviceIdStore.getOrCreate();
-    // Restore the last known target so a relaunch can re-register it on connect
-    // without waiting for the distributor to re-emit an endpoint.
+    _deviceId ??= await _deviceIdStore.getOrCreate();
     _target = await _targetStore.load();
     _unifiedPush.preferredDistributor = appPackageName;
 
@@ -81,7 +115,20 @@ class PushController {
     final launchId = await PushNotifications.instance.launchSessionId();
     if (launchId != null) _emitTap(launchId);
 
-    if (await _unifiedPush.isAvailable()) await _activate(_unifiedPush);
+    await activateInitialProvider();
+  }
+
+  /// Activates the persisted provider choice, falling back to UnifiedPush.
+  /// Called from [init] on startup so a prior selection survives a restart.
+  @visibleForTesting
+  Future<void> activateInitialProvider() async {
+    final saved = await _providerKv.read(_kProviderKey);
+    final savedProvider = saved != null ? _providers[saved] : null;
+    if (savedProvider != null) {
+      await _activate(savedProvider);
+    } else if (await _unifiedPush.isAvailable()) {
+      await _activate(_unifiedPush);
+    }
   }
 
   /// Asks the gateway to send a test notification to this device's registered
@@ -95,31 +142,29 @@ class PushController {
     await client.call('push.test', {'device_id': _deviceId});
   }
 
-  /// Forces a fresh registration to recover from a stale/missing one (e.g. a
-  /// failed test, or the gateway pruned a gone target). Re-requests an endpoint
-  /// from the distributor and re-registers it with the gateway, bypassing the
-  /// per-connection dedupe. Returns true once the gateway acknowledges.
-  ///
-  /// With [force] (push.test returned [pushGoneCode]: the cached endpoint is
-  /// permanently dead), the dead target is dropped everywhere — persisted,
-  /// in-memory, and the distributor's last-emitted endpoint — and only a brand-new
-  /// endpoint is registered; the dead one is never resurrected. Returns false if no
-  /// fresh endpoint could be obtained (the push token is likely dead; the user must
-  /// clear app data / reinstall to mint a new one).
+  /// Forces a fresh registration to recover from a stale/missing one. Pass
+  /// [force] when the endpoint is permanently gone.
   Future<bool> reregister({bool force = false}) async {
-    _registeredTarget = null; // bypass dedupe so the register actually fires
+    _registeredTarget = null;
     _registerInFlight = null;
     if (force) {
       await _targetStore.clear();
       _target = null;
-      final fresh = await _unifiedPush.forceFreshTarget();
-      if (fresh == null) return false;
-      _target = fresh;
-      await _targetStore.save(fresh);
+      if (_active == _unifiedPush) {
+        // UP: force-unregister first so the dead endpoint can't be re-emitted.
+        final fresh = await _unifiedPush.forceFreshTarget();
+        if (fresh == null) return false;
+        _target = fresh;
+        await _targetStore.save(fresh);
+      } else {
+        // Non-UP providers (pushport/fcm): restart to mint a fresh subscription.
+        final provider = _active;
+        if (provider != null) {
+          await provider.stop();
+          await _activate(provider);
+        }
+      }
     } else {
-      // refresh() waits for the fresh endpoint, during which _setTarget may start
-      // its own registration; _registerIfPossible then awaits that same in-flight
-      // RPC rather than returning before it completes.
       await _active?.refresh();
     }
     return _registerIfPossible();
@@ -128,16 +173,13 @@ class PushController {
   /// Installed UnifiedPush distributor apps detected on the device.
   Future<List<String>> distributors() => _unifiedPush.availableDistributors();
 
-  /// The selected UnifiedPush distributor: the acknowledged one if known, else the
-  /// user's last choice (getDistributor only returns an acknowledged distributor,
-  /// which is async for the embedded FCM one).
+  /// The selected UnifiedPush distributor.
   Future<String?> currentDistributor() async =>
       (await _unifiedPush.savedDistributor()) ?? _selectedDistributor;
 
-  /// Selects a distributor and (re)registers it as the active backend.
+  /// Selects a UnifiedPush distributor and (re)registers it as the active backend.
   Future<void> useDistributor(String distributor) async {
     _selectedDistributor = distributor;
-    // The embedded FCM distributor needs the VAPID key at register() time.
     final client = _client;
     if (client != null && _unifiedPush.vapidPubKey == null) {
       await _fetchVapidKey(client);
@@ -145,9 +187,18 @@ class PushController {
     await _unifiedPush.chooseDistributor(distributor);
     if (_active != _unifiedPush) await _active?.stop();
     await _activate(_unifiedPush);
-    // start() auto-registers only a single/preferred distributor; for an explicit
-    // pick alongside others, register the chosen one directly.
     await _unifiedPush.register();
+  }
+
+  /// Switches to the named provider, stopping the current one. Throws if the
+  /// name is not among the available providers.
+  Future<void> useProvider(String name) async {
+    final provider = _providers[name];
+    if (provider == null) throw ArgumentError('Unknown provider: $name');
+    if (_active == provider) return;
+    await _active?.stop();
+    await _activate(provider);
+    await _providerKv.write(_kProviderKey, name);
   }
 
   /// Registers the current target once connected, and fetches the gateway's VAPID
@@ -158,22 +209,15 @@ class PushController {
   }
 
   Future<void> _onAttached(GatewayClient client) async {
-    // New connection: register once (refreshing the gateway record), even if the
-    // target is unchanged from the previous connection.
     _registeredTarget = null;
     _registerInFlight = null;
-    // Fetch the VAPID key first (the embedded distributor needs it before it can
-    // produce an endpoint), then register the known target. If we still have no
-    // target, ask the backend to re-emit one so registration can follow.
-    await _fetchVapidKey(client);
+    await Future.wait([_fetchVapidKey(client), refreshServerInfo()]);
     await _registerIfPossible();
     if (_target == null) await _active?.refresh();
   }
 
   /// Tell the currently-connected gateway to stop pushing to this device, then
-  /// detach. Called when the active connection is torn down (profile switch or
-  /// disconnect) so only the active gateway delivers notifications. Leaves the
-  /// push backend and stored endpoint intact so the next connect re-registers.
+  /// detach.
   Future<void> unregisterFromCurrentGateway() async {
     final client = _client;
     final deviceId = _deviceId;
@@ -187,6 +231,19 @@ class PushController {
   Future<void> dispose() async {
     await _tapSub?.cancel();
     await _registrations.close();
+  }
+
+  /// Fetches `server.info` to update [pushPortAvailable]. Fail-closed: if the
+  /// call throws, [pushPortAvailable] is set to false.
+  Future<void> refreshServerInfo() async {
+    final client = _client;
+    if (client == null) return;
+    try {
+      final res = await client.call('server.info');
+      _pushPortAvailable = (res is Map) && res['pushPortConfigured'] == true;
+    } catch (_) {
+      _pushPortAvailable = false;
+    }
   }
 
   Future<void> _fetchVapidKey(GatewayClient client) async {
@@ -228,10 +285,6 @@ class PushController {
     final target = _target;
     final deviceId = _deviceId;
     if (client == null || target == null || deviceId == null) return false;
-    // Collapse the duplicate calls that fire on a single connect (the persisted
-    // target and the distributor's re-emitted endpoint are normally identical).
-    // Claim synchronously before awaiting so a concurrent call sees it and awaits
-    // the same in-flight RPC instead of starting a second one or returning early.
     if (target == _registeredTarget) {
       return _registerInFlight ?? Future.value(true);
     }
@@ -243,7 +296,7 @@ class PushController {
 
   Future<bool> _register(GatewayClient client, String deviceId, PushTarget target) async {
     final ok = await registerWithRetry(client, deviceId, target);
-    if (!ok) _registeredTarget = null; // let a later attempt retry
+    if (!ok) _registeredTarget = null;
     _lastRegistration = ok;
     _registrations.add(ok);
     return ok;

--- a/app/lib/push/pushport_client.dart
+++ b/app/lib/push/pushport_client.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class PushPortSubscription {
+  final String endpoint;
+  final int expiresAt;
+
+  const PushPortSubscription({required this.endpoint, required this.expiresAt});
+}
+
+class PushPortClient {
+  final String _baseUrl;
+  final String _appId;
+  final http.Client _httpClient;
+
+  PushPortClient({
+    required this._baseUrl,
+    required this._appId,
+    http.Client? httpClient,
+  }) : _httpClient = httpClient ?? http.Client();
+
+  Future<PushPortSubscription> subscribe({
+    required String transport,
+    required Object token,
+    String ttl = '24h',
+  }) async {
+    final url = Uri.parse('$_baseUrl/apps/$_appId/subscribe');
+    final res = await _httpClient.post(
+      url,
+      headers: {'content-type': 'application/json'},
+      body: jsonEncode({'transport': transport, 'token': token, 'ttl': ttl}),
+    );
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw Exception('PushPort subscribe failed: ${res.statusCode} ${res.body}');
+    }
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    final data = body['data'] as Map<String, dynamic>;
+    return PushPortSubscription(
+      endpoint: data['endpoint'] as String,
+      expiresAt: data['expires_at'] as int,
+    );
+  }
+}

--- a/app/lib/push/pushport_config.dart
+++ b/app/lib/push/pushport_config.dart
@@ -1,0 +1,11 @@
+/// Build-time PushPort constants, set with --dart-define (e.g.
+/// ARGUS_PUSHPORT_APP_ID). appId is empty unless a build embeds it, leaving
+/// PushPort unconfigured by default.
+class PushPortConfig {
+  static const String appId =
+      String.fromEnvironment('ARGUS_PUSHPORT_APP_ID', defaultValue: '');
+  static const String baseUrl = String.fromEnvironment('ARGUS_PUSHPORT_BASE_URL',
+      defaultValue: 'https://pushport.muniftanjim.dev');
+
+  static bool get isConfigured => appId.isNotEmpty && baseUrl.isNotEmpty;
+}

--- a/app/lib/push/pushport_fcm_provider.dart
+++ b/app/lib/push/pushport_fcm_provider.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+
+import '../pairing/gateway_store.dart';
+import 'push_message.dart';
+import 'push_provider.dart';
+import 'pushport_client.dart';
+import 'unifiedpush_background.dart' show decodeUnifiedPush;
+import 'webpush_crypto.dart';
+
+/// Persists and loads a [WebPushKeys] keypair.
+abstract class WebPushKeyStore {
+  /// Returns the persisted keypair, generating and persisting one on first use.
+  Future<WebPushKeys> loadOrCreate();
+}
+
+/// Production store: persists the keypair in secure storage.
+class SecureWebPushKeyStore implements WebPushKeyStore {
+  SecureWebPushKeyStore([SecureKv? kv]) : _kv = kv ?? const FlutterSecureKv();
+
+  final SecureKv _kv;
+
+  static const _privKey = 'webpush_private_key';
+  static const _authKey = 'webpush_auth';
+  static const _pubKey = 'webpush_p256dh';
+
+  @override
+  Future<WebPushKeys> loadOrCreate() async {
+    final priv = await _kv.read(_privKey);
+    final auth = await _kv.read(_authKey);
+    final pub = await _kv.read(_pubKey);
+    if (priv != null && auth != null && pub != null) {
+      final privBytes = base64Url
+          .decode(priv + '=' * ((4 - priv.length % 4) % 4));
+      return WebPushKeys(privateKey: privBytes, auth: auth, p256dh: pub);
+    }
+    final keys = await generateWebPushKeys();
+    final privB64 = base64Url.encode(keys.privateKey).replaceAll('=', '');
+    await _kv.write(_privKey, privB64);
+    await _kv.write(_authKey, keys.auth);
+    await _kv.write(_pubKey, keys.p256dh);
+    return keys;
+  }
+}
+
+@visibleForTesting
+class FixedWebPushKeyStore implements WebPushKeyStore {
+  const FixedWebPushKeyStore(this._keys);
+  final WebPushKeys _keys;
+
+  @override
+  Future<WebPushKeys> loadOrCreate() async => _keys;
+}
+
+/// Delivers pushes over PushPort's FCM transport. The app generates its own
+/// ECDH keypair and decrypts messages on-device — no Firebase types leak here;
+/// FCM is consumed through the injected [getFcmToken] and [incomingEncrypted].
+class PushPortFcmProvider implements PushProvider {
+  PushPortFcmProvider({
+    required this.client,
+    required this.getFcmToken,
+    required this.incomingEncrypted,
+    Stream<List<int>>? incomingEncryptedOpens,
+    WebPushKeyStore? keyStore,
+  })  : _openStream = incomingEncryptedOpens,
+        _keyStore = keyStore ?? SecureWebPushKeyStore();
+
+  final PushPortClient client;
+  final Future<String> Function() getFcmToken;
+  final Stream<List<int>> incomingEncrypted;
+  final Stream<List<int>>? _openStream;
+  final WebPushKeyStore _keyStore;
+
+  StreamSubscription<List<int>>? _sub;
+  StreamSubscription<List<int>>? _openSub;
+
+  @override
+  String get name => 'pushport/fcm';
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<void> start({
+    required void Function(PushTarget) onTarget,
+    required void Function(PushMessage) onMessage,
+    required void Function(PushMessage) onOpen,
+  }) async {
+    final keys = await _keyStore.loadOrCreate();
+    final fcmToken = await getFcmToken();
+    final sub = await client.subscribe(transport: 'fcm', token: fcmToken);
+    onTarget(PushTarget(sub.endpoint, p256dh: keys.p256dh, auth: keys.auth));
+
+    await _sub?.cancel();
+    _sub = incomingEncrypted.listen((body) async {
+      try {
+        final plaintext = await decryptWebPush(
+          privateKey: keys.privateKey,
+          auth: keys.auth,
+          body: body,
+        );
+        // Dedup and display both live in PushNotifications.show (the single
+        // chokepoint, shared with the background isolate and UnifiedPush).
+        onMessage(decodeUnifiedPush(Uint8List.fromList(plaintext)));
+      } catch (_) {
+        return;
+      }
+    });
+
+    final opens = _openStream;
+    if (opens != null) {
+      await _openSub?.cancel();
+      _openSub = opens.listen((body) async {
+        try {
+          final plaintext = await decryptWebPush(
+            privateKey: keys.privateKey,
+            auth: keys.auth,
+            body: body,
+          );
+          onOpen(decodeUnifiedPush(Uint8List.fromList(plaintext)));
+        } catch (_) {
+          return;
+        }
+      });
+    }
+  }
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<void> stop() async {
+    await _sub?.cancel();
+    _sub = null;
+    await _openSub?.cancel();
+    _openSub = null;
+  }
+}

--- a/app/lib/push/webpush_crypto.dart
+++ b/app/lib/push/webpush_crypto.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography_plus/cryptography_plus.dart';
+import 'package:pointycastle/ecc/curves/prime256v1.dart';
+
+final _p256 = ECCurve_prime256v1();
+
+class WebPushKeys {
+  final String p256dh;
+  final String auth;
+  final List<int> privateKey;
+
+  const WebPushKeys({
+    required this.p256dh,
+    required this.auth,
+    required this.privateKey,
+  });
+}
+
+Future<WebPushKeys> generateWebPushKeys() async {
+  final rng = Random.secure();
+  final d = Uint8List.fromList(List.generate(32, (_) => rng.nextInt(256)));
+  final authBytes = Uint8List.fromList(List.generate(16, (_) => rng.nextInt(256)));
+  return WebPushKeys(
+    p256dh: _b64url(_p256PublicFromPrivate(d)),
+    auth: _b64url(authBytes),
+    privateKey: d,
+  );
+}
+
+Future<List<int>> decryptWebPush({
+  required List<int> privateKey,
+  required String auth,
+  required List<int> body,
+}) async {
+  if (body.length < 21) throw ArgumentError('body too short');
+
+  final salt = body.sublist(0, 16);
+  final idLen = body[20];
+  final asPub = body.sublist(21, 21 + idLen);
+  final ciphertext = body.sublist(21 + idLen);
+
+  final uaPub = _p256PublicFromPrivate(privateKey);
+  final shared = _p256Ecdh(privateKey, asPub);
+
+  final authBytes = base64Url.decode(auth + '=' * ((4 - auth.length % 4) % 4));
+
+  // RFC 8291 §3.4: derive IKM from ECDH secret
+  final keyInfo = [
+    ...utf8.encode('WebPush: info\x00'),
+    ...uaPub,
+    ...asPub,
+  ];
+  final ikmKey = await Hkdf(hmac: Hmac.sha256(), outputLength: 32).deriveKey(
+    secretKey: SecretKey(shared),
+    nonce: authBytes,
+    info: keyInfo,
+  );
+  final ikm = await ikmKey.extractBytes();
+
+  // RFC 8188: extract PRK from IKM + per-message salt
+  final prk = (await Hmac.sha256().calculateMac(ikm, secretKey: SecretKey(salt))).bytes;
+
+  final cek = await _hkdfExpand(prk, utf8.encode('Content-Encoding: aes128gcm\x00'), 16);
+  final nonce = await _hkdfExpand(prk, utf8.encode('Content-Encoding: nonce\x00'), 12);
+
+  final secretBox = SecretBox(
+    ciphertext.sublist(0, ciphertext.length - 16),
+    nonce: nonce,
+    mac: Mac(ciphertext.sublist(ciphertext.length - 16)),
+  );
+  final record = await AesGcm.with128bits().decrypt(secretBox, secretKey: SecretKey(cek));
+
+  // Strip trailing 0x02 last-record delimiter (and any zero padding before it)
+  var i = record.length - 1;
+  while (i >= 0 && record[i] == 0x00) {
+    i--;
+  }
+  if (i < 0 || record[i] != 0x02) throw StateError('missing padding delimiter');
+  return record.sublist(0, i);
+}
+
+String _b64url(List<int> bytes) => base64Url.encode(bytes).replaceAll('=', '');
+
+BigInt _bytesToBigInt(List<int> bytes) {
+  var result = BigInt.zero;
+  for (final b in bytes) {
+    result = (result << 8) | BigInt.from(b);
+  }
+  return result;
+}
+
+Uint8List _bigIntTo32Bytes(BigInt n) {
+  final result = Uint8List(32);
+  var value = n;
+  for (var i = 31; i >= 0; i--) {
+    result[i] = (value & BigInt.from(0xFF)).toInt();
+    value >>= 8;
+  }
+  return result;
+}
+
+Uint8List _p256PublicFromPrivate(List<int> privateKeyBytes) {
+  final d = _bytesToBigInt(privateKeyBytes);
+  return (_p256.G * d)!.getEncoded(false);
+}
+
+Uint8List _p256Ecdh(List<int> privateKeyBytes, List<int> peerPublicBytes) {
+  final d = _bytesToBigInt(privateKeyBytes);
+  final sharedPoint = (_p256.curve.decodePoint(peerPublicBytes)! * d)!;
+  return _bigIntTo32Bytes(sharedPoint.x!.toBigInteger()!);
+}
+
+// HKDF-Expand(PRK, info, L) per RFC 5869
+Future<Uint8List> _hkdfExpand(List<int> prk, List<int> info, int length) async {
+  final hmac = Hmac.sha256();
+  final prkKey = SecretKey(prk);
+  var t = <int>[];
+  final result = <int>[];
+  var counter = 1;
+  while (result.length < length) {
+    t = (await hmac.calculateMac(
+      [...t, ...info, counter & 0xFF],
+      secretKey: prkKey,
+    )).bytes;
+    result.addAll(t);
+    counter++;
+  }
+  return Uint8List.fromList(result.sublist(0, length));
+}

--- a/app/lib/ui/push_settings_screen.dart
+++ b/app/lib/ui/push_settings_screen.dart
@@ -5,14 +5,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../e2e/aggregate.dart' show pushGoneCode;
 import '../push/push_controller.dart';
+import '../push/pushport_config.dart';
 import '../state/push.dart';
 import '../transport/jsonrpc.dart';
 import 'responsive.dart';
 import 'theme.dart';
 
-/// Push notifications settings: the active backend, a test button, and a
-/// UnifiedPush distributor picker (the embedded FCM distributor appears here as
-/// "argus" alongside any installed external distributors).
+/// Push notifications settings: the active backend, a test button, a provider
+/// picker, and (when UnifiedPush is active) a distributor picker.
 class PushSettingsScreen extends ConsumerStatefulWidget {
   const PushSettingsScreen({super.key});
 
@@ -23,6 +23,7 @@ class PushSettingsScreen extends ConsumerStatefulWidget {
 class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
   List<String> _distributors = [];
   String? _currentDistributor;
+  String? _activeProvider;
   bool _loading = true;
   bool? _registered;
   StreamSubscription<String>? _failureSub;
@@ -30,12 +31,13 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
 
   PushController get _controller => ref.read(pushControllerProvider);
 
+  bool get _showDistributorPicker => _activeProvider == 'unifiedpush';
+
   @override
   void initState() {
     super.initState();
-    // Seed from the last known result: registration usually completes on connect,
-    // before this screen (and its broadcast subscription) exists.
     _registered = _controller.lastRegistration;
+    _activeProvider = _controller.activeBackend;
     _failureSub = _controller.pushFailures.listen((reason) {
       if (mounted) _toast('UnifiedPush registration failed: $reason');
     });
@@ -57,12 +59,12 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
   Future<void> _load() async {
     final distributors = await _controller.distributors();
     final current = await _controller.currentDistributor();
+    await _controller.refreshServerInfo();
     if (!mounted) return;
     setState(() {
       _distributors = distributors;
-      // Keep the existing selection if the plugin hasn't acknowledged one yet
-      // (ack is async, especially for the embedded FCM distributor).
       _currentDistributor = current ?? _currentDistributor;
+      _activeProvider = _controller.activeBackend;
       _loading = false;
     });
   }
@@ -86,8 +88,13 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
                     label: const Text('Send test notification'),
                   ),
                   const SizedBox(height: 16),
-                  _header('Distributor'),
-                  ..._distributorBody(),
+                  _header('Provider'),
+                  ..._providerBody(),
+                  if (_showDistributorPicker) ...[
+                    const SizedBox(height: 16),
+                    _header('Distributor'),
+                    ..._distributorBody(),
+                  ],
                 ],
               ),
             ),
@@ -95,9 +102,7 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
   }
 
   Widget _registrationStatus() {
-    const red = Color(
-      0xFFfb4934,
-    ); // gruvbox red — matches status usage elsewhere
+    const red = Color(0xFFfb4934);
     final (icon, color, label) = switch (_registered) {
       true => (
         Icons.check_circle_outline,
@@ -128,6 +133,34 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
       ),
     ),
   );
+
+  List<Widget> _providerBody() {
+    final options = [
+      ('unifiedpush', 'UnifiedPush', 'Default — uses distributor apps on the device'),
+      if (PushPortConfig.isConfigured && _controller.pushPortAvailable)
+        ('pushport/fcm', 'PushPort / FCM', 'Firebase Cloud Messaging with on-device decrypt'),
+    ];
+    return [
+      RadioGroup<String>(
+        groupValue: _activeProvider,
+        onChanged: _selectProvider,
+        child: Column(
+          children: [
+            for (final (value, label, subtitle) in options)
+              RadioListTile<String>(
+                contentPadding: EdgeInsets.zero,
+                value: value,
+                title: Text(label),
+                subtitle: Text(
+                  subtitle,
+                  style: const TextStyle(color: AppColors.dim, fontSize: 11),
+                ),
+              ),
+          ],
+        ),
+      ),
+    ];
+  }
 
   List<Widget> _distributorBody() {
     if (_distributors.isEmpty) {
@@ -176,20 +209,14 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
       if (mounted) _toast('Test notification sent — check your notifications');
       return;
     } on RpcError catch (e) {
-      // The gateway pruned a permanently dead target: re-registering the same
-      // endpoint would just fail again, so force a fresh one instead.
       if (e.code == pushGoneCode) {
         await _recoverGoneAndRetry();
         return;
       }
-      // Other RPC failure (e.g. no/stale registration): re-register and retry.
-    } catch (_) {
-      // Not connected yet / no target: re-register and retry.
-    }
+    } catch (_) {}
     await _reregisterAndRetry();
   }
 
-  /// The cached endpoint is gone: mint a fresh one, then retry the test.
   Future<void> _recoverGoneAndRetry() async {
     if (mounted) _toast('Push endpoint expired — refreshing…');
     final ok = await _controller.reregister(force: true);
@@ -208,7 +235,6 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
     );
   }
 
-  /// Stale/missing registration: re-register the current endpoint, then retry.
   Future<void> _reregisterAndRetry() async {
     if (mounted) _toast('Re-registering with the gateway…');
     final ok = await _controller.reregister();
@@ -223,8 +249,6 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
     );
   }
 
-  /// Sends a test notification and toasts the outcome; [onFailure] gets the error
-  /// appended.
   Future<void> _sendTestThenToast({
     required String onSuccess,
     required String onFailure,
@@ -237,9 +261,23 @@ class _PushSettingsScreenState extends ConsumerState<PushSettingsScreen> {
     }
   }
 
+  Future<void> _selectProvider(String? name) async {
+    if (name == null) return;
+    final prev = _activeProvider;
+    setState(() => _activeProvider = name);
+    try {
+      await _controller.useProvider(name);
+      await _load();
+      if (mounted) _toast('Using $name for push');
+    } catch (e) {
+      if (mounted) setState(() => _activeProvider = prev);
+      if (mounted) _toast('Failed to switch to $name: $e');
+    }
+  }
+
   Future<void> _selectDistributor(String? d) async {
     if (d == null) return;
-    setState(() => _currentDistributor = d); // reflect the choice immediately
+    setState(() => _currentDistributor = d);
     await _controller.useDistributor(d);
     await _load();
     if (mounted) _toast('Using ${_distributorLabel(d)} for push');

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "99.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      sha256: ff0a84a2734d9e1089f8aedd5c0af0061b82fb94e95260d943404e0ef2134b11
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.59"
   analyzer:
     dependency: transitive
     description:
@@ -217,6 +225,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  firebase_core:
+    dependency: "direct main"
+    description:
+      name: firebase_core
+      sha256: "7be63a3f841fc9663342f7f3a011a42aef6a61066943c90b1c434d79d5c995c5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.15.2"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      sha256: "0ecda14c1bfc9ed8cac303dd0f8d04a320811b479362a9a4efb14fd331a473ce"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.3"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      sha256: "0ed0dc292e8f9ac50992e2394e9d336a0275b6ae400d64163fdf0a8a8b556c37"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.24.1"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: "60be38574f8b5658e2f22b7e311ff2064bea835c248424a383783464e8e02fcc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.10"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "685e1771b3d1f9c8502771ccc9f91485b376ffe16d553533f335b9183ea99754"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.10"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: "0d1be17bc89ed3ff5001789c92df678b2e963a51b6fa2bdb467532cc9dbed390"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.10"
   fixnum:
     dependency: transitive
     description:
@@ -393,7 +449,7 @@ packages:
     source: hosted
     version: "2.0.2"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
@@ -513,7 +569,7 @@ packages:
     source: hosted
     version: "0.13.0"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -53,6 +53,10 @@ dependencies:
   xterm: ^4.0.0
   url_launcher: ^6.3.2
   pointycastle: ^4.0.0
+  http: ^1.2.0
+  meta: ^1.15.0
+  firebase_core: ^3.6.0
+  firebase_messaging: ^15.1.3
 
 dev_dependencies:
   flutter_test:

--- a/app/test/push/fcm_source_test.dart
+++ b/app/test/push/fcm_source_test.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:argus/push/fcm_source.dart';
+
+void main() {
+  group('decodeFcmBody', () {
+    test('reads the PushPort `e` key (base64url, unpadded)', () {
+      final bytes = Uint8List.fromList([1, 2, 3, 250, 0, 255, 128, 64, 200]);
+      // Mirror PushPort's base64.RawURLEncoding.
+      final e = base64Url.encode(bytes).replaceAll('=', '');
+      expect(decodeFcmBody({'e': e}), bytes);
+    });
+
+    test('returns null when `e` is absent (e.g. only a legacy `body` key)', () {
+      expect(decodeFcmBody({'body': 'AQID'}), isNull);
+    });
+
+    test('returns null on malformed base64', () {
+      expect(decodeFcmBody({'e': '@@not-base64@@'}), isNull);
+    });
+
+    test('returns null when `e` is empty', () {
+      expect(decodeFcmBody({'e': ''}), isNull);
+    });
+  });
+}

--- a/app/test/push/push_controller_test.dart
+++ b/app/test/push/push_controller_test.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+
+import 'package:argus/pairing/gateway_store.dart';
+import 'package:argus/push/device_id.dart';
+import 'package:argus/push/push_controller.dart';
+import 'package:argus/push/push_message.dart';
+import 'package:argus/push/push_provider.dart';
+import 'package:argus/push/push_target_store.dart';
+import 'package:argus/push/unifiedpush_provider.dart';
+import 'package:argus/transport/gateway_client.dart';
+import 'package:argus/transport/jsonrpc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _MemKv implements SecureKv {
+  final _m = <String, String>{};
+  @override
+  Future<String?> read(String key) async => _m[key];
+  @override
+  Future<void> write(String key, String value) async => _m[key] = value;
+  @override
+  Future<void> delete(String key) async => _m.remove(key);
+}
+
+class _FakeGatewayClient implements GatewayClient {
+  final calls = <String>[];
+  final params = <Map<String, dynamic>>[];
+  final responses = <String, Object?>{};
+  final throws = <String, Object>{};
+
+  @override
+  Future<Object?> call(String method, [Object? p]) async {
+    calls.add(method);
+    if (p is Map) params.add((p as Map).cast<String, dynamic>());
+    if (throws.containsKey(method)) throw throws[method]!;
+    return responses[method];
+  }
+
+  @override
+  Stream<RpcMessage> get notifications => StreamController<RpcMessage>().stream;
+
+  @override
+  FutureOr<void> close() {}
+}
+
+class _FakeUnifiedPushProvider extends UnifiedPushProvider {
+  bool forceFreshTargetCalled = false;
+
+  @override
+  Future<bool> isAvailable() async => false;
+  @override
+  Future<List<String>> availableDistributors() async => [];
+  @override
+  Future<String?> savedDistributor() async => null;
+  @override
+  Future<PushTarget?> forceFreshTarget() async {
+    forceFreshTargetCalled = true;
+    return null;
+  }
+}
+
+class _FakePushProvider implements PushProvider {
+  _FakePushProvider(this.name, this._endpoint);
+
+  @override
+  final String name;
+  final String _endpoint;
+  int startCount = 0;
+  int stopCount = 0;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<void> start({
+    required void Function(PushTarget) onTarget,
+    required void Function(PushMessage) onMessage,
+    required void Function(PushMessage) onOpen,
+  }) async {
+    startCount++;
+    onTarget(PushTarget(_endpoint));
+  }
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<void> stop() async {
+    stopCount++;
+  }
+}
+
+PushController _makeController({
+  required _FakeUnifiedPushProvider unifiedPush,
+  required List<PushProvider> extraProviders,
+  required _FakeGatewayClient client,
+}) {
+  final kv = _MemKv();
+  final controller = PushController(
+    unifiedPush: unifiedPush,
+    extraProviders: extraProviders,
+    deviceIdStore: DeviceIdStore(kv),
+    targetStore: PushTargetStore(kv),
+    providerKv: kv,
+    testDeviceId: 'test-device-id',
+  );
+  controller.attach(client);
+  return controller;
+}
+
+void main() {
+  test('useProvider activates fake provider and registers on target', () async {
+    final client = _FakeGatewayClient();
+    const endpoint = 'https://ppdev.example/push/abc';
+    final fakeProvider = _FakePushProvider('pushport/fcm', endpoint);
+    final unifiedPush = _FakeUnifiedPushProvider();
+
+    final controller = _makeController(
+      unifiedPush: unifiedPush,
+      extraProviders: [fakeProvider],
+      client: client,
+    );
+
+    await controller.useProvider('pushport/fcm');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.activeBackend, 'pushport/fcm');
+    expect(client.calls, contains('push.register'));
+
+    final regCall = client.params.firstWhere((p) => p.containsKey('endpoint'));
+    expect(regCall['endpoint'], endpoint);
+    expect(regCall['device_id'], 'test-device-id');
+
+    await controller.dispose();
+  });
+
+  test('reregister(force: true) does not drive UnifiedPush when FCM is active', () async {
+    final client = _FakeGatewayClient();
+    const endpoint = 'https://ppdev.example/push/abc';
+    final fakeProvider = _FakePushProvider('pushport/fcm', endpoint);
+    final unifiedPush = _FakeUnifiedPushProvider();
+
+    final controller = _makeController(
+      unifiedPush: unifiedPush,
+      extraProviders: [fakeProvider],
+      client: client,
+    );
+
+    await controller.useProvider('pushport/fcm');
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.activeBackend, 'pushport/fcm');
+
+    client.calls.clear();
+    client.params.clear();
+
+    final ok = await controller.reregister(force: true);
+    await Future<void>.delayed(Duration.zero);
+
+    // The UP force path must not fire for FCM (it restarts its own provider).
+    expect(unifiedPush.forceFreshTargetCalled, isFalse);
+
+    // The FCM provider must be restarted to mint a fresh subscription.
+    expect(fakeProvider.stopCount, greaterThan(0));
+    expect(fakeProvider.startCount, greaterThan(1));
+
+    expect(ok, isTrue);
+    expect(client.calls, contains('push.register'));
+    final regCall = client.params.firstWhere((p) => p.containsKey('endpoint'));
+    expect(regCall['endpoint'], endpoint);
+
+    await controller.dispose();
+  });
+
+  test('persists the provider choice and restores it on a fresh controller', () async {
+    final kv = _MemKv();
+
+    final c1 = PushController(
+      unifiedPush: _FakeUnifiedPushProvider(),
+      extraProviders: [_FakePushProvider('pushport/fcm', 'https://pp.example/ep')],
+      deviceIdStore: DeviceIdStore(_MemKv()),
+      targetStore: PushTargetStore(_MemKv()),
+      providerKv: kv,
+      testDeviceId: 'd',
+    );
+    c1.attach(_FakeGatewayClient());
+    await c1.useProvider('pushport/fcm');
+    expect(await kv.read('push_provider'), 'pushport/fcm');
+    await c1.dispose();
+
+    final c2 = PushController(
+      unifiedPush: _FakeUnifiedPushProvider(),
+      extraProviders: [_FakePushProvider('pushport/fcm', 'https://pp.example/ep')],
+      deviceIdStore: DeviceIdStore(_MemKv()),
+      targetStore: PushTargetStore(_MemKv()),
+      providerKv: kv,
+      testDeviceId: 'd',
+    );
+    await c2.activateInitialProvider();
+    expect(c2.activeBackend, 'pushport/fcm');
+    await c2.dispose();
+  });
+
+  test('pushPortAvailable is true when server.info reports pushPortConfigured: true', () async {
+    final client = _FakeGatewayClient();
+    client.responses['server.info'] = {
+      'version': 'x',
+      'nodes': [],
+      'pushPortConfigured': true,
+    };
+    final controller = PushController(
+      unifiedPush: _FakeUnifiedPushProvider(),
+      extraProviders: [],
+      deviceIdStore: DeviceIdStore(_MemKv()),
+      targetStore: PushTargetStore(_MemKv()),
+      testDeviceId: 'test-device-id',
+    );
+    controller.attach(client);
+    await controller.refreshServerInfo();
+    expect(controller.pushPortAvailable, isTrue);
+    await controller.dispose();
+  });
+
+  test('pushPortAvailable is false when server.info reports pushPortConfigured: false', () async {
+    final client = _FakeGatewayClient();
+    client.responses['server.info'] = {
+      'version': 'x',
+      'nodes': [],
+      'pushPortConfigured': false,
+    };
+    final controller = PushController(
+      unifiedPush: _FakeUnifiedPushProvider(),
+      extraProviders: [],
+      deviceIdStore: DeviceIdStore(_MemKv()),
+      targetStore: PushTargetStore(_MemKv()),
+      testDeviceId: 'test-device-id',
+    );
+    controller.attach(client);
+    await controller.refreshServerInfo();
+    expect(controller.pushPortAvailable, isFalse);
+    await controller.dispose();
+  });
+
+  test('pushPortAvailable is false when server.info throws (fail-closed)', () async {
+    final client = _FakeGatewayClient();
+    client.throws['server.info'] = Exception('network error');
+    final controller = PushController(
+      unifiedPush: _FakeUnifiedPushProvider(),
+      extraProviders: [],
+      deviceIdStore: DeviceIdStore(_MemKv()),
+      targetStore: PushTargetStore(_MemKv()),
+      testDeviceId: 'test-device-id',
+    );
+    controller.attach(client);
+    await controller.refreshServerInfo();
+    expect(controller.pushPortAvailable, isFalse);
+    await controller.dispose();
+  });
+
+}

--- a/app/test/push/pushport_client_test.dart
+++ b/app/test/push/pushport_client_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+import 'package:argus/push/pushport_client.dart';
+
+void main() {
+  test('subscribe posts transport+token and parses the sealed endpoint',
+      () async {
+    late http.Request seen;
+    final mock = MockClient((req) async {
+      seen = req;
+      return http.Response(
+        jsonEncode({
+          'request_id': 'r1',
+          'data': {
+            'endpoint': 'https://push.pushport.dev/push/abc',
+            'expires_at': 123
+          },
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+    final c = PushPortClient(
+        baseUrl: 'https://push.pushport.dev', appId: 'argus', httpClient: mock);
+    final sub =
+        await c.subscribe(transport: 'fcm', token: 'fcm-token', ttl: '360h');
+
+    expect(seen.url.toString(), 'https://push.pushport.dev/apps/argus/subscribe');
+    final sent = jsonDecode(seen.body) as Map<String, dynamic>;
+    expect(sent['transport'], 'fcm');
+    expect(sent['token'], 'fcm-token');
+    expect(sub.endpoint, 'https://push.pushport.dev/push/abc');
+    expect(sub.expiresAt, 123);
+  });
+}

--- a/app/test/push/pushport_config_test.dart
+++ b/app/test/push/pushport_config_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:argus/push/pushport_config.dart';
+
+void main() {
+  test('exposes the build-time PushPort constants', () {
+    expect(PushPortConfig.baseUrl, isNotEmpty);
+    // appId is empty unless injected at build time via --dart-define=ARGUS_PUSHPORT_APP_ID=...
+    expect(
+      PushPortConfig.isConfigured,
+      PushPortConfig.appId.isNotEmpty && PushPortConfig.baseUrl.isNotEmpty,
+    );
+  });
+}

--- a/app/test/push/pushport_fcm_provider_test.dart
+++ b/app/test/push/pushport_fcm_provider_test.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:argus/push/pushport_client.dart';
+import 'package:argus/push/pushport_fcm_provider.dart';
+import 'package:argus/push/push_provider.dart';
+import 'package:argus/push/push_message.dart';
+import 'package:argus/push/webpush_crypto.dart';
+
+List<int> _hex(String s) => [
+      for (var i = 0; i < s.length; i += 2) int.parse(s.substring(i, i + 2), radix: 16)
+    ];
+
+List<int> _b64url(String s) =>
+    base64Url.decode(s + '=' * ((4 - s.length % 4) % 4));
+
+// Fixed keys from the Go cross-compat test vector.
+final _fixedKeys = WebPushKeys(
+  privateKey: _hex('e859f5e3d28955864eb9d1d9d89c091372af501a59eac3890c235e41e0eb3fe7'),
+  auth: 'p3pGeayq2kyywiSY8ZqCZg',
+  p256dh: 'TESTPUB',
+);
+
+// Ciphertext body (encrypts '{"id":"v1","title":"hi","body":"there","data":{"session_id":"s1"}}').
+final _encryptedBody = _b64url(
+    'sGK83czgtFjdXc_IdEzhtgAAEABBBNOOFRKizonxBeK25gBG46GtLbSeeT7WM8OivsWAATYMUiJ1l_Rezde3SQ69vtR6TQAFZIJKKGeHKAAVrGjVs2f6yV8BGQuZzvrwvqJh_34INggqLVVMjqxFkjj1kl1591fav0K-xofzeqm88iFuH1kMDHENkZ5ulIU761iVHodRlQDX6IphEZCgPjalgrRqvDNeig');
+
+// Ciphertext body encrypting '{"id":"v2","title":"hi","body":"there","data":{"node_id":"n1","session_id":"s1"}}'.
+// Used to verify the foreground FCM path composites session_id as nodeId:sessionId.
+final _encryptedBodyWithNodeId = _b64url(
+    '-xmAaudP6yEQA3ko6AdJiwAAEABBBOeGTy-ZT1vL5xK7HH1P89AHefYGlFI2qg2bkOBQTo00GEIk2rgOpMXtbP7BmXp4QdSGmcbBvKgPI6F3NJvwL2_Z4GyR2PtuiZZj6Z_DWmBQyzT7Cg4OemgtMOb4enhULdpe2_h_qXbR-hjEs8E1VxponSvGONCY14OIL_38xqKHZWwfc0dkjK1lyMGHksOniQgfsBMbjHVY2QMk9uNxPFwldQ');
+
+const _sealedEndpoint = 'https://push.pushport.dev/push/fcm-sealed';
+
+PushPortClient _mockClient() => PushPortClient(
+      baseUrl: 'https://push.pushport.dev',
+      appId: 'argus',
+      httpClient: MockClient((_) async => http.Response(
+            jsonEncode({
+              'data': {'endpoint': _sealedEndpoint, 'expires_at': 999},
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          )),
+    );
+
+PushPortFcmProvider _makeProvider(StreamController<List<int>> ctrl) {
+  return PushPortFcmProvider(
+    client: _mockClient(),
+    getFcmToken: () async => 'test-fcm-token',
+    incomingEncrypted: ctrl.stream,
+    keyStore: FixedWebPushKeyStore(_fixedKeys),
+  );
+}
+
+void main() {
+  test('reports target and decrypts incoming message', () async {
+    final ctrl = StreamController<List<int>>();
+    final provider = _makeProvider(ctrl);
+
+    PushTarget? emittedTarget;
+    final messages = <PushMessage>[];
+
+    await provider.start(
+      onTarget: (t) => emittedTarget = t,
+      onMessage: messages.add,
+      onOpen: (_) {},
+    );
+
+    expect(emittedTarget, isNotNull);
+    expect(emittedTarget!.endpoint, _sealedEndpoint);
+    expect(emittedTarget!.p256dh, _fixedKeys.p256dh);
+    expect(emittedTarget!.auth, _fixedKeys.auth);
+
+    ctrl.add(_encryptedBody);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(messages, hasLength(1));
+    expect(messages.first.title, 'hi');
+    expect(messages.first.body, 'there');
+
+    await ctrl.close();
+  });
+
+  test('silently drops a corrupt body and keeps the subscription alive', () async {
+    final ctrl = StreamController<List<int>>();
+    final provider = _makeProvider(ctrl);
+
+    final messages = <PushMessage>[];
+    await provider.start(
+      onTarget: (_) {},
+      onMessage: messages.add,
+      onOpen: (_) {},
+    );
+
+    // Garbage body — decryptWebPush throws.
+    ctrl.add([0x00, 0x01, 0x02]);
+    await Future<void>.delayed(Duration.zero);
+    expect(messages, isEmpty);
+
+    ctrl.add(_encryptedBody);
+    await Future<void>.delayed(Duration.zero);
+    expect(messages, hasLength(1));
+    expect(messages.first.title, 'hi');
+
+    await ctrl.close();
+  });
+
+  test('forwards duplicates — dedup is the display chokepoint (show), not here', () async {
+    final ctrl = StreamController<List<int>>();
+    final provider = _makeProvider(ctrl);
+
+    final messages = <PushMessage>[];
+    await provider.start(
+      onTarget: (_) {},
+      onMessage: messages.add,
+      onOpen: (_) {},
+    );
+
+    ctrl.add(_encryptedBody);
+    ctrl.add(_encryptedBody);
+    await Future<void>.delayed(Duration.zero);
+
+    // The provider no longer dedups; PushNotifications.show dedups by id so a
+    // message shown in the background is not re-shown in the foreground.
+    expect(messages, hasLength(2));
+    await ctrl.close();
+  });
+
+  test('composites session_id as nodeId:sessionId when node_id is present', () async {
+    final ctrl = StreamController<List<int>>();
+    final provider = _makeProvider(ctrl);
+
+    final messages = <PushMessage>[];
+    await provider.start(
+      onTarget: (_) {},
+      onMessage: messages.add,
+      onOpen: (_) {},
+    );
+
+    ctrl.add(_encryptedBodyWithNodeId);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(messages, hasLength(1));
+    expect(messages.first.sessionId, 'n1:s1');
+  });
+}

--- a/app/test/push/webpush_crypto_test.dart
+++ b/app/test/push/webpush_crypto_test.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:argus/push/webpush_crypto.dart';
+
+List<int> _b64url(String s) =>
+    base64Url.decode(s + '=' * ((4 - s.length % 4) % 4));
+
+List<int> _hex(String s) => [
+      for (var i = 0; i < s.length; i += 2) int.parse(s.substring(i, i + 2), radix: 16)
+    ];
+
+void main() {
+  test('decrypts a body produced by the Go encryptor', () async {
+    final privateKey = _hex('e859f5e3d28955864eb9d1d9d89c091372af501a59eac3890c235e41e0eb3fe7');
+    const auth = 'p3pGeayq2kyywiSY8ZqCZg';
+    final body = _b64url('sGK83czgtFjdXc_IdEzhtgAAEABBBNOOFRKizonxBeK25gBG46GtLbSeeT7WM8OivsWAATYMUiJ1l_Rezde3SQ69vtR6TQAFZIJKKGeHKAAVrGjVs2f6yV8BGQuZzvrwvqJh_34INggqLVVMjqxFkjj1kl1591fav0K-xofzeqm88iFuH1kMDHENkZ5ulIU761iVHodRlQDX6IphEZCgPjalgrRqvDNeig');
+    const plaintext = '{"id":"v1","title":"hi","body":"there","data":{"session_id":"s1"}}';
+
+    final out = await decryptWebPush(privateKey: privateKey, auth: auth, body: body);
+    expect(utf8.decode(out), plaintext);
+  });
+
+  test('generateWebPushKeys yields a 65-byte point and 16-byte auth', () async {
+    final keys = await generateWebPushKeys();
+    expect(_b64url(keys.p256dh).length, 65);
+    expect(_b64url(keys.auth).length, 16);
+  });
+}

--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -11,6 +11,12 @@ import (
 // version is overridden at build time via -ldflags.
 var version = "dev"
 
+// pushPortAppID is overridden at build time via -ldflags.
+var pushPortAppID = ""
+
+// pushPortBaseURL is overridden at build time via -ldflags.
+var pushPortBaseURL = "https://pushport.muniftanjim.dev"
+
 func main() {
 	cmd := newRootCmd(version)
 	err := cmd.Execute()

--- a/cmd/argus/openurl.go
+++ b/cmd/argus/openurl.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+var openURLFn = openURL
+
+func browserCommand(goos, url string) (string, []string) {
+	switch goos {
+	case "darwin":
+		return "open", []string{url}
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		return "xdg-open", []string{url}
+	}
+}
+
+func openURL(url string) error {
+	name, args := browserCommand(runtime.GOOS, url)
+	if err := exec.Command(name, args...).Run(); err != nil {
+		return fmt.Errorf("open browser: %w", err)
+	}
+	return nil
+}

--- a/cmd/argus/openurl_test.go
+++ b/cmd/argus/openurl_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBrowserCommand(t *testing.T) {
+	const url = "https://example.com/register"
+	tests := []struct {
+		goos     string
+		wantCmd  string
+		wantArgs []string
+	}{
+		{"darwin", "open", []string{url}},
+		{"windows", "rundll32", []string{"url.dll,FileProtocolHandler", url}},
+		{"linux", "xdg-open", []string{url}},
+		{"freebsd", "xdg-open", []string{url}},
+	}
+	for _, tt := range tests {
+		cmd, args := browserCommand(tt.goos, url)
+		if cmd != tt.wantCmd || !reflect.DeepEqual(args, tt.wantArgs) {
+			t.Errorf("browserCommand(%q, url) = %q %v, want %q %v",
+				tt.goos, cmd, args, tt.wantCmd, tt.wantArgs)
+		}
+	}
+}

--- a/cmd/argus/pushport.go
+++ b/cmd/argus/pushport.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MunifTanjim/argus/internal/api"
+	"github.com/MunifTanjim/argus/internal/shell"
+)
+
+var pushportStdinReader io.Reader = os.Stdin
+
+func newPushPortCmd(appID, baseURL string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pushport",
+		Short: "Manage PushPort integration",
+	}
+	cmd.AddCommand(newPushPortRegisterCmd(appID, baseURL))
+	return cmd
+}
+
+func registrationURL(base, appID string) string {
+	return strings.TrimRight(base, "/") + "/apps/" + appID + "/instances/register"
+}
+
+func newPushPortRegisterCmd(appID, baseURL string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "register",
+		Short:         "Register this deployment with PushPort and apply the instance token via the gateway",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if appID == "" {
+				return fail(cmd, fmt.Errorf("this argus build has no PushPort app id embedded; rebuild with 'make build PUSHPORT_APP_ID=<your-app-id>'"))
+			}
+
+			cfg, err := resolveConfig(cmd)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			if cfg.Gateway.URL == "" {
+				return fail(cmd, fmt.Errorf("--gateway ws(s)://host is required"))
+			}
+
+			url := registrationURL(baseURL, appID)
+			shell.StdOutF("Registration URL: %s\n", url)
+			if err := openURLFn(url); err != nil {
+				shell.StdErrF("Could not open browser automatically. Visit the URL above.\n")
+			}
+
+			shell.StdOutF("Paste the instance token (pit_...): ")
+			scanner := bufio.NewScanner(pushportStdinReader)
+			scanner.Scan()
+			if err := scanner.Err(); err != nil {
+				return fail(cmd, fmt.Errorf("read token: %w", err))
+			}
+			token := strings.TrimSpace(scanner.Text())
+			if token == "" {
+				return fail(cmd, fmt.Errorf("no token provided"))
+			}
+			if !strings.HasPrefix(token, "pit_") {
+				shell.StdErrF("warning: token does not start with pit_ — double-check you copied the right value\n")
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			client, err := dialGatewayClient(ctx, cfg.Gateway.URL, cfg.Token)
+			if err != nil {
+				return fail(cmd, fmt.Errorf("connect: %w", err))
+			}
+			defer client.Close()
+
+			if err := client.Call(api.MethodPushPortSetToken, api.PushPortSetTokenParams{Token: token}, nil); err != nil {
+				return fail(cmd, fmt.Errorf("set token: %w", err))
+			}
+
+			shell.StdOutF("Instance token applied to the gateway.\n")
+			return nil
+		},
+	}
+	addGatewayClientFlags(cmd.Flags())
+	return cmd
+}

--- a/cmd/argus/pushport_test.go
+++ b/cmd/argus/pushport_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MunifTanjim/argus/internal/gateway"
+)
+
+func TestRegistrationURL(t *testing.T) {
+	tests := []struct {
+		base  string
+		appID string
+		want  string
+	}{
+		{
+			"https://pushport.muniftanjim.dev",
+			"argus",
+			"https://pushport.muniftanjim.dev/apps/argus/instances/register",
+		},
+		{
+			"https://pushport.muniftanjim.dev/",
+			"argus",
+			"https://pushport.muniftanjim.dev/apps/argus/instances/register",
+		},
+		{
+			"https://example.com//",
+			"myapp",
+			"https://example.com/apps/myapp/instances/register",
+		},
+	}
+	for _, tt := range tests {
+		got := registrationURL(tt.base, tt.appID)
+		if got != tt.want {
+			t.Errorf("registrationURL(%q, %q) = %q, want %q", tt.base, tt.appID, got, tt.want)
+		}
+	}
+}
+
+func TestPushPortRegisterEmptyAppID(t *testing.T) {
+	opened := false
+	orig := openURLFn
+	openURLFn = func(string) error { opened = true; return nil }
+	t.Cleanup(func() { openURLFn = orig })
+
+	origReader := pushportStdinReader
+	pushportStdinReader = strings.NewReader("pit_tok\n")
+	t.Cleanup(func() { pushportStdinReader = origReader })
+
+	root := newRootCmd("test") // pushPortAppID is "" in tests
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"pushport", "register", "--no-config", "--gateway", "ws://127.0.0.1:1", "--token", "tok"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for empty app id")
+	}
+	if opened {
+		t.Error("opener must not be called when app id is empty")
+	}
+}
+
+func TestPushPortRegisterMissingGateway(t *testing.T) {
+	t.Setenv("ARGUS_GATEWAY_URL", "") // prevent shell env from bypassing the guard
+
+	origAppID := pushPortAppID
+	pushPortAppID = "testapp"
+	t.Cleanup(func() { pushPortAppID = origAppID })
+
+	orig := openURLFn
+	openURLFn = func(string) error { return nil }
+	t.Cleanup(func() { openURLFn = orig })
+
+	origReader := pushportStdinReader
+	pushportStdinReader = strings.NewReader("pit_tok\n")
+	t.Cleanup(func() { pushportStdinReader = origReader })
+
+	root := newRootCmd("test")
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	// --no-config isolates the test from any real config file, so it cannot
+	// resolve (and mutate) a live gateway.
+	root.SetArgs([]string{"pushport", "register", "--no-config"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error when --gateway is not set")
+	}
+}
+
+func TestPushPortRegisterEmptyToken(t *testing.T) {
+	origAppID := pushPortAppID
+	pushPortAppID = "testapp"
+	t.Cleanup(func() { pushPortAppID = origAppID })
+
+	orig := openURLFn
+	openURLFn = func(string) error { return nil }
+	t.Cleanup(func() { openURLFn = orig })
+
+	origReader := pushportStdinReader
+	pushportStdinReader = strings.NewReader("\n")
+	t.Cleanup(func() { pushportStdinReader = origReader })
+
+	root := newRootCmd("test")
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"pushport", "register", "--no-config", "--gateway", "ws://127.0.0.1:1"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestPushPortRegisterCallsGateway(t *testing.T) {
+	origAppID := pushPortAppID
+	pushPortAppID = "testapp"
+	t.Cleanup(func() { pushPortAppID = origAppID })
+
+	var received string
+	hsrv := gateway.NewServer(gateway.New(0), tokenAuth("admin"), tokenAuth("admin"))
+	hsrv.SetClientTokens(nil, "admin") // make "admin" token grant admin principal
+	hsrv.SetPushPortTokenSetter(func(tok string) error { received = tok; return nil })
+	ts := httptest.NewServer(hsrv.Handler())
+	defer ts.Close()
+
+	orig := openURLFn
+	openURLFn = func(string) error { return nil }
+	t.Cleanup(func() { openURLFn = orig })
+
+	origReader := pushportStdinReader
+	pushportStdinReader = strings.NewReader("pit_newtoken\n")
+	t.Cleanup(func() { pushportStdinReader = origReader })
+
+	root := newRootCmd("test")
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"pushport", "register", "--no-config", "--gateway", wsURL(ts.URL), "--token", "admin"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if received != "pit_newtoken" {
+		t.Errorf("received token = %q, want pit_newtoken", received)
+	}
+}

--- a/cmd/argus/root.go
+++ b/cmd/argus/root.go
@@ -114,7 +114,7 @@ func newRootCmd(version string) *cobra.Command {
 
 	addClientFlags(cmd.Flags())
 
-	cmd.AddCommand(newStartCmd(version), newSpawnCmd(), newHooksCmd(), newHookCmd(), newPingCmd(), newPairCmd(), newUnpairCmd(), newFocusCmd(), newUpgradeCmd(), newConfigCmd(), newViewCmd(), newLockCmd())
+	cmd.AddCommand(newStartCmd(version), newSpawnCmd(), newHooksCmd(), newHookCmd(), newPingCmd(), newPairCmd(), newUnpairCmd(), newFocusCmd(), newUpgradeCmd(), newConfigCmd(), newViewCmd(), newLockCmd(), newPushPortCmd(pushPortAppID, pushPortBaseURL))
 
 	cmd.InitDefaultCompletionCmd()
 	if subcmd, _, _ := cmd.Find([]string{"completion"}); subcmd != nil && subcmd.Name() == "completion" {

--- a/cmd/argus/start.go
+++ b/cmd/argus/start.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"sync/atomic"
@@ -472,7 +473,25 @@ func setupBlindPush(ctx context.Context, d *node.Node, hsrv *gateway.Server, del
 		return
 	}
 	hsrv.SetVAPIDPublicKey(vapid.PublicKey())
-	hsrv.SetPushDeliverer(push.NewGatewayDeliverer(vapid))
+	tokenPath := config.GetStatePath("pushport-token")
+	ppHost := ""
+	if u, err := url.Parse(pushPortBaseURL); err == nil {
+		ppHost = u.Host
+	}
+	var pp *push.PushPortAuth
+	if tok, _ := push.ReadInstanceToken(tokenPath); tok != "" && ppHost != "" {
+		pp = &push.PushPortAuth{Host: ppHost, Token: tok}
+	}
+	dv := push.NewGatewayDeliverer(vapid, pp)
+	hsrv.SetPushDeliverer(dv)
+	hsrv.SetPushPortTokenSetter(func(tok string) error {
+		if err := push.WriteInstanceToken(tokenPath, tok); err != nil {
+			return err
+		}
+		dv.SetPushPort(ppHost, tok)
+		return nil
+	})
+	hsrv.SetPushPortStatus(func() bool { return dv.HasPushPort() })
 	if d != nil {
 		d.SetPushStore(push.NewStore(config.GetStatePath("push-tokens")))
 		go d.StartPush(ctx, delay)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -106,6 +106,7 @@ export default defineConfig({
           { text: "End-to-End Encryption", link: "/guide/e2ee" },
           { text: "TUI", link: "/guide/tui" },
           { text: "Mobile App", link: "/guide/mobile-app" },
+          { text: "PushPort", link: "/guide/pushport" },
         ],
       },
     ],

--- a/docs/guide/pushport.md
+++ b/docs/guide/pushport.md
@@ -1,0 +1,37 @@
+# PushPort
+
+[**PushPort**](https://pushport.muniftanjim.dev) is a hosted push relay and an
+alternative push provider for Argus.
+
+[UnifiedPush](/guide/mobile-app#push-notification) is the default. PushPort is an
+alternative — pick whichever you prefer. Your notifications stay private either
+way: the Argus node encrypts each notification end-to-end for your device, so
+neither the gateway nor the relay sees the content.
+
+Delivery runs over **Firebase Cloud Messaging** (Android).
+
+## Prerequisites
+
+- An Argus app build that embeds a PushPort app id. Build it with
+  `make build PUSHPORT_APP_ID=<your-app-id>`. Without an embedded app id, the
+  PushPort option does not appear in the app.
+- A reachable gateway and its master token.
+
+## Setup
+
+1. Register the instance token. Run this command on any machine that can reach
+   your gateway:
+
+   ```sh
+   argus pushport register --gateway wss://your-gateway --token <master-token>
+   ```
+
+   The command opens the PushPort registration page. Complete the form, copy the
+   `pit_…` token, and paste it back when prompted. The gateway stores the token
+   and applies it live. No restart is needed.
+
+2. Select the provider in the app. Open **Settings → Push → Provider** and
+   select **PushPort/FCM**. This option appears only when the gateway has an
+   instance token.
+
+The app then subscribes and registers its endpoint with your gateway.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	github.com/tyler-smith/go-bip39 v1.1.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.36.0
 	modernc.org/sqlite v1.53.0
 )
@@ -37,8 +39,6 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/api/protocol.go
+++ b/internal/api/protocol.go
@@ -77,8 +77,11 @@ const (
 	// MethodPushDeliver is a node->gateway request carrying an opaque, pre-encrypted
 	// Web Push body for the gateway to VAPID-sign and POST. The gateway never sees
 	// cleartext notification content.
-	MethodPushDeliver   = "push.deliver"          // node->gateway request: PushDeliverParams; result: PushDeliverResult
-	MethodSessionExport = "sessions.exportBundle" // request: ExportBundleParams; result: ExportBundleResult
+	MethodPushDeliver = "push.deliver" // node->gateway request: PushDeliverParams; result: PushDeliverResult
+	// MethodPushPortSetToken stores the PushPort instance token on the gateway
+	// (admin only) and applies it live.
+	MethodPushPortSetToken = "pushport.setToken"     // admin request: PushPortSetTokenParams; result: nil
+	MethodSessionExport    = "sessions.exportBundle" // request: ExportBundleParams; result: ExportBundleResult
 	// Changed-files review for a live session's working directory (vs HEAD).
 	MethodSessionChangedFiles = "sessions.changedFiles" // request: SessionRef; result: ChangedFilesResult
 	MethodSessionFileDiff     = "sessions.fileDiff"     // request: FileDiffParams; result: FileDiffResult
@@ -248,6 +251,11 @@ type PushDeliverResult struct {
 	Gone bool `json:"gone,omitempty"`
 }
 
+// PushPortSetTokenParams is the request body for MethodPushPortSetToken.
+type PushPortSetTokenParams struct {
+	Token string `json:"token"`
+}
+
 // PairStartResult carries a freshly minted client token plus the gateway's public
 // base URL for the pairing QR.
 type PairStartResult struct {
@@ -287,8 +295,9 @@ type NodeCapabilities struct {
 // ServerInfo carries server-wide metadata for a connected client: server version
 // and connected nodes. Served by the gateway.
 type ServerInfo struct {
-	Version string     `json:"version"`
-	Nodes   []NodeInfo `json:"nodes"`
+	Version            string     `json:"version"`
+	Nodes              []NodeInfo `json:"nodes"`
+	PushPortConfigured bool       `json:"pushPortConfigured"`
 }
 
 // IdentifyResult announces a node's identity to the gateway. ID is the stable node

--- a/internal/e2etest/push_blind_integration_test.go
+++ b/internal/e2etest/push_blind_integration_test.go
@@ -24,6 +24,138 @@ import (
 	"github.com/MunifTanjim/argus/internal/session"
 )
 
+// TestPushPortBearerDelivery proves that when a device endpoint host matches the
+// configured PushPort host, delivery uses Bearer authorization rather than VAPID.
+func TestPushPortBearerDelivery(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		gotAuth     string
+		gotEncoding string
+		gotBody     []byte
+		gotDelivery = make(chan struct{}, 1)
+	)
+	fakePushPort := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		gotEncoding = r.Header.Get("Content-Encoding")
+		gotBody = body
+		mu.Unlock()
+		select {
+		case gotDelivery <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer fakePushPort.Close()
+
+	ppHost := fakePushPort.Listener.Addr().String()
+
+	vapid, err := push.LoadOrCreateVAPID(filepath.Join(t.TempDir(), "vapid_key.pem"))
+	if err != nil {
+		t.Fatalf("vapid: %v", err)
+	}
+
+	agg := gateway.New(time.Second)
+	gwsrv := gateway.NewServer(agg, nil, nil)
+	gwsrv.SetVAPIDPublicKey(vapid.PublicKey())
+	gwsrv.SetPushDeliverer(push.NewGatewayDeliverer(vapid, &push.PushPortAuth{Host: ppHost, Token: "pit_test"}))
+	ts := httptest.NewServer(gwsrv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := node.New()
+	d.SetIdentity("pp-itest", "pp-itest")
+	d.SetVersion("itest")
+	kp, err := e2e.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("identity keypair: %v", err)
+	}
+	d.SetIdentityKey(kp)
+	d.SetE2EE(true)
+	d.SetPushStore(push.NewStore(t.TempDir()))
+
+	go d.StartPush(ctx, 0)
+
+	sd := sockDir(t)
+	sockPath := filepath.Join(sd, "pp.sock")
+	go func() { _ = d.Run(ctx, sockPath) }()
+	waitFor(t, "node socket ready", func() bool {
+		_, err := os.Stat(sockPath)
+		return err == nil
+	})
+
+	uaPriv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ua keypair: %v", err)
+	}
+	authSecret := make([]byte, 16)
+	if _, err := rand.Read(authSecret); err != nil {
+		t.Fatal(err)
+	}
+	enc := base64.RawURLEncoding
+
+	nc, err := api.Dial(sockPath)
+	if err != nil {
+		t.Fatalf("dial node socket: %v", err)
+	}
+	if err := nc.Call(api.MethodPushRegister, api.PushRegisterParams{
+		DeviceID: "pp-dev-1",
+		Endpoint: fakePushPort.URL,
+		P256dh:   enc.EncodeToString(uaPriv.PublicKey().Bytes()),
+		Auth:     enc.EncodeToString(authSecret),
+	}, nil); err != nil {
+		t.Fatalf("push.register: %v", err)
+	}
+	nc.Close()
+
+	go d.ConnectGateway(ctx, wsURL(ts.URL, "/node"), "", nil)
+
+	waitFor(t, "node rostered", func() bool {
+		pc, err := api.DialWSConn(ctx, wsURL(ts.URL, "/client"), "", nil)
+		if err != nil {
+			return false
+		}
+		poll := api.NewClient(pc)
+		defer poll.Close()
+		var r api.NodesListResult
+		if poll.Call(api.MethodNodesList, nil, &r) != nil {
+			return false
+		}
+		for _, n := range r.Nodes {
+			if n.ID == "pp-itest" && n.Online {
+				return true
+			}
+		}
+		return false
+	})
+
+	d.Registry().ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s2", Status: session.StatusWorking})
+	d.Registry().ApplyHook(registry.HookUpdate{Agent: "claude", AgentSessionID: "s2", Status: session.StatusAwaitingInput})
+
+	select {
+	case <-gotDelivery:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no push delivered to fake PushPort within 5s")
+	}
+
+	mu.Lock()
+	auth, encoding, body := gotAuth, gotEncoding, gotBody
+	mu.Unlock()
+
+	if auth != "Bearer pit_test" {
+		t.Fatalf("expected Bearer authorization, got: %q", auth)
+	}
+	if encoding != "aes128gcm" {
+		t.Fatalf("expected Content-Encoding aes128gcm, got: %q", encoding)
+	}
+	if len(body) == 0 {
+		t.Fatal("push body is empty")
+	}
+}
+
 // TestBlindPushNodeDeliversEncryptedPayload proves the e2ee push spec:
 // a node encrypts and delivers a push through the gateway (a pure router)
 // without the gateway ever seeing the notification cleartext.
@@ -58,7 +190,7 @@ func TestBlindPushNodeDeliversEncryptedPayload(t *testing.T) {
 	agg := gateway.New(time.Second)
 	gwsrv := gateway.NewServer(agg, nil, nil)
 	gwsrv.SetVAPIDPublicKey(vapid.PublicKey())
-	gwsrv.SetPushDeliverer(push.NewGatewayDeliverer(vapid))
+	gwsrv.SetPushDeliverer(push.NewGatewayDeliverer(vapid, nil))
 	ts := httptest.NewServer(gwsrv.Handler())
 	defer ts.Close()
 

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -27,12 +27,14 @@ type Server struct {
 	clientAuth func(token string) bool
 	clientSrv  *api.Server
 
-	clientTokens  *clienttoken.Store
-	pushDeliverer push.Deliverer
-	vapidPubKey   string
-	master        string
-	version       string
-	publicURL     atomic.Pointer[string]
+	clientTokens        *clienttoken.Store
+	pushDeliverer       push.Deliverer
+	vapidPubKey         string
+	pushPortTokenSetter func(string) error
+	pushPortStatus      func() bool
+	master              string
+	version             string
+	publicURL           atomic.Pointer[string]
 
 	nodeKeepaliveInterval time.Duration
 	nodeKeepaliveTimeout  time.Duration
@@ -79,6 +81,14 @@ func (s *Server) SetPushDeliverer(d push.Deliverer) { s.pushDeliverer = d }
 
 // SetVAPIDPublicKey publishes the VAPID public key devices fetch via push.vapidKey.
 func (s *Server) SetVAPIDPublicKey(key string) { s.vapidPubKey = key }
+
+// SetPushPortTokenSetter injects a callback that persists and live-applies a new
+// PushPort instance token. When unset, pushport.setToken returns "not enabled".
+func (s *Server) SetPushPortTokenSetter(fn func(string) error) { s.pushPortTokenSetter = fn }
+
+// SetPushPortStatus injects a callback reporting whether the gateway holds a
+// PushPort token, surfaced on server.info.
+func (s *Server) SetPushPortStatus(fn func() bool) { s.pushPortStatus = fn }
 
 // SetVersion records the server binary's version, served via server.info. Call before serving.
 func (s *Server) SetVersion(v string) { s.version = v }
@@ -147,6 +157,25 @@ func requireAdmin(h api.HandlerFunc) api.HandlerFunc {
 		}
 		return h(ctx, params)
 	}
+}
+
+func (s *Server) registerPushPortAdmin(srv *api.Server) {
+	srv.Handle(api.MethodPushPortSetToken, requireAdmin(func(_ context.Context, params json.RawMessage) (any, error) {
+		var p api.PushPortSetTokenParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "pushport.setToken: bad params"}
+		}
+		if p.Token == "" {
+			return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "pushport.setToken: empty token"}
+		}
+		if s.pushPortTokenSetter == nil {
+			return nil, &api.RPCError{Code: api.CodeInvalidRequest, Message: "pushport not enabled on this gateway"}
+		}
+		if err := s.pushPortTokenSetter(p.Token); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}))
 }
 
 // registerClientAdmin wires the client-token management methods (admin-only).
@@ -409,7 +438,8 @@ func (s *Server) buildClientServer() *api.Server {
 	srv.Handle(api.MethodPing, func(context.Context, json.RawMessage) (any, error) { return nil, nil })
 
 	srv.Handle(api.MethodServerInfo, func(context.Context, json.RawMessage) (any, error) {
-		return api.ServerInfo{Version: s.version, Nodes: s.agg.Nodes()}, nil
+		configured := s.pushPortStatus != nil && s.pushPortStatus()
+		return api.ServerInfo{Version: s.version, Nodes: s.agg.Nodes(), PushPortConfigured: configured}, nil
 	})
 
 	srv.Handle(api.MethodNodesList, func(context.Context, json.RawMessage) (any, error) {
@@ -502,6 +532,7 @@ func (s *Server) buildClientServer() *api.Server {
 	})
 
 	s.registerPush(srv)
+	s.registerPushPortAdmin(srv)
 	s.registerClientAdmin(srv)
 	return srv
 }

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -149,6 +149,76 @@ func TestRelayOpenCloseAndNodesList(t *testing.T) {
 	})
 }
 
+func TestPushPortSetTokenAdmin(t *testing.T) {
+	s := NewServer(New(0), nil, nil)
+	var got string
+	s.SetPushPortTokenSetter(func(tok string) error { got = tok; return nil })
+
+	dispatch := s.clientSrv.DispatchFunc()
+
+	params, _ := json.Marshal(api.PushPortSetTokenParams{Token: "pit_xyz"})
+	adminCtx := api.WithPrincipal(context.Background(), api.Principal{Admin: true})
+	if _, err := dispatch(adminCtx, api.MethodPushPortSetToken, params); err != nil {
+		t.Fatalf("admin dispatch: %v", err)
+	}
+	if got != "pit_xyz" {
+		t.Fatalf("setter got %q, want pit_xyz", got)
+	}
+
+	if _, err := dispatch(context.Background(), api.MethodPushPortSetToken, params); err == nil {
+		t.Fatal("non-admin: want error, got nil")
+	}
+
+	s2 := NewServer(New(0), nil, nil)
+	dispatch2 := s2.clientSrv.DispatchFunc()
+	_, err := dispatch2(adminCtx, api.MethodPushPortSetToken, params)
+	if err == nil {
+		t.Fatal("nil setter: want error, got nil")
+	}
+	if rpcErr, ok := err.(*api.RPCError); !ok || rpcErr.Message != "pushport not enabled on this gateway" {
+		t.Fatalf("nil setter: want 'pushport not enabled on this gateway', got %v", err)
+	}
+}
+
+func TestServerInfoPushPortConfigured(t *testing.T) {
+	dispatch := func(s *Server) func(context.Context, string, json.RawMessage) (any, error) {
+		return s.clientSrv.DispatchFunc()
+	}
+
+	call := func(t *testing.T, s *Server) api.ServerInfo {
+		t.Helper()
+		res, err := dispatch(s)(context.Background(), api.MethodServerInfo, nil)
+		if err != nil {
+			t.Fatalf("server.info: %v", err)
+		}
+		info, ok := res.(api.ServerInfo)
+		if !ok {
+			t.Fatalf("result type = %T, want api.ServerInfo", res)
+		}
+		return info
+	}
+
+	// no hook set: PushPortConfigured must be false
+	s := NewServer(New(0), nil, nil)
+	if info := call(t, s); info.PushPortConfigured {
+		t.Fatal("want PushPortConfigured=false when no hook is set")
+	}
+
+	// hook returns false
+	s2 := NewServer(New(0), nil, nil)
+	s2.SetPushPortStatus(func() bool { return false })
+	if info := call(t, s2); info.PushPortConfigured {
+		t.Fatal("want PushPortConfigured=false when hook returns false")
+	}
+
+	// hook returns true
+	s3 := NewServer(New(0), nil, nil)
+	s3.SetPushPortStatus(func() bool { return true })
+	if info := call(t, s3); !info.PushPortConfigured {
+		t.Fatal("want PushPortConfigured=true when hook returns true")
+	}
+}
+
 func makeBlindNodeEntries(t *testing.T) [][]byte {
 	t.Helper()
 	signer, err := trustlog.GenerateSigner()

--- a/internal/push/instancetoken.go
+++ b/internal/push/instancetoken.go
@@ -1,0 +1,28 @@
+package push
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ReadInstanceToken returns the trimmed PushPort instance token stored at path,
+// or "" when the file does not exist.
+func ReadInstanceToken(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// WriteInstanceToken persists the token at path with 0600, creating the dir.
+func WriteInstanceToken(path, token string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strings.TrimSpace(token)), 0o600)
+}

--- a/internal/push/instancetoken_test.go
+++ b/internal/push/instancetoken_test.go
@@ -1,0 +1,31 @@
+package push
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstanceTokenRoundTripAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "pushport-token")
+
+	got, err := ReadInstanceToken(path)
+	if err != nil || got != "" {
+		t.Fatalf("missing file: got %q, err %v; want empty, nil", got, err)
+	}
+	if err := WriteInstanceToken(path, "pit_abc\n"); err != nil {
+		t.Fatal(err)
+	}
+	got, err = ReadInstanceToken(path)
+	if err != nil || got != "pit_abc" {
+		t.Fatalf("round-trip: got %q, err %v", got, err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %v, want 0600", fi.Mode().Perm())
+	}
+}

--- a/internal/push/pushport_test.go
+++ b/internal/push/pushport_test.go
@@ -1,0 +1,134 @@
+package push
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func hostOf(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u.Host
+}
+
+func TestPostToPushPortSetsBearerAndSucceedsOn202(t *testing.T) {
+	var gotAuth, gotEnc string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotEnc = r.Header.Get("Content-Encoding")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	err := PostToPushPort(context.Background(), srv.Client(), "pit_tok", srv.URL+"/push/x", []byte("body"), "", "")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if gotAuth != "Bearer pit_tok" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotEnc != "aes128gcm" {
+		t.Errorf("Content-Encoding = %q", gotEnc)
+	}
+}
+
+func TestPostToPushPortGoneOn410(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+	}))
+	defer srv.Close()
+	err := PostToPushPort(context.Background(), srv.Client(), "pit_tok", srv.URL, []byte("b"), "", "")
+	if !errors.Is(err, ErrGone) {
+		t.Fatalf("want ErrGone, got %v", err)
+	}
+}
+
+func TestPostToPushPortConfigErrorDoesNotPrune(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(code)
+		}))
+		err := PostToPushPort(context.Background(), srv.Client(), "pit_tok", srv.URL, []byte("b"), "", "")
+		if err == nil {
+			t.Errorf("code %d: want error", code)
+		}
+		if errors.Is(err, ErrGone) {
+			t.Errorf("code %d: must not be ErrGone (no prune)", code)
+		}
+		srv.Close()
+	}
+}
+
+func TestGatewayDelivererSetPushPortLiveUpdate(t *testing.T) {
+	var gotAuth string
+	pp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer pp.Close()
+
+	d := NewGatewayDeliverer(nil, nil)
+	// Before SetPushPort: PushPort host with no token -> VAPID path (nil vapid -> no auth header)
+	if err := d.Deliver(context.Background(), pp.URL+"/x", []byte("b"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("pre-set Authorization = %q, want empty", gotAuth)
+	}
+	d.SetPushPort(hostOf(t, pp.URL), "pit_live")
+	if err := d.Deliver(context.Background(), pp.URL+"/x", []byte("b"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer pit_live" {
+		t.Fatalf("post-set Authorization = %q, want Bearer pit_live", gotAuth)
+	}
+}
+
+func TestGatewayDelivererHasPushPort(t *testing.T) {
+	d := NewGatewayDeliverer(nil, nil)
+	if d.HasPushPort() {
+		t.Fatal("HasPushPort should be false initially")
+	}
+	d.SetPushPort("push.example", "pit_x")
+	if !d.HasPushPort() {
+		t.Fatal("HasPushPort should be true after SetPushPort with a token")
+	}
+	d.SetPushPort("push.example", "")
+	if d.HasPushPort() {
+		t.Fatal("HasPushPort should be false after clearing the token")
+	}
+}
+
+func TestGatewayDelivererRoutesByHost(t *testing.T) {
+	var pushportAuth, vapidPath string
+	pp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pushportAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer pp.Close()
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vapidPath = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer other.Close()
+
+	d := NewGatewayDeliverer(nil, &PushPortAuth{Host: hostOf(t, pp.URL), Token: "pit_tok"})
+	if err := d.Deliver(context.Background(), pp.URL+"/push/x", []byte("b"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if pushportAuth != "Bearer pit_tok" {
+		t.Errorf("pushport Authorization = %q", pushportAuth)
+	}
+	if err := d.Deliver(context.Background(), other.URL+"/ep", []byte("b"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if vapidPath != "" {
+		t.Errorf("non-pushport host got Authorization %q (vapid nil should omit)", vapidPath)
+	}
+}

--- a/internal/push/relay.go
+++ b/internal/push/relay.go
@@ -3,6 +3,8 @@ package push
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"sync"
 	"time"
 )
 
@@ -37,19 +39,60 @@ func (r relaySender) Send(ctx context.Context, t Target, n Notification) error {
 	return r.deliver.Deliver(ctx, t.Endpoint, body, unifiedPushTTL, unifiedPushUrgency)
 }
 
+// PushPortAuth holds the credentials for delivering to a sealed PushPort endpoint.
+type PushPortAuth struct {
+	Host  string
+	Token string
+}
+
 // GatewayDeliverer POSTs pre-encrypted bodies via the gateway's VAPID key and HTTP
 // client — the in-process (co-located gateway) Deliverer, and the engine behind the
 // push.deliver RPC handler.
 type GatewayDeliverer struct {
 	client *http.Client
 	vapid  *VAPID
+
+	mu      sync.RWMutex
+	ppHost  string
+	ppToken string
 }
 
-// NewGatewayDeliverer returns a GatewayDeliverer signing with v (may be nil).
-func NewGatewayDeliverer(v *VAPID) *GatewayDeliverer {
-	return &GatewayDeliverer{client: &http.Client{Timeout: 10 * time.Second}, vapid: v}
+// NewGatewayDeliverer returns a GatewayDeliverer signing with v (may be nil). pp
+// configures PushPort bearer-token delivery (may be nil).
+func NewGatewayDeliverer(v *VAPID, pp *PushPortAuth) *GatewayDeliverer {
+	g := &GatewayDeliverer{client: &http.Client{Timeout: 10 * time.Second}, vapid: v}
+	if pp != nil {
+		g.ppHost, g.ppToken = pp.Host, pp.Token
+	}
+	return g
 }
 
 func (g *GatewayDeliverer) Deliver(ctx context.Context, endpoint string, ciphertext []byte, ttl, urgency string) error {
+	g.mu.RLock()
+	host, token := g.ppHost, g.ppToken
+	g.mu.RUnlock()
+	if token != "" && sameHost(endpoint, host) {
+		return PostToPushPort(ctx, g.client, token, endpoint, ciphertext, ttl, urgency)
+	}
 	return PostEncrypted(ctx, g.client, g.vapid, endpoint, ciphertext, ttl, urgency)
+}
+
+// HasPushPort reports whether a PushPort instance token is currently set.
+func (g *GatewayDeliverer) HasPushPort() bool {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.ppToken != ""
+}
+
+// SetPushPort updates the bearer credentials used for sealed PushPort endpoints.
+// An empty token disables bearer delivery (VAPID is used instead).
+func (g *GatewayDeliverer) SetPushPort(host, token string) {
+	g.mu.Lock()
+	g.ppHost, g.ppToken = host, token
+	g.mu.Unlock()
+}
+
+func sameHost(endpoint, host string) bool {
+	u, err := url.Parse(endpoint)
+	return err == nil && u.Host == host
 }

--- a/internal/push/unifiedpush.go
+++ b/internal/push/unifiedpush.go
@@ -55,12 +55,7 @@ func encodePayload(n Notification, id string) ([]byte, error) {
 	})
 }
 
-// PostEncrypted POSTs a pre-encrypted aes128gcm Web Push body to endpoint, adding
-// the VAPID Authorization header (nil vapid omits it). Returns ErrGone on 404/410
-// and on a 403 whose body signals a permanent VAPID-credential mismatch.
-// This is the blind-relay half: the caller supplies an opaque ciphertext it need
-// not have produced, so a gateway can deliver a body a node encrypted.
-func PostEncrypted(ctx context.Context, client *http.Client, vapid *VAPID, endpoint string, body []byte, ttl, urgency string) error {
+func newPushRequest(ctx context.Context, endpoint string, body []byte, ttl, urgency string) (*http.Request, error) {
 	if ttl == "" {
 		ttl = unifiedPushTTL
 	}
@@ -69,12 +64,49 @@ func PostEncrypted(ctx context.Context, client *http.Client, vapid *VAPID, endpo
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Content-Encoding", "aes128gcm")
 	req.Header.Set("TTL", ttl)
 	req.Header.Set("Urgency", urgency)
+	return req, nil
+}
+
+// PostToPushPort delivers a pre-encrypted aes128gcm body to a sealed PushPort
+// endpoint, authenticating with the node's instance token. 410 marks a dead
+// subscription (prune); 401/403 signal a bad or wrong-app token — a config error
+// that must not prune the target.
+func PostToPushPort(ctx context.Context, client *http.Client, token, endpoint string, body []byte, ttl, urgency string) error {
+	req, err := newPushRequest(ctx, endpoint, body, ttl, urgency)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	switch {
+	case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
+		return fmt.Errorf("%w: %s %s", ErrGone, resp.Status, endpoint)
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return fmt.Errorf("push: POST %s: %s: %s", endpoint, resp.Status, bytes.TrimSpace(readLimited(resp.Body)))
+	}
+	return nil
+}
+
+// PostEncrypted POSTs a pre-encrypted aes128gcm Web Push body to endpoint, adding
+// the VAPID Authorization header (nil vapid omits it). Returns ErrGone on 404/410
+// and on a 403 whose body signals a permanent VAPID-credential mismatch.
+// This is the blind-relay half: the caller supplies an opaque ciphertext it need
+// not have produced, so a gateway can deliver a body a node encrypted.
+func PostEncrypted(ctx context.Context, client *http.Client, vapid *VAPID, endpoint string, body []byte, ttl, urgency string) error {
+	req, err := newPushRequest(ctx, endpoint, body, ttl, urgency)
+	if err != nil {
+		return err
+	}
 	if vapid != nil {
 		auth, verr := vapid.authHeader(endpoint, time.Now())
 		if verr != nil {


### PR DESCRIPTION
## Summary

Adds PushPort as an alternative push provider, alongside the default UnifiedPush. Delivery runs over FCM (Android). Notifications stay end-to-end encrypted: the node encrypts, and the gateway and PushPort only relay opaque bodies.

## Changes

- **Node / gateway (Go):** deliver pre-encrypted bodies to sealed PushPort endpoints with a bearer instance token; admin RPC to set the token on the gateway live; report PushPort availability on `server.info`.
- **App (Flutter):** PushPort/FCM provider with on-device RFC 8291 decryption, plus provider selection in Settings. UnifiedPush stays the default.
- **CLI:** `argus pushport register` opens the registration page and applies the pasted `pit_…` token to the gateway.
- **CI:** release binaries embed the PushPort app id from `secrets.PUSHPORT_APP_ID`.

## Testing

- Go: `make test` green (includes the PushPort blind-delivery e2e test).
- App: `flutter test` green.
